### PR TITLE
Set Content-Length manually for postBinary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -595,21 +595,6 @@
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-7.2.0.tgz",
       "integrity": "sha1-ETz+1S4daVmrgCSJBuLyWozcy3Q="
     },
-    "file-type-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-type-stream/-/file-type-stream-1.0.0.tgz",
-      "integrity": "sha1-3Qoe3R9f6XNiPtb+Fr4ZyJMbRMM=",
-      "requires": {
-        "file-type": "3.9.0"
-      },
-      "dependencies": {
-        "file-type": {
-          "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-          "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
-        }
-      }
-    },
     "finalhandler": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     "@types/node": "^7.0.31",
     "axios": "^0.16.2",
     "body-parser": "^1.18.2",
-    "file-type": "^7.2.0",
-    "file-type-stream": "^1.0.0"
+    "file-type": "^7.2.0"
   },
   "devDependencies": {
     "@types/express": "^4.0.35",

--- a/test/http.spec.ts
+++ b/test/http.spec.ts
@@ -114,6 +114,7 @@ describe("http", () => {
         equal(req.headers["test-header-key"], testHeaders["test-header-key"]);
         equal(req.headers["user-agent"], `${pkg.name}/${pkg.version}`);
         equal(req.headers["content-type"], "image/png");
+        equal(req.headers["content-length"], buffer.length);
       },
     );
   });
@@ -126,6 +127,7 @@ describe("http", () => {
         const req = getRecentReq();
         equal(req.body, buffer.toString("base64"));
         equal(req.headers["content-type"], "image/jpeg");
+        equal(req.headers["content-length"], buffer.length);
       },
     );
   });
@@ -134,9 +136,12 @@ describe("http", () => {
     const filepath = join(__dirname, "/helpers/line-icon.png");
     const stream = createReadStream(filepath);
     return postBinary(`${TEST_URL}/post/binary`, {}, stream).then(() => {
+      const buffer = readFileSync(filepath);
+
       const req = getRecentReq();
-      equal(req.body, readFileSync(filepath).toString("base64"));
+      equal(req.body, buffer.toString("base64"));
       equal(req.headers["content-type"], "image/png");
+      equal(req.headers["content-length"], buffer.length);
     });
   });
 


### PR DESCRIPTION
Concerning #41.

In some systems, `Content-Length` header is not properly set with readable streams. In the case, the server does not recognise the body and responses with 411.

This PR adds a logic to manually set `Content-Length` and test cases. For streams, it's not possible to get its size before it's fully consumed, so I changed `postBinary` to create a buffer from a stream in advance. With the change, `fileTypeStream` is no longer needed and thus removed.