### PR TITLE
Refactoring

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-/docs
-/examples
-/test
-/tools
-tslint.json
-yarn.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "4"
   - "6"
   - "7"
-cache: yarn
+  - "8"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,8 @@ Here are each top-level directory explained:
 Also, you may use the following npm scripts for development:
 
 * `npm run test`: Run test suites in `test`.
-* `npm run lint`: Lint source code with [TSLint](https://github.com/palantir/tslint)
+* `npm run format`: Format source code with [Prettier](https://github.com/prettier/prettier)
+* `npm run format:check`: Silently run `format` and report formatting errors
 * `npm run build`: Build TypeScript code into JavaScript. The built files will
   be placed in `dist/`.
 * `npm run docs`: Build GitBook docs and serve a doc server

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -13,21 +13,30 @@ export default class Client {
     this.config = config;
   }
 
-  public pushMessage(to: string, messages: Line.Message | Line.Message[]): Promise<any> {
+  public pushMessage(
+    to: string,
+    messages: Line.Message | Line.Message[],
+  ): Promise<any> {
     return this.post(URL.push, {
       messages: toArray(messages),
       to,
     });
   }
 
-  public replyMessage(replyToken: string, messages: Line.Message | Line.Message[]): Promise<any> {
+  public replyMessage(
+    replyToken: string,
+    messages: Line.Message | Line.Message[],
+  ): Promise<any> {
     return this.post(URL.reply, {
       messages: toArray(messages),
       replyToken,
     });
   }
 
-  public multicast(to: string[], messages: Line.Message | Line.Message[]): Promise<any> {
+  public multicast(
+    to: string[],
+    messages: Line.Message | Line.Message[],
+  ): Promise<any> {
     return this.post(URL.multicast, {
       messages: toArray(messages),
       to,
@@ -38,36 +47,44 @@ export default class Client {
     return this.get(URL.profile(userId));
   }
 
-  public getGroupMemberProfile(groupId: string, userId: string): Promise<Line.Profile> {
+  public getGroupMemberProfile(
+    groupId: string,
+    userId: string,
+  ): Promise<Line.Profile> {
     return this.get(URL.groupMemberProfile(groupId, userId));
   }
 
-  public getRoomMemberProfile(roomId: string, userId: string): Promise<Line.Profile> {
+  public getRoomMemberProfile(
+    roomId: string,
+    userId: string,
+  ): Promise<Line.Profile> {
     return this.get(URL.roomMemberProfile(roomId, userId));
   }
 
   public getGroupMemberIds(groupId: string): Promise<string[]> {
     const load = (start?: string): Promise<string[]> =>
-      this.get(URL.groupMemberIds(groupId, start))
-      .then((res: { memberIds: string[], next?: string }) => {
+      this.get(
+        URL.groupMemberIds(groupId, start),
+      ).then((res: { memberIds: string[]; next?: string }) => {
         if (!res.next) {
           return res.memberIds;
         }
 
-        return load(res.next).then((extraIds) => res.memberIds.concat(extraIds));
+        return load(res.next).then(extraIds => res.memberIds.concat(extraIds));
       });
     return load();
   }
 
   public getRoomMemberIds(roomId: string): Promise<string[]> {
     const load = (start?: string): Promise<string[]> =>
-      this.get(URL.roomMemberIds(roomId, start))
-      .then((res: { memberIds: string[], next?: string }) => {
+      this.get(
+        URL.roomMemberIds(roomId, start),
+      ).then((res: { memberIds: string[]; next?: string }) => {
         if (!res.next) {
           return res.memberIds;
         }
 
-        return load(res.next).then((extraIds) => res.memberIds.concat(extraIds));
+        return load(res.next).then(extraIds => res.memberIds.concat(extraIds));
       });
     return load();
   }

--- a/lib/exceptions.ts
+++ b/lib/exceptions.ts
@@ -1,17 +1,11 @@
 export class SignatureValidationFailed extends Error {
-  constructor(
-    message: string,
-    public signature?: string,
-  ) {
+  constructor(message: string, public signature?: string) {
     super(message);
   }
 }
 
 export class JSONParseError extends Error {
-  constructor(
-    message: string,
-    public raw: any,
-  ) {
+  constructor(message: string, public raw: any) {
     super(message);
   }
 }
@@ -27,9 +21,7 @@ export class RequestError extends Error {
 }
 
 export class ReadError extends Error {
-  constructor(
-    private originalError: Error,
-  ) {
+  constructor(private originalError: Error) {
     super(originalError.message);
   }
 }

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -25,11 +25,7 @@ function wrapError(err: AxiosError) {
       err,
     );
   } else if (err.code) {
-    throw new RequestError(
-      err.message,
-      err.code,
-      err,
-    );
+    throw new RequestError(err.message, err.code, err);
   } else if (err.config) {
     // unknown, but from axios
     throw new ReadError(err);
@@ -41,11 +37,14 @@ function wrapError(err: AxiosError) {
 
 const userAgent = `${pkg.name}/${pkg.version}`;
 
-export function stream(url: string, headers: any): Promise<NodeJS.ReadableStream> {
+export function stream(
+  url: string,
+  headers: any,
+): Promise<NodeJS.ReadableStream> {
   headers["User-Agent"] = userAgent;
   return axios
     .get(url, { headers, responseType: "stream" })
-    .then((res) => res.data as NodeJS.ReadableStream);
+    .then(res => res.data as NodeJS.ReadableStream);
 }
 
 export function get(url: string, headers: any): Promise<any> {
@@ -53,7 +52,7 @@ export function get(url: string, headers: any): Promise<any> {
 
   return axios
     .get(url, { headers })
-    .then((res) => checkJSON(res.data))
+    .then(res => checkJSON(res.data))
     .catch(wrapError);
 }
 
@@ -62,6 +61,6 @@ export function post(url: string, headers: any, data?: any): Promise<any> {
   headers["User-Agent"] = userAgent;
   return axios
     .post(url, data, { headers })
-    .then((res) => checkJSON(res.data))
+    .then(res => checkJSON(res.data))
     .catch(wrapError);
 }

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -6,7 +6,7 @@ import {
   RequestError,
 } from "./exceptions";
 
-const pkg = require("../package.json"); // tslint:disable-line no-var-requires
+const pkg = require("../package.json");
 
 function checkJSON(raw: any): any {
   if (typeof raw === "object") {

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -7,9 +7,15 @@ export type Request = http.IncomingMessage & { body: any };
 export type Response = http.ServerResponse;
 export type NextCallback = (err?: Error) => void;
 
-export type Middleware = (req: Request, res: Response, next: NextCallback) => void;
+export type Middleware = (
+  req: Request,
+  res: Response,
+  next: NextCallback,
+) => void;
 
-export default function middleware(config: Line.Config & Line.MiddlewareConfig): Middleware {
+export default function middleware(
+  config: Line.Config & Line.MiddlewareConfig,
+): Middleware {
   if (!config.channelSecret) {
     throw new Error("no channel secret");
   }
@@ -28,7 +34,12 @@ export default function middleware(config: Line.Config & Line.MiddlewareConfig):
 
     const validate = (body: string | Buffer) => {
       if (!validateSignature(body, secret, signature)) {
-        next(new SignatureValidationFailed("signature validation failed", signature));
+        next(
+          new SignatureValidationFailed(
+            "signature validation failed",
+            signature,
+          ),
+        );
         return;
       }
 

--- a/lib/urls.ts
+++ b/lib/urls.ts
@@ -1,6 +1,7 @@
 import * as qs from "querystring";
 
-const baseURL: string = process.env.API_BASE_URL || "https://api.line.me/v2/bot/";
+const baseURL: string =
+  process.env.API_BASE_URL || "https://api.line.me/v2/bot/";
 
 const apiURL = (path: string, query?: object) =>
   baseURL + path + (query ? `?${qs.stringify(query)}` : "");

--- a/lib/validate-signature.ts
+++ b/lib/validate-signature.ts
@@ -31,9 +31,15 @@ function safeCompare(a: Buffer, b: Buffer): boolean {
   }
 }
 
-export default function validateSignature(body: string | Buffer, channelSecret: string, signature: string): boolean {
+export default function validateSignature(
+  body: string | Buffer,
+  channelSecret: string,
+  signature: string,
+): boolean {
   return safeCompare(
-    createHmac("SHA256", channelSecret).update(body).digest(),
+    createHmac("SHA256", channelSecret)
+      .update(body)
+      .digest(),
     s2b(signature, "base64"),
   );
 }

--- a/lib/validate-signature.ts
+++ b/lib/validate-signature.ts
@@ -25,7 +25,7 @@ function safeCompare(a: Buffer, b: Buffer): boolean {
   } else {
     let result = 0;
     for (let i = 0; i < a.length; i++) {
-      result |= a[i] ^ b[i]; // tslint:disable-line no-bitwise
+      result |= a[i] ^ b[i];
     }
     return result === 0;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@line/bot-sdk",
-  "version": "2.0.0",
+  "version": "3.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -126,17 +126,6 @@
       "requires": {
         "follow-redirects": "1.2.4",
         "is-buffer": "1.1.5"
-      }
-    },
-    "babel-code-frame": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.1"
       }
     },
     "balanced-match": {
@@ -265,12 +254,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
-    },
-    "colors": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
       "dev": true
     },
     "commander": {
@@ -466,12 +449,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
-    },
-    "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
     "etag": {
@@ -893,12 +870,6 @@
       "requires": {
         "is-object": "1.0.1"
       }
-    },
-    "js-tokens": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-      "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
-      "dev": true
     },
     "json3": {
       "version": "3.3.2",
@@ -4977,12 +4948,6 @@
       "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68=",
       "dev": true
     },
-    "path-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-      "dev": true
-    },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -5033,6 +4998,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.7.4.tgz",
+      "integrity": "sha1-XoYkrpNjyA+V7GRFhOzfVddPk/o=",
       "dev": true
     },
     "proxy-addr": {
@@ -5147,15 +5118,6 @@
       "dev": true,
       "requires": {
         "is-finite": "1.0.2"
-      }
-    },
-    "resolve": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
-      "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
-      "dev": true,
-      "requires": {
-        "path-parse": "1.0.5"
       }
     },
     "rimraf": {
@@ -5399,44 +5361,6 @@
         "strip-bom": "3.0.0",
         "strip-json-comments": "2.0.1"
       }
-    },
-    "tslib": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.7.1.tgz",
-      "integrity": "sha1-vIAEFkaRkjp5/oN4u+s9ogF1OOw=",
-      "dev": true
-    },
-    "tslint": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.4.3.tgz",
-      "integrity": "sha1-dhyEArgONHt3M6BDkKdXslNYBGc=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "6.22.0",
-        "colors": "1.1.2",
-        "commander": "2.9.0",
-        "diff": "3.2.0",
-        "glob": "7.1.2",
-        "minimatch": "3.0.4",
-        "resolve": "1.3.3",
-        "semver": "5.3.0",
-        "tslib": "1.7.1",
-        "tsutils": "2.4.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-          "dev": true
-        }
-      }
-    },
-    "tsutils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.4.0.tgz",
-      "integrity": "sha1-rUzm26Dlo+2934Ymt8oEB4IYn+o=",
-      "dev": true
     },
     "type-is": {
       "version": "1.6.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -244,6 +244,12 @@
         }
       }
     },
+    "ci-info": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.1.tgz",
+      "integrity": "sha512-vHDDF/bP9RYpTWtUhpJRhCFdvvp3iDWvEbuDbWgvjUrNGV1MXJrE0MPcwGtEled04m61iwdBLUIHZtDgzWS4ZQ==",
+      "dev": true
+    },
     "cli-boxes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
@@ -708,6 +714,25 @@
         "statuses": "1.3.1"
       }
     },
+    "husky": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
+      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+      "dev": true,
+      "requires": {
+        "is-ci": "1.0.10",
+        "normalize-path": "1.0.0",
+        "strip-indent": "2.0.0"
+      },
+      "dependencies": {
+        "strip-indent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+          "dev": true
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
@@ -779,6 +804,15 @@
       "dev": true,
       "requires": {
         "builtin-modules": "1.1.1"
+      }
+    },
+    "is-ci": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
+      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "dev": true,
+      "requires": {
+        "ci-info": "1.1.1"
       }
     },
     "is-finite": {
@@ -1218,6 +1252,12 @@
         "semver": "5.1.0",
         "validate-npm-package-license": "3.0.1"
       }
+    },
+    "normalize-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
+      "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
+      "dev": true
     },
     "npm": {
       "version": "3.7.5",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "build": "tsc",
     "docs": "gitbook install && gitbook serve docs",
     "docs:publish": "./docs/publish.sh",
-    "release": "npm run build && npm publish --access public"
+    "release": "npm run build && npm publish --access public",
+    "precommit": "npm run format:check",
+    "prepush": "npm run format:check && npm run build && npm run test"
   },
   "repository": {
     "type": "git",
@@ -49,6 +51,7 @@
     "del-cli": "^1.1.0",
     "express": "^4.15.3",
     "gitbook-cli": "^2.3.0",
+    "husky": "^0.14.3",
     "mocha": "^3.4.2",
     "prettier": "^1.7.4",
     "ts-node": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,14 @@
   },
   "main": "dist/index.js",
   "types": "types/index.d.ts",
+  "files": [
+    "dist",
+    "docs",
+    "exceptions.js",
+    "exceptions.ts",
+    "lib",
+    "types"
+  ],
   "scripts": {
     "pretest": "npm run build",
     "test": "API_BASE_URL=http://localhost:1234/ TEST_PORT=1234 mocha -r ts-node/register test/*.spec.ts",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,11 @@
   "scripts": {
     "pretest": "npm run build",
     "test": "API_BASE_URL=http://localhost:1234/ TEST_PORT=1234 mocha -r ts-node/register test/*.spec.ts",
-    "lint": "tslint '{lib,test}/**/*.ts'",
+    "prettier": "prettier --parser typescript --trailing-comma all '{lib,test}/**/*.ts'",
+    "format": "npm run prettier -- --write",
+    "format:check": "npm run prettier -- -l",
     "clean": "del-cli dist",
-    "prebuild": "npm run lint && npm run clean",
+    "prebuild": "npm run format:check && npm run clean",
     "build": "tsc",
     "docs": "gitbook install && gitbook serve docs",
     "docs:publish": "./docs/publish.sh",
@@ -48,8 +50,8 @@
     "express": "^4.15.3",
     "gitbook-cli": "^2.3.0",
     "mocha": "^3.4.2",
+    "prettier": "^1.7.4",
     "ts-node": "^3.0.6",
-    "tslint": "^5.4.3",
     "typescript": "^2.3.4"
   },
   "license": "Apache-2.0"

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -17,50 +17,51 @@ describe("client", () => {
   const testMsg: Line.TextMessage = { type: "text", text: "hello" };
 
   it("reply", () => {
-    return client.replyMessage("test_reply_token", testMsg)
-      .then((res: any) => {
-        equal(res.headers.authorization, "Bearer test_channel_access_token");
-        equal(res.path, "/message/reply");
-        equal(res.method, "POST");
-        equal(res.body.replyToken, "test_reply_token");
-        deepEqual(res.body.messages, [testMsg]);
-      });
+    return client.replyMessage("test_reply_token", testMsg).then((res: any) => {
+      equal(res.headers.authorization, "Bearer test_channel_access_token");
+      equal(res.path, "/message/reply");
+      equal(res.method, "POST");
+      equal(res.body.replyToken, "test_reply_token");
+      deepEqual(res.body.messages, [testMsg]);
+    });
   });
 
   it("push", () => {
-    return client.pushMessage("test_user_id", testMsg)
-      .then((res: any) => {
-        equal(res.headers.authorization, "Bearer test_channel_access_token");
-        equal(res.path, "/message/push");
-        equal(res.method, "POST");
-        equal(res.body.to, "test_user_id");
-        deepEqual(res.body.messages, [testMsg]);
-      });
+    return client.pushMessage("test_user_id", testMsg).then((res: any) => {
+      equal(res.headers.authorization, "Bearer test_channel_access_token");
+      equal(res.path, "/message/push");
+      equal(res.method, "POST");
+      equal(res.body.to, "test_user_id");
+      deepEqual(res.body.messages, [testMsg]);
+    });
   });
 
   it("multicast", () => {
     const ids = ["test_user_id_1", "test_user_id_2", "test_user_id_3"];
-    return client.multicast(ids, [testMsg, testMsg])
-      .then((res: any) => {
-        equal(res.headers.authorization, "Bearer test_channel_access_token");
-        equal(res.path, "/message/multicast");
-        equal(res.method, "POST");
-        deepEqual(res.body.to, ["test_user_id_1", "test_user_id_2", "test_user_id_3"]);
-        deepEqual(res.body.messages, [testMsg, testMsg]);
-      });
+    return client.multicast(ids, [testMsg, testMsg]).then((res: any) => {
+      equal(res.headers.authorization, "Bearer test_channel_access_token");
+      equal(res.path, "/message/multicast");
+      equal(res.method, "POST");
+      deepEqual(res.body.to, [
+        "test_user_id_1",
+        "test_user_id_2",
+        "test_user_id_3",
+      ]);
+      deepEqual(res.body.messages, [testMsg, testMsg]);
+    });
   });
 
   it("getProfile", () => {
-    return client.getProfile("test_user_id")
-      .then((res: any) => {
-        equal(res.headers.authorization, "Bearer test_channel_access_token");
-        equal(res.path, "/profile/test_user_id");
-        equal(res.method, "GET");
-      });
+    return client.getProfile("test_user_id").then((res: any) => {
+      equal(res.headers.authorization, "Bearer test_channel_access_token");
+      equal(res.path, "/profile/test_user_id");
+      equal(res.method, "GET");
+    });
   });
 
   it("getGroupMemberProfile", () => {
-    return client.getGroupMemberProfile("test_group_id", "test_user_id")
+    return client
+      .getGroupMemberProfile("test_group_id", "test_user_id")
       .then((res: any) => {
         equal(res.headers.authorization, "Bearer test_channel_access_token");
         equal(res.path, "/group/test_group_id/member/test_user_id");
@@ -69,7 +70,8 @@ describe("client", () => {
   });
 
   it("getRoomMemberProfile", () => {
-    return client.getRoomMemberProfile("test_room_id", "test_user_id")
+    return client
+      .getRoomMemberProfile("test_room_id", "test_user_id")
       .then((res: any) => {
         equal(res.headers.authorization, "Bearer test_channel_access_token");
         equal(res.path, "/room/test_room_id/member/test_user_id");
@@ -78,39 +80,46 @@ describe("client", () => {
   });
 
   it("getGroupMemberIds", () => {
-    return client.getGroupMemberIds("test_group_id")
-      .then((ids) => deepEqual(ids, [
-        "group-test_group_id-0",
-        "group-test_group_id-1",
-        "group-test_group_id-2",
-        "group-test_group_id-3",
-        "group-test_group_id-4",
-        "group-test_group_id-5",
-        "group-test_group_id-6",
-        "group-test_group_id-7",
-        "group-test_group_id-8",
-      ]));
+    return client
+      .getGroupMemberIds("test_group_id")
+      .then(ids =>
+        deepEqual(ids, [
+          "group-test_group_id-0",
+          "group-test_group_id-1",
+          "group-test_group_id-2",
+          "group-test_group_id-3",
+          "group-test_group_id-4",
+          "group-test_group_id-5",
+          "group-test_group_id-6",
+          "group-test_group_id-7",
+          "group-test_group_id-8",
+        ]),
+      );
   });
 
   it("getRoomMemberIds", () => {
-    return client.getRoomMemberIds("test_room_id")
-      .then((ids) => deepEqual(ids, [
-        "room-test_room_id-0",
-        "room-test_room_id-1",
-        "room-test_room_id-2",
-        "room-test_room_id-3",
-        "room-test_room_id-4",
-        "room-test_room_id-5",
-        "room-test_room_id-6",
-        "room-test_room_id-7",
-        "room-test_room_id-8",
-      ]));
+    return client
+      .getRoomMemberIds("test_room_id")
+      .then(ids =>
+        deepEqual(ids, [
+          "room-test_room_id-0",
+          "room-test_room_id-1",
+          "room-test_room_id-2",
+          "room-test_room_id-3",
+          "room-test_room_id-4",
+          "room-test_room_id-5",
+          "room-test_room_id-6",
+          "room-test_room_id-7",
+          "room-test_room_id-8",
+        ]),
+      );
   });
 
   it("getMessageContent", () => {
-    return client.getMessageContent("test_message_id")
-      .then((s) => getStreamData(s))
-      .then((data) => {
+    return client
+      .getMessageContent("test_message_id")
+      .then(s => getStreamData(s))
+      .then(data => {
         const res = JSON.parse(data);
         equal(res.headers.authorization, "Bearer test_channel_access_token");
         equal(res.path, "/message/test_message_id/content");
@@ -119,20 +128,18 @@ describe("client", () => {
   });
 
   it("leaveGroup", () => {
-    return client.leaveGroup("test_group_id")
-      .then((res) => {
-        equal(res.headers.authorization, "Bearer test_channel_access_token");
-        equal(res.path, "/group/test_group_id/leave");
-        equal(res.method, "POST");
-      });
+    return client.leaveGroup("test_group_id").then(res => {
+      equal(res.headers.authorization, "Bearer test_channel_access_token");
+      equal(res.path, "/group/test_group_id/leave");
+      equal(res.method, "POST");
+    });
   });
 
   it("leaveRoom", () => {
-    return client.leaveRoom("test_room_id")
-      .then((res: any) => {
-        equal(res.headers.authorization, "Bearer test_channel_access_token");
-        equal(res.path, "/room/test_room_id/leave");
-        equal(res.method, "POST");
-      });
+    return client.leaveRoom("test_room_id").then((res: any) => {
+      equal(res.headers.authorization, "Bearer test_channel_access_token");
+      equal(res.path, "/room/test_room_id/leave");
+      equal(res.method, "POST");
+    });
   });
 });

--- a/test/helpers/stream.ts
+++ b/test/helpers/stream.ts
@@ -1,5 +1,5 @@
 export function getStreamData(stream: NodeJS.ReadableStream): Promise<string> {
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     let result: string = "";
     stream.on("data", (chunk: Buffer) => {
       result += chunk.toString();

--- a/test/helpers/test-server.ts
+++ b/test/helpers/test-server.ts
@@ -2,7 +2,10 @@ import * as bodyParser from "body-parser";
 import * as express from "express";
 import { Server } from "http";
 import { join } from "path";
-import { JSONParseError, SignatureValidationFailed } from "../../lib/exceptions";
+import {
+  JSONParseError,
+  SignatureValidationFailed,
+} from "../../lib/exceptions";
 
 let server: Server = null;
 
@@ -33,8 +36,8 @@ function listen(port: number, middleware?: express.RequestHandler) {
     const id: string = req.params.id;
     const start: number = parseInt(req.query.start, 10) || 0;
 
-    const result: { memberIds: string[], next?: string } = {
-      memberIds: [start, start + 1, start + 2].map((i) => `${ty}-${id}-${i}`),
+    const result: { memberIds: string[]; next?: string } = {
+      memberIds: [start, start + 1, start + 2].map(i => `${ty}-${id}-${i}`),
     };
 
     if (start / 3 < 2) {
@@ -53,28 +56,32 @@ function listen(port: number, middleware?: express.RequestHandler) {
       res.status(404).end();
     } else {
       const keys = ["body", "headers", "method", "path", "query"];
-      res.json(keys.reduce((r, k) => Object.assign(r, { [k]: (req as any)[k] }), {}));
+      res.json(
+        keys.reduce((r, k) => Object.assign(r, { [k]: (req as any)[k] }), {}),
+      );
     }
   });
 
-  app.use((err: Error, req: express.Request, res: express.Response, next: any) => {
-    if (err instanceof SignatureValidationFailed) {
-      res.status(401).send(err.signature);
-      return;
-    } else if (err instanceof JSONParseError) {
-      res.status(400).send(err.raw);
-      return;
-    }
-    next(err);
-  });
+  app.use(
+    (err: Error, req: express.Request, res: express.Response, next: any) => {
+      if (err instanceof SignatureValidationFailed) {
+        res.status(401).send(err.signature);
+        return;
+      } else if (err instanceof JSONParseError) {
+        res.status(400).send(err.raw);
+        return;
+      }
+      next(err);
+    },
+  );
 
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     server = app.listen(port, () => resolve());
   });
 }
 
 function close() {
-  return new Promise((resolve) => {
+  return new Promise(resolve => {
     if (!server) {
       resolve();
     }

--- a/test/http.spec.ts
+++ b/test/http.spec.ts
@@ -1,9 +1,5 @@
 import { deepEqual, equal, ok } from "assert";
-import {
-  HTTPError,
-  JSONParseError,
-  RequestError,
-} from "../lib/exceptions";
+import { HTTPError, JSONParseError, RequestError } from "../lib/exceptions";
 import { get, post, stream } from "../lib/http";
 import { getStreamData } from "./helpers/stream";
 import { close, listen } from "./helpers/test-server";
@@ -22,14 +18,13 @@ describe("http", () => {
       "test-header-key": "Test-Header-Value",
     };
 
-    return get(`${TEST_URL}/get?x=10`, testHeaders)
-      .then((res: any) => {
-        equal(res.method, "GET");
-        equal(res.path, "/get");
-        equal(res.query.x, "10");
-        equal(res.headers["test-header-key"], testHeaders["test-header-key"]);
-        equal(res.headers["user-agent"], `${pkg.name}/${pkg.version}`);
-      });
+    return get(`${TEST_URL}/get?x=10`, testHeaders).then((res: any) => {
+      equal(res.method, "GET");
+      equal(res.path, "/get");
+      equal(res.query.x, "10");
+      equal(res.headers["test-header-key"], testHeaders["test-header-key"]);
+      equal(res.headers["user-agent"], `${pkg.name}/${pkg.version}`);
+    });
   });
 
   it("post without body", () => {
@@ -37,13 +32,12 @@ describe("http", () => {
       "test-header-key": "Test-Header-Value",
     };
 
-    return post(`${TEST_URL}/post`, testHeaders)
-      .then((res: any) => {
-        equal(res.method, "POST");
-        equal(res.path, "/post");
-        equal(res.headers["test-header-key"], testHeaders["test-header-key"]);
-        equal(res.headers["user-agent"], `${pkg.name}/${pkg.version}`);
-      });
+    return post(`${TEST_URL}/post`, testHeaders).then((res: any) => {
+      equal(res.method, "POST");
+      equal(res.path, "/post");
+      equal(res.headers["test-header-key"], testHeaders["test-header-key"]);
+      equal(res.headers["user-agent"], `${pkg.name}/${pkg.version}`);
+    });
   });
 
   it("post with body", () => {
@@ -56,14 +50,17 @@ describe("http", () => {
       message: "hello, body!",
     };
 
-    return post(`${TEST_URL}/post/body`, testHeaders, testBody)
-      .then((res: any) => {
-        equal(res.method, "POST");
-        equal(res.path, "/post/body");
-        equal(res.headers["test-header-key"], testHeaders["test-header-key"]);
-        equal(res.headers["user-agent"], `${pkg.name}/${pkg.version}`);
-        deepEqual(res.body, testBody);
-      });
+    return post(
+      `${TEST_URL}/post/body`,
+      testHeaders,
+      testBody,
+    ).then((res: any) => {
+      equal(res.method, "POST");
+      equal(res.path, "/post/body");
+      equal(res.headers["test-header-key"], testHeaders["test-header-key"]);
+      equal(res.headers["user-agent"], `${pkg.name}/${pkg.version}`);
+      deepEqual(res.body, testBody);
+    });
   });
 
   it("stream", () => {
@@ -72,8 +69,8 @@ describe("http", () => {
     };
 
     return stream(`${TEST_URL}/stream.txt`, testHeaders)
-      .then((s) => getStreamData(s))
-      .then((result) => {
+      .then(s => getStreamData(s))
+      .then(result => {
         equal(result, "hello, stream!\n");
       });
   });
@@ -81,7 +78,7 @@ describe("http", () => {
   it("fail to parse json", () => {
     return get(`${TEST_URL}/text`, {})
       .then(() => ok(false))
-      .catch((err) => {
+      .catch(err => {
         ok(err instanceof JSONParseError);
         equal(err.raw, "i am not jason");
       });

--- a/test/http.spec.ts
+++ b/test/http.spec.ts
@@ -8,7 +8,7 @@ import { get, post, stream } from "../lib/http";
 import { getStreamData } from "./helpers/stream";
 import { close, listen } from "./helpers/test-server";
 
-const pkg = require("../package.json"); // tslint:disable-line no-var-requires
+const pkg = require("../package.json");
 
 const TEST_PORT = parseInt(process.env.TEST_PORT, 10);
 const TEST_URL = `http://localhost:${TEST_PORT}`;

--- a/test/middleware.spec.ts
+++ b/test/middleware.spec.ts
@@ -29,48 +29,65 @@ describe("middleware", () => {
   };
 
   it("succeed", () => {
-    const auth: any = { "X-Line-Signature": "qeDy61PbQK+aO97Bs8zjaFgYjQxFruGd13pfXPQoBRU=" };
+    const auth: any = {
+      "X-Line-Signature": "qeDy61PbQK+aO97Bs8zjaFgYjQxFruGd13pfXPQoBRU=",
+    };
 
-    return post(`${TEST_URL}/webhook`, auth, { events: [webhook] })
-      .then((res: any) => {
-        deepEqual(res.body.events, [webhook]);
-      });
+    return post(`${TEST_URL}/webhook`, auth, {
+      events: [webhook],
+    }).then((res: any) => {
+      deepEqual(res.body.events, [webhook]);
+    });
   });
 
   it("succeed with pre-parsed string", () => {
-    const auth: any = { "X-Line-Signature": "qeDy61PbQK+aO97Bs8zjaFgYjQxFruGd13pfXPQoBRU=" };
+    const auth: any = {
+      "X-Line-Signature": "qeDy61PbQK+aO97Bs8zjaFgYjQxFruGd13pfXPQoBRU=",
+    };
 
-    return post(`${TEST_URL}/mid-text`, auth, { events: [webhook] })
-      .then((res: any) => {
-        deepEqual(res.body.events, [webhook]);
-      });
+    return post(`${TEST_URL}/mid-text`, auth, {
+      events: [webhook],
+    }).then((res: any) => {
+      deepEqual(res.body.events, [webhook]);
+    });
   });
 
   it("succeed with pre-parsed buffer", () => {
-    const auth: any = { "X-Line-Signature": "qeDy61PbQK+aO97Bs8zjaFgYjQxFruGd13pfXPQoBRU=" };
+    const auth: any = {
+      "X-Line-Signature": "qeDy61PbQK+aO97Bs8zjaFgYjQxFruGd13pfXPQoBRU=",
+    };
 
-    return post(`${TEST_URL}/mid-buffer`, auth, { events: [webhook] })
-      .then((res: any) => {
-        deepEqual(res.body.events, [webhook]);
-      });
+    return post(`${TEST_URL}/mid-buffer`, auth, {
+      events: [webhook],
+    }).then((res: any) => {
+      deepEqual(res.body.events, [webhook]);
+    });
   });
 
   it("fails on wrong signature", () => {
-    const auth: any = { "X-Line-Signature": "qeDy61PbQK+aO97Bs8zjbFgYjQxFruGd13pfXPQoBRU=" };
+    const auth: any = {
+      "X-Line-Signature": "qeDy61PbQK+aO97Bs8zjbFgYjQxFruGd13pfXPQoBRU=",
+    };
 
-    return post(`${TEST_URL}/webhook`, auth, { events: [webhook] })
-      .catch((err: HTTPError) => {
-        equal(err.statusCode, 401);
-      });
+    return post(`${TEST_URL}/webhook`, auth, {
+      events: [webhook],
+    }).catch((err: HTTPError) => {
+      equal(err.statusCode, 401);
+    });
   });
 
   it("fails on invalid JSON", () => {
-    const auth: any = { "X-Line-Signature": "Z8YlPpm0lQOqPipiCHVbiuwIDIzRzD7w5hvHgmwEuEs=" };
+    const auth: any = {
+      "X-Line-Signature": "Z8YlPpm0lQOqPipiCHVbiuwIDIzRzD7w5hvHgmwEuEs=",
+    };
 
-    return post(`${TEST_URL}/webhook`, auth, "i am not jason")
-      .catch((err: HTTPError) => {
-        equal(err.statusCode, 400);
-      });
+    return post(
+      `${TEST_URL}/webhook`,
+      auth,
+      "i am not jason",
+    ).catch((err: HTTPError) => {
+      equal(err.statusCode, 400);
+    });
   });
 
   it("fails on empty signature", () => {

--- a/tslint.json
+++ b/tslint.json
@@ -1,7 +1,0 @@
-{
-  "extends": "tslint:recommended",
-  "rules": {
-    "max-classes-per-file": false,
-    "no-console": { "severity": "warning", "options": ["log", "error", "warn", "info"] }
-  }
-}

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,4 +1,3 @@
-/* tslint:disable interface-over-type-literal no-namespace */
 // Type definitions globally used in source code
 
 declare namespace Line {


### PR DESCRIPTION
Some project-level refactorings.

- Use package.json `"files"` field instead of `.npmignore`
    - https://docs.npmjs.com/files/package.json#files
- Use [Prettier](https://github.com/prettier/prettier) instead of TSLint
    - As TypeScript compiler get rids of needs for linting, what's needed is a formatter, not a linter
    - Include a commit formatting existing source codes
- Update `.travis.yml`, update target versions of Node.js
    - Cut 4, add 8
- Add git hooks to format, build, and test before commit or push
    - Used [Husky](https://github.com/typicode/husky) to integrate with npm scripts