### PR TITLE
TemplateColumn type definition is wrong

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -233,7 +233,7 @@ export type TemplateCarousel = {
 
 export type TemplateColumn = {
   thumbnailImageUrl?: string;
-  imageAspectRatio?: "rectangle" | "square";
+  imageBackgroundColor?: string;
   title?: string;
   text: string;
   actions: Action<{ label: string }>[];


### PR DESCRIPTION
I modify TemplateColumn type definition to fit the LINE Messaging API Reference.