### PR TITLE
get actual audio duration

### DIFF
--- a/examples/kitchensink/index.js
+++ b/examples/kitchensink/index.js
@@ -315,14 +315,23 @@ function handleAudio(message, replyToken) {
 
   return downloadContent(message.id, downloadPath)
     .then((downloadPath) => {
-      return client.replyMessage(
-        replyToken,
-        {
-          type: 'audio',
-          originalContentUrl: baseURL + '/downloaded/' + path.basename(downloadPath),
-          duration: 1000,
-        }
-      );
+      // get-audio-duration is needed here to get audio duration
+      // npm install get-audio-duration --save
+      var getDuration = require('get-audio-duration');
+      var audioDuration;
+      getDuration(downloadPath)
+        .then((duration) => { audioDuration = duration; })
+        .catch((error) => { audioDuration = 1; })
+        .finally(() => {
+          return client.replyMessage(
+            replyToken,
+            {
+              type: 'audio',
+              originalContentUrl: baseURL + '/downloaded/' + path.basename(downloadPath),
+              duration: audioDuration * 1000,
+            }
+          );
+        });
     });
 }
 


### PR DESCRIPTION
I see replied audio's duration always show as 1 second, it does't real.
So I use get-audio-duration (https://github.com/caffco/get-audio-duration).
It gets actual audio duration from ffprobe.