### PR TITLE
Adding support for development/testing in local environment

### DIFF
--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -19,17 +19,22 @@ export default function middleware(config: Line.Config & Line.MiddlewareConfig):
   return (req, res, next) => {
     // header names are lower-cased
     // https://nodejs.org/api/http.html#http_message_headers
-    const signature = req.headers["x-line-signature"] as string;
+    let signature: any;
+    if (!process.env.TEST) {
+      signature = req.headers["x-line-signature"] as string;
 
-    if (!signature) {
-      next(new SignatureValidationFailed("no signature"));
-      return;
+      if (!signature) {
+        next(new SignatureValidationFailed("no signature"));
+        return;
+      }
     }
 
     const validate = (body: string | Buffer) => {
-      if (!validateSignature(body, secret, signature)) {
-        next(new SignatureValidationFailed("signature validation failed", signature));
-        return;
+      if (!process.env.TEST) {
+        if (!validateSignature(body, secret, signature)) {
+          next(new SignatureValidationFailed("signature validation failed", signature));
+          return;
+        }
       }
 
       const strBody = Buffer.isBuffer(body) ? body.toString() : body;

--- a/test/middleware.spec.ts
+++ b/test/middleware.spec.ts
@@ -86,4 +86,20 @@ describe("middleware", () => {
         }
       });
   });
+
+  it("success on empty signature while process.env.test = true", () => {
+    process.env.TEST = true;
+    const myMiddleware = middleware({ channelSecret: "test_channel_secret" });
+    const myTestPort = 4321;
+    const myTestUrl = `http://localhost:${myTestPort}`;
+    listen(myTestPort, myMiddleware);
+
+    return post(`${myTestUrl}/webhook`, {}, { events: [webhook] })
+      .then((res: any) => {
+        deepEqual(res.body.events, [webhook]);
+      })
+      .catch((err: any) => {
+        throw new Error();
+      });
+  });
 });


### PR DESCRIPTION
## TLDR;
### :+1: You can test your bot locally, you can test directly on your own computer without passing through long-boring build pipeline, No need to put on staging server, Heroku / Azure or other PaaS provider just to test your bot is working.  :desktop_computer: 
### :+1: Test your bot by simulating multiple user at once *without any devices* :no_mobile_phones: 

With this pull request, the developers are able to test their bots on local computer/environment. Accelerating bot development by bypassing `x-line-signature` verification. 

## 1. Create your own LineMockServer.js
You can write a simple Line API Mock Server like this : 
```js
var express = require('express');
var bodyParser = require('body-parser');
var app = express();

app.use(bodyParser.json());

app.get('/', function(req, res){
    res.send('Hello world');
});

app.post('/message/reply',function(req, res){
    console.dir(req.body);
    res.json(req.body);
});

app.post('/message/push', function(req, res){
    console.dir(req.body);
    res.json(req.body);
});

app.get('/profile/:userId', function(req, res){
    var users = {
        'member_1':{
            'displayName': 'Spongebob',
            'userId': 'member_1',
            'pictureUrl': 'http://placeholder.it/256x256',
            'statusMessage': 'exampleStatusMessage',
        },
        'member_2':{
            'displayName': 'Patrick Star',
            'userId': 'member_2',
            'pictureUrl': 'http://placeholder.it/256x256',
            'statusMessage': 'exampleStatusMessage',
        },
    };

    var selectedUser = users[req.params.userId];
    console.log("Returning profile for userId = "+req.params.userId);
    console.dir(selectedUser);
    res.json(selectedUser);
});

app.post('*', function(req, res){
    showTime();
    console.dir(req.body);
    res.json(req.body);
});

app.listen(8000, function(){
    console.log("listening on port 8000");
});
```
then run your Line API Mock Server with :
```
node LineMockserver.js
```
## 2. Run your server js with TEST flag and appropriate API_BASE_URL
In this case, we are listening to port 8000, then run your bot server using this command : 
```
API_BASE_URL=http://localhost:8000/ TEST=true node server.js
```

## 3. Create API request to your local bot server
You can use any REST client to create a Http request to your bot server. Make sure you follow the Line API payload structure as written on [their docs](https://developers.line.me/en/docs/messaging-api/reference/#message-objects) while making your request.
In this case, I use [Postman Chrome Plugin](https://chrome.google.com/webstore/detail/postman/fhbjgbiflinjbdggehcddcbncdddomop?hl=en) since my bot server running on port `3000`, I put `localhost:3000` on Postman's address bar, set the `Content-Type` header to `application/json` and put Line Message Object, in the body. like this : 
```
{
  "events": [
    {
      "replyToken": "nHuyWiB7yP5Zw52FIkcQobQuGDXCTA",
      "type": "message",
      "timestamp": 1462629479859,
      "source": {
        "type": "user",
        "userId": "member_1"
      },
      "message": {
        "id": "325708",
        "type": "text",
        "text": "help"
      }
    }
  ]
}
```
## 4. Enjoy it !
![working perfectly](https://user-images.githubusercontent.com/1295143/32061705-8feed3d6-ba9c-11e7-84ce-f29ed9ed6000.gif)
