### PR TITLE
Template type additions

### DIFF
--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -129,7 +129,7 @@ declare namespace Line {
 
   export type ImageMapArea = { x: number, y: number, width: number, height: number };
 
-  export type TemplateContent = TemplateButtons | TemplateConfirm | TemplateCarousel;
+  export type TemplateContent = TemplateButtons | TemplateConfirm | TemplateCarousel | TemplateImageCarousel;
   export type TemplateButtons = {
     type: "buttons",
     thumbnailImageUrl?: string,
@@ -149,6 +149,16 @@ declare namespace Line {
     title?: string,
     text: string,
     actions: TemplateAction[],
+  };
+
+  export type TemplateImageCarousel = {
+    type: "image_carousel",
+    columns: TemplateImageColumn,
+  };
+
+  export type TemplateImageColumn = {
+    imageUrl: string,
+    action: TemplateAction,
   };
 
   export type TemplateAction = TemplatePostbackAction | TemplateMessageAction | TemplateURIAction;

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -41,7 +41,13 @@ declare namespace Line {
   export type UnfollowEvent = { type: "unfollow" } & EventBase;
   export type JoinEvent = { type: "join" } & ReplyableEvent;
   export type LeaveEvent = { type: "leave" } & EventBase;
-  export type PostbackEvent = { type: "postback", postback: { data: string } } & ReplyableEvent;
+  export type PostbackEvent = {
+    type: "postback",
+    postback: {
+      data: string,
+      params?: string,
+    },
+  } & ReplyableEvent;
   export type BeaconEvent = ReplyableEvent & {
     type: "beacon",
     beacon: {
@@ -135,12 +141,12 @@ declare namespace Line {
     thumbnailImageUrl?: string,
     title?: string,
     text: string,
-    actions: TemplateAction[],
+    actions: TemplateAction<{ label: string }>[],
   };
   export type TemplateConfirm = {
     type: "confirm",
     text: string,
-    actions: TemplateAction[],
+    actions: TemplateAction<{ label: string }>[],
   };
   export type TemplateCarousel = { type: "carousel", columns: TemplateColumn[] };
 
@@ -148,7 +154,7 @@ declare namespace Line {
     thumbnailImageUrl?: string,
     title?: string,
     text: string,
-    actions: TemplateAction[],
+    actions: TemplateAction<{ label: string }>[],
   };
 
   export type TemplateImageCarousel = {
@@ -158,22 +164,33 @@ declare namespace Line {
 
   export type TemplateImageColumn = {
     imageUrl: string,
-    action: TemplateAction,
+    action: TemplateAction<{ label?: string }>,
   };
 
-  export type TemplateAction = TemplatePostbackAction | TemplateMessageAction | TemplateURIAction;
-  export type TemplateActionBase = { label: string };
+  export type TemplateAction<Label> =
+    | TemplatePostbackAction & Label
+    | TemplateMessageAction & Label
+    | TemplateURIAction & Label
+    | TemplateDatetimePickerAction & Label;
   export type TemplatePostbackAction = {
     type: "postback",
     data: string,
     text?: string,
-  } & TemplateActionBase;
+  };
   export type TemplateMessageAction = {
     type: "message",
     text: string,
-  } & TemplateActionBase;
+  };
   export type TemplateURIAction = {
     type: "template",
     uri: string,
-  } & TemplateActionBase;
+  };
+  export type TemplateDatetimePickerAction = {
+    type: "datetimepicker",
+    data: string,
+    mode: "date" | "time" | "datetime",
+    initial?: string,
+    max?: string,
+    min?: string,
+  };
 }

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -182,7 +182,7 @@ declare namespace Line {
     text: string,
   };
   export type TemplateURIAction = {
-    type: "template",
+    type: "uri",
     uri: string,
   };
   export type TemplateDatetimePickerAction = {


### PR DESCRIPTION
Resolves #17 and #19 

It basically adds type supports for the followings:

- [Image carousel template](https://devdocs.line.me/en/#image-carousel)
- [Datetime picker template action](https://devdocs.line.me/en/#datetime-picker-action)

Currently, this SDK doesn't provide any abstraction for message objects, but provides only types for them. I still think it's enough for daily usages.

This PR includes a typo fix for template URI action.