### PR TITLE
Fix #72 get-audio-duration dependency should be in kitchensink

### DIFF
--- a/examples/kitchensink/package-lock.json
+++ b/examples/kitchensink/package-lock.json
@@ -9,13 +9,13 @@
       "resolved": "https://registry.npmjs.org/@line/bot-sdk/-/bot-sdk-5.0.0.tgz",
       "integrity": "sha1-TTQOHgK09Q32vMtqnCPOWs20JWk=",
       "requires": {
-        "@types/body-parser": "1.16.8",
-        "@types/file-type": "5.2.1",
-        "@types/node": "7.0.46",
-        "axios": "0.16.2",
-        "body-parser": "1.18.2",
-        "file-type": "7.2.0",
-        "file-type-stream": "1.0.0"
+        "@types/body-parser": "^1.16.3",
+        "@types/file-type": "^5.2.1",
+        "@types/node": "^7.0.31",
+        "axios": "^0.16.2",
+        "body-parser": "^1.17.2",
+        "file-type": "^7.2.0",
+        "file-type-stream": "^1.0.0"
       }
     },
     "@types/body-parser": {
@@ -23,8 +23,8 @@
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.16.8.tgz",
       "integrity": "sha512-BdN2PXxOFnTXFcyONPW6t0fHjz2fvRZHVMFpaS0wYr+Y8fWEaNOs4V8LEu/fpzQlMx+ahdndgTaGTwPC+J/EeA==",
       "requires": {
-        "@types/express": "4.0.39",
-        "@types/node": "7.0.46"
+        "@types/express": "*",
+        "@types/node": "*"
       }
     },
     "@types/express": {
@@ -32,9 +32,9 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.0.39.tgz",
       "integrity": "sha512-dBUam7jEjyuEofigUXCtublUHknRZvcRgITlGsTbFgPvnTwtQUt2NgLakbsf+PsGo/Nupqr3IXCYsOpBpofyrA==",
       "requires": {
-        "@types/body-parser": "1.16.8",
-        "@types/express-serve-static-core": "4.0.56",
-        "@types/serve-static": "1.13.1"
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/serve-static": "*"
       }
     },
     "@types/express-serve-static-core": {
@@ -42,7 +42,7 @@
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.56.tgz",
       "integrity": "sha512-/0nwIzF1Bd4KGwW4lhDZYi5StmCZG1DIXXMfQ/zjORzlm4+F1eRA4c6yJQrt4hqX//TDtPULpSlYwmSNyCMeMg==",
       "requires": {
-        "@types/node": "7.0.46"
+        "@types/node": "*"
       }
     },
     "@types/file-type": {
@@ -50,7 +50,7 @@
       "resolved": "https://registry.npmjs.org/@types/file-type/-/file-type-5.2.1.tgz",
       "integrity": "sha512-Im0cJaIPJbbpuW91OrjXnqWPZCJK/tcFy2cFX+1qjG1gubgVZPPO9OVsTVAjotN4I1E6FAV0eIqt+rR8Y1c3iA==",
       "requires": {
-        "@types/node": "7.0.46"
+        "@types/node": "*"
       }
     },
     "@types/mime": {
@@ -68,8 +68,8 @@
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.1.tgz",
       "integrity": "sha512-jDMH+3BQPtvqZVIcsH700Dfi8Q3MIcEx16g/VdxjoqiGR/NntekB10xdBpirMKnPe9z2C5cBmL0vte0YttOr3Q==",
       "requires": {
-        "@types/express-serve-static-core": "4.0.56",
-        "@types/mime": "2.0.0"
+        "@types/express-serve-static-core": "*",
+        "@types/mime": "*"
       }
     },
     "accepts": {
@@ -77,9 +77,14 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
       "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
       "requires": {
-        "mime-types": "2.1.17",
+        "mime-types": "~2.1.16",
         "negotiator": "0.6.1"
       }
+    },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
     "array-flatten": {
       "version": "1.1.1",
@@ -91,8 +96,8 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.16.2.tgz",
       "integrity": "sha1-uk+S8XFn37q0CYN4VFS5rBScPG0=",
       "requires": {
-        "follow-redirects": "1.2.5",
-        "is-buffer": "1.1.6"
+        "follow-redirects": "^1.2.3",
+        "is-buffer": "^1.1.5"
       }
     },
     "body-parser": {
@@ -101,15 +106,15 @@
       "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.1",
-        "http-errors": "1.6.2",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
         "iconv-lite": "0.4.19",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "1.6.15"
+        "type-is": "~1.6.15"
       }
     },
     "bytes": {
@@ -180,36 +185,36 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
       "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
       "requires": {
-        "accepts": "1.3.4",
+        "accepts": "~1.3.4",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.1",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.1",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "finalhandler": "1.1.0",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.2",
+        "proxy-addr": "~2.0.2",
         "qs": "6.5.1",
-        "range-parser": "1.2.0",
+        "range-parser": "~1.2.0",
         "safe-buffer": "5.1.1",
         "send": "0.16.1",
         "serve-static": "1.13.1",
         "setprototypeof": "1.1.0",
-        "statuses": "1.3.1",
-        "type-is": "1.6.15",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.15",
         "utils-merge": "1.0.1",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       },
       "dependencies": {
         "setprototypeof": {
@@ -234,7 +239,7 @@
       "resolved": "https://registry.npmjs.org/file-type-stream/-/file-type-stream-1.0.0.tgz",
       "integrity": "sha1-3Qoe3R9f6XNiPtb+Fr4ZyJMbRMM=",
       "requires": {
-        "file-type": "3.9.0"
+        "file-type": "^3.8.0"
       },
       "dependencies": {
         "file-type": {
@@ -250,12 +255,12 @@
       "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.3.1",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
       },
       "dependencies": {
         "statuses": {
@@ -270,7 +275,7 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.5.tgz",
       "integrity": "sha512-lMhwQTryFbG+wYsAIEKC1Kf5IGDlVNnONRogIBllh7LLoV7pNIxW0z9fhjRar9NBql+hd2Y49KboVVNxf6GEfg==",
       "requires": {
-        "debug": "2.6.9"
+        "debug": "^2.6.9"
       }
     },
     "forwarded": {
@@ -283,6 +288,14 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
+    "get-audio-duration": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/get-audio-duration/-/get-audio-duration-0.0.1.tgz",
+      "integrity": "sha1-a+oD7DgldbcGL4tUhoVJ6shMXiw=",
+      "requires": {
+        "mz": "^1.2.1"
+      }
+    },
     "http-errors": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
@@ -291,7 +304,7 @@
         "depd": "1.1.1",
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
-        "statuses": "1.4.0"
+        "statuses": ">= 1.3.1 < 2"
       }
     },
     "iconv-lite": {
@@ -344,13 +357,28 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": "~1.30.0"
       }
     },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "mz": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-1.3.0.tgz",
+      "integrity": "sha1-BvCT/dmVagbTfhsegTROJ0eMQvA=",
+      "requires": {
+        "native-or-bluebird": "1",
+        "thenify": "3",
+        "thenify-all": "1"
+      }
+    },
+    "native-or-bluebird": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.2.0.tgz",
+      "integrity": "sha1-OcR7/Xgl0fuf+tMiEK4l2q3xAck="
     },
     "negotiator": {
       "version": "0.6.1",
@@ -380,7 +408,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
       "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
       "requires": {
-        "forwarded": "0.1.2",
+        "forwarded": "~0.1.2",
         "ipaddr.js": "1.5.2"
       }
     },
@@ -416,18 +444,18 @@
       "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.1",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.1",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.6.2",
+        "http-errors": "~1.6.2",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.3.1"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
       },
       "dependencies": {
         "statuses": {
@@ -442,9 +470,9 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
       "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
       "requires": {
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
         "send": "0.16.1"
       }
     },
@@ -458,13 +486,29 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
       "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
     },
+    "thenify": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
+      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+      "requires": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+      "requires": {
+        "thenify": ">= 3.1.0 < 4"
+      }
+    },
     "type-is": {
       "version": "1.6.15",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
       "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.17"
+        "mime-types": "~2.1.15"
       }
     },
     "unpipe": {

--- a/examples/kitchensink/package.json
+++ b/examples/kitchensink/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@line/bot-sdk": "^5.0.0",
-    "express": "^4.16.2"
+    "express": "^4.16.2",
+    "get-audio-duration": "0.0.1"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@line/bot-sdk",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9,8 +9,8 @@
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.16.8.tgz",
       "integrity": "sha512-BdN2PXxOFnTXFcyONPW6t0fHjz2fvRZHVMFpaS0wYr+Y8fWEaNOs4V8LEu/fpzQlMx+ahdndgTaGTwPC+J/EeA==",
       "requires": {
-        "@types/express": "4.0.35",
-        "@types/node": "7.0.31"
+        "@types/express": "*",
+        "@types/node": "*"
       }
     },
     "@types/express": {
@@ -18,8 +18,8 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.0.35.tgz",
       "integrity": "sha1-YmfHtgpR+sRzRns8SgLNHkQYBf4=",
       "requires": {
-        "@types/express-serve-static-core": "4.0.46",
-        "@types/serve-static": "1.7.31"
+        "@types/express-serve-static-core": "*",
+        "@types/serve-static": "*"
       }
     },
     "@types/express-serve-static-core": {
@@ -27,7 +27,7 @@
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.46.tgz",
       "integrity": "sha512-dtJos9GpTYqX/LBvpu8xHxOQTeAXEgFzZkQmcLgxj/ZbNv0v+cpM3A2ZAiOljgNAbHeguPivFn2wHbNYvLJVcA==",
       "requires": {
-        "@types/node": "7.0.31"
+        "@types/node": "*"
       }
     },
     "@types/file-type": {
@@ -35,7 +35,7 @@
       "resolved": "https://registry.npmjs.org/@types/file-type/-/file-type-5.2.1.tgz",
       "integrity": "sha1-569J4IGHtrdZhQnF5BZmnSX6NGE=",
       "requires": {
-        "@types/node": "7.0.31"
+        "@types/node": "*"
       }
     },
     "@types/mime": {
@@ -59,8 +59,8 @@
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.7.31.tgz",
       "integrity": "sha1-FUVt6NmNa0z/Mb5savdJKuY/Uho=",
       "requires": {
-        "@types/express-serve-static-core": "4.0.46",
-        "@types/mime": "0.0.29"
+        "@types/express-serve-static-core": "*",
+        "@types/mime": "*"
       }
     },
     "accepts": {
@@ -69,7 +69,7 @@
       "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
       "dev": true,
       "requires": {
-        "mime-types": "2.1.15",
+        "mime-types": "~2.1.11",
         "negotiator": "0.6.1"
       }
     },
@@ -79,7 +79,7 @@
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "dev": true,
       "requires": {
-        "string-width": "2.1.0"
+        "string-width": "^2.0.0"
       }
     },
     "ansi-regex": {
@@ -93,11 +93,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
-    },
-    "any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
     },
     "array-find-index": {
       "version": "1.0.2",
@@ -117,7 +112,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -137,8 +132,8 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.16.2.tgz",
       "integrity": "sha1-uk+S8XFn37q0CYN4VFS5rBScPG0=",
       "requires": {
-        "follow-redirects": "1.2.4",
-        "is-buffer": "1.1.5"
+        "follow-redirects": "^1.2.3",
+        "is-buffer": "^1.1.5"
       }
     },
     "balanced-match": {
@@ -159,15 +154,15 @@
       "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.1",
-        "http-errors": "1.6.2",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
         "iconv-lite": "0.4.19",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "1.6.15"
+        "type-is": "~1.6.15"
       },
       "dependencies": {
         "bytes": {
@@ -201,7 +196,7 @@
             "depd": "1.1.1",
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
-            "statuses": "1.3.1"
+            "statuses": ">= 1.3.1 < 2"
           }
         },
         "iconv-lite": {
@@ -233,13 +228,13 @@
       "integrity": "sha1-sbad1SIwXoB6md7ud329blFnsQI=",
       "dev": true,
       "requires": {
-        "ansi-align": "2.0.0",
-        "camelcase": "4.1.0",
-        "chalk": "1.1.3",
-        "cli-boxes": "1.0.0",
-        "string-width": "2.1.0",
-        "term-size": "0.1.1",
-        "widest-line": "1.0.0"
+        "ansi-align": "^2.0.0",
+        "camelcase": "^4.0.0",
+        "chalk": "^1.1.1",
+        "cli-boxes": "^1.0.0",
+        "string-width": "^2.0.0",
+        "term-size": "^0.1.0",
+        "widest-line": "^1.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -256,7 +251,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -284,8 +279,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
       }
     },
     "chalk": {
@@ -294,11 +289,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       },
       "dependencies": {
         "supports-color": {
@@ -333,7 +328,7 @@
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -348,7 +343,7 @@
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
       "dev": true,
       "requires": {
-        "graceful-readlink": "1.0.1"
+        "graceful-readlink": ">= 1.0.0"
       }
     },
     "concat-map": {
@@ -363,12 +358,12 @@
       "integrity": "sha1-Rd+QcHPibfoc9LLVL1tgVF6qEdE=",
       "dev": true,
       "requires": {
-        "dot-prop": "4.1.1",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.0.0",
-        "unique-string": "1.0.0",
-        "write-file-atomic": "2.1.0",
-        "xdg-basedir": "3.0.0"
+        "dot-prop": "^4.1.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
       }
     },
     "content-disposition": {
@@ -401,8 +396,8 @@
       "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.1",
-        "which": "1.2.14"
+        "lru-cache": "^4.0.0",
+        "which": "^1.2.8"
       }
     },
     "crypto-random-string": {
@@ -417,7 +412,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "debug": {
@@ -440,7 +435,7 @@
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "dev": true,
       "requires": {
-        "mimic-response": "1.0.0"
+        "mimic-response": "^1.0.0"
       }
     },
     "deep-extend": {
@@ -455,12 +450,12 @@
       "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
       "dev": true,
       "requires": {
-        "globby": "6.1.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "p-map": "1.1.1",
-        "pify": "3.0.0",
-        "rimraf": "2.6.1"
+        "globby": "^6.1.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "p-map": "^1.1.1",
+        "pify": "^3.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "del-cli": {
@@ -469,9 +464,9 @@
       "integrity": "sha1-J1V9aaC335ncuqHjSgnmrGWR0sQ=",
       "dev": true,
       "requires": {
-        "del": "3.0.0",
-        "meow": "3.7.0",
-        "update-notifier": "2.2.0"
+        "del": "^3.0.0",
+        "meow": "^3.6.0",
+        "update-notifier": "^2.1.0"
       }
     },
     "depd": {
@@ -498,7 +493,7 @@
       "integrity": "sha1-qEk/C3te7sglJbXHWH+n3nyoWcE=",
       "dev": true,
       "requires": {
-        "is-obj": "1.0.1"
+        "is-obj": "^1.0.0"
       }
     },
     "duplexer3": {
@@ -524,7 +519,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "escape-html": {
@@ -551,12 +546,12 @@
       "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
       "dev": true,
       "requires": {
-        "cross-spawn-async": "2.2.5",
-        "is-stream": "1.1.0",
-        "npm-run-path": "1.0.0",
-        "object-assign": "4.1.1",
-        "path-key": "1.0.0",
-        "strip-eof": "1.0.0"
+        "cross-spawn-async": "^2.1.1",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "path-key": "^1.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "express": {
@@ -565,34 +560,34 @@
       "integrity": "sha1-urZdDwOqgMNYQIly/HAPkWlEtmI=",
       "dev": true,
       "requires": {
-        "accepts": "1.3.3",
+        "accepts": "~1.3.3",
         "array-flatten": "1.1.1",
         "content-disposition": "0.5.2",
-        "content-type": "1.0.2",
+        "content-type": "~1.0.2",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.7",
-        "depd": "1.1.0",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.8.0",
-        "finalhandler": "1.0.3",
+        "depd": "~1.1.0",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "finalhandler": "~1.0.3",
         "fresh": "0.5.0",
         "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "1.1.4",
+        "proxy-addr": "~1.1.4",
         "qs": "6.4.0",
-        "range-parser": "1.2.0",
+        "range-parser": "~1.2.0",
         "send": "0.15.3",
         "serve-static": "1.12.3",
         "setprototypeof": "1.0.3",
-        "statuses": "1.3.1",
-        "type-is": "1.6.15",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.15",
         "utils-merge": "1.0.0",
-        "vary": "1.1.1"
+        "vary": "~1.1.1"
       }
     },
     "file-type": {
@@ -607,12 +602,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.7",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.1",
-        "statuses": "1.3.1",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
       }
     },
     "find-up": {
@@ -621,8 +616,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "follow-redirects": {
@@ -630,7 +625,7 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.4.tgz",
       "integrity": "sha512-Suw6KewLV2hReSyEOeql+UUkBVyiBm3ok1VPrVFRZnQInWpdoZbbiG5i8aJVSjTr0yQ4Ava0Sh6/joCg1Brdqw==",
       "requires": {
-        "debug": "2.6.7"
+        "debug": "^2.4.5"
       }
     },
     "forwarded": {
@@ -651,11 +646,11 @@
       "integrity": "sha1-U6x0Znygg/0twXEsgTA5yjLWmn8=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0",
-        "klaw": "1.3.1",
-        "path-is-absolute": "1.0.1",
-        "rimraf": "2.6.1"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0",
+        "path-is-absolute": "^1.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "fs.realpath": {
@@ -663,14 +658,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "get-audio-duration": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/get-audio-duration/-/get-audio-duration-0.0.1.tgz",
-      "integrity": "sha1-a+oD7DgldbcGL4tUhoVJ6shMXiw=",
-      "requires": {
-        "mz": "1.3.0"
-      }
     },
     "get-stdin": {
       "version": "4.0.1",
@@ -709,12 +696,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "globby": {
@@ -723,11 +710,11 @@
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -744,19 +731,19 @@
       "integrity": "sha1-gtQ59nY82xyIIbejquJ4TIjDuNM=",
       "dev": true,
       "requires": {
-        "decompress-response": "3.3.0",
-        "duplexer3": "0.1.4",
-        "get-stream": "3.0.0",
-        "is-plain-obj": "1.1.0",
-        "is-retry-allowed": "1.1.0",
-        "is-stream": "1.1.0",
-        "isurl": "1.0.0-alpha5",
-        "lowercase-keys": "1.0.0",
-        "p-cancelable": "0.2.0",
-        "p-timeout": "1.1.1",
-        "safe-buffer": "5.1.0",
-        "timed-out": "4.0.1",
-        "url-parse-lax": "1.0.0"
+        "decompress-response": "^3.2.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-plain-obj": "^1.1.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "isurl": "^1.0.0-alpha5",
+        "lowercase-keys": "^1.0.0",
+        "p-cancelable": "^0.2.0",
+        "p-timeout": "^1.1.1",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "url-parse-lax": "^1.0.0"
       }
     },
     "graceful-fs": {
@@ -783,7 +770,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -798,7 +785,7 @@
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "dev": true,
       "requires": {
-        "parse-passwd": "1.0.0"
+        "parse-passwd": "^1.0.0"
       }
     },
     "hosted-git-info": {
@@ -816,7 +803,7 @@
         "depd": "1.1.0",
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
-        "statuses": "1.3.1"
+        "statuses": ">= 1.3.1 < 2"
       }
     },
     "husky": {
@@ -825,9 +812,9 @@
       "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
       "dev": true,
       "requires": {
-        "is-ci": "1.0.10",
-        "normalize-path": "1.0.0",
-        "strip-indent": "2.0.0"
+        "is-ci": "^1.0.10",
+        "normalize-path": "^1.0.0",
+        "strip-indent": "^2.0.0"
       },
       "dependencies": {
         "strip-indent": {
@@ -856,7 +843,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "inflight": {
@@ -865,8 +852,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -903,7 +890,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-ci": {
@@ -912,7 +899,7 @@
       "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
       "dev": true,
       "requires": {
-        "ci-info": "1.1.1"
+        "ci-info": "^1.0.0"
       }
     },
     "is-finite": {
@@ -921,7 +908,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -960,7 +947,7 @@
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -969,7 +956,7 @@
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-plain-obj": {
@@ -1008,7 +995,7 @@
       "integrity": "sha1-d/oSL/8fMb4ntvFXZh+IWCuhzTY=",
       "dev": true,
       "requires": {
-        "is-object": "1.0.1"
+        "is-object": "^1.0.1"
       }
     },
     "json3": {
@@ -1023,7 +1010,7 @@
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "klaw": {
@@ -1032,7 +1019,7 @@
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.9"
       }
     },
     "latest-version": {
@@ -1041,7 +1028,7 @@
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "dev": true,
       "requires": {
-        "package-json": "4.0.1"
+        "package-json": "^4.0.0"
       }
     },
     "load-json-file": {
@@ -1050,11 +1037,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -1077,8 +1064,8 @@
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._basecopy": {
@@ -1111,9 +1098,9 @@
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true,
       "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
       }
     },
     "lodash.isarguments": {
@@ -1134,9 +1121,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "loud-rejection": {
@@ -1145,8 +1132,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lowercase-keys": {
@@ -1161,8 +1148,8 @@
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "make-dir": {
@@ -1171,7 +1158,7 @@
       "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
       "dev": true,
       "requires": {
-        "pify": "2.3.0"
+        "pify": "^2.3.0"
       },
       "dependencies": {
         "pify": {
@@ -1205,16 +1192,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "0.0.10",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
       }
     },
     "merge-descriptors": {
@@ -1245,7 +1232,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
       "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
       "requires": {
-        "mime-db": "1.27.0"
+        "mime-db": "~1.27.0"
       }
     },
     "mimic-response": {
@@ -1260,7 +1247,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -1320,12 +1307,12 @@
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "ms": {
@@ -1341,21 +1328,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
-    "mz": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-1.3.0.tgz",
-      "integrity": "sha1-BvCT/dmVagbTfhsegTROJ0eMQvA=",
-      "requires": {
-        "native-or-bluebird": "1.2.0",
-        "thenify": "3.3.0",
-        "thenify-all": "1.6.0"
-      }
-    },
-    "native-or-bluebird": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.2.0.tgz",
-      "integrity": "sha1-OcR7/Xgl0fuf+tMiEK4l2q3xAck="
-    },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
@@ -1368,10 +1340,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.1.0",
-        "validate-npm-package-license": "3.0.1"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -1386,91 +1358,91 @@
       "integrity": "sha1-p9rljlLsviY8HIYMb9ZP+lDzx5s=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.7",
-        "ansi-regex": "2.0.0",
-        "ansicolors": "0.3.2",
-        "ansistyles": "0.1.3",
-        "aproba": "1.0.1",
-        "archy": "1.0.0",
-        "async-some": "1.0.2",
-        "chownr": "1.0.1",
-        "cmd-shim": "2.0.2",
-        "columnify": "1.5.4",
-        "config-chain": "1.1.10",
-        "debuglog": "1.0.1",
-        "dezalgo": "1.0.3",
-        "editor": "1.0.0",
-        "fs-vacuum": "1.2.7",
-        "fs-write-stream-atomic": "1.0.8",
-        "fstream": "1.0.8",
-        "fstream-npm": "1.0.7",
-        "glob": "7.0.0",
-        "graceful-fs": "4.1.3",
-        "has-unicode": "2.0.0",
-        "hosted-git-info": "2.1.4",
-        "iferr": "0.1.5",
-        "imurmurhash": "0.1.4",
-        "inflight": "1.0.4",
-        "inherits": "2.0.1",
-        "ini": "1.3.4",
-        "init-package-json": "1.9.3",
-        "lockfile": "1.0.1",
-        "lodash._baseindexof": "3.1.0",
-        "lodash._baseuniq": "4.4.0",
-        "lodash._bindcallback": "3.0.1",
-        "lodash._cacheindexof": "3.0.2",
-        "lodash._createcache": "3.1.2",
-        "lodash._getnative": "3.9.1",
-        "lodash.clonedeep": "4.3.0",
-        "lodash.isarguments": "3.0.7",
-        "lodash.isarray": "4.0.0",
-        "lodash.keys": "4.0.3",
-        "lodash.restparam": "3.6.1",
-        "lodash.union": "4.2.0",
-        "lodash.uniq": "4.2.0",
-        "lodash.without": "4.1.0",
-        "mkdirp": "0.5.1",
-        "node-gyp": "3.3.0",
-        "nopt": "3.0.6",
-        "normalize-git-url": "3.0.1",
-        "normalize-package-data": "2.3.5",
-        "npm-cache-filename": "1.0.2",
-        "npm-install-checks": "3.0.0",
-        "npm-package-arg": "4.1.0",
-        "npm-registry-client": "7.0.9",
-        "npm-user-validate": "0.1.2",
-        "npmlog": "2.0.2",
-        "once": "1.3.3",
-        "opener": "1.4.1",
-        "osenv": "0.1.3",
-        "path-is-inside": "1.0.1",
-        "read": "1.0.7",
-        "read-cmd-shim": "1.0.1",
-        "read-installed": "4.0.3",
-        "read-package-json": "2.0.3",
-        "read-package-tree": "5.1.2",
-        "readable-stream": "2.0.5",
-        "readdir-scoped-modules": "1.0.2",
-        "realize-package-specifier": "3.0.1",
-        "request": "2.69.0",
-        "retry": "0.9.0",
-        "rimraf": "2.5.2",
-        "semver": "5.1.0",
-        "sha": "2.0.1",
-        "slide": "1.1.6",
-        "sorted-object": "1.0.0",
-        "strip-ansi": "3.0.0",
-        "tar": "2.2.1",
-        "text-table": "0.2.0",
+        "abbrev": "~1.0.7",
+        "ansi-regex": "*",
+        "ansicolors": "~0.3.2",
+        "ansistyles": "~0.1.3",
+        "aproba": "~1.0.1",
+        "archy": "~1.0.0",
+        "async-some": "~1.0.2",
+        "chownr": "~1.0.1",
+        "cmd-shim": "~2.0.2",
+        "columnify": "~1.5.4",
+        "config-chain": "~1.1.10",
+        "debuglog": "*",
+        "dezalgo": "~1.0.3",
+        "editor": "~1.0.0",
+        "fs-vacuum": "~1.2.7",
+        "fs-write-stream-atomic": "~1.0.8",
+        "fstream": "~1.0.8",
+        "fstream-npm": "~1.0.7",
+        "glob": "~7.0.0",
+        "graceful-fs": "~4.1.3",
+        "has-unicode": "~2.0.0",
+        "hosted-git-info": "~2.1.4",
+        "iferr": "~0.1.5",
+        "imurmurhash": "*",
+        "inflight": "~1.0.4",
+        "inherits": "~2.0.1",
+        "ini": "~1.3.4",
+        "init-package-json": "~1.9.3",
+        "lockfile": "~1.0.1",
+        "lodash._baseindexof": "*",
+        "lodash._baseuniq": "~4.4.0",
+        "lodash._bindcallback": "*",
+        "lodash._cacheindexof": "*",
+        "lodash._createcache": "*",
+        "lodash._getnative": "*",
+        "lodash.clonedeep": "~4.3.0",
+        "lodash.isarguments": "~3.0.7",
+        "lodash.isarray": "~4.0.0",
+        "lodash.keys": "~4.0.3",
+        "lodash.restparam": "*",
+        "lodash.union": "~4.2.0",
+        "lodash.uniq": "~4.2.0",
+        "lodash.without": "~4.1.0",
+        "mkdirp": "~0.5.1",
+        "node-gyp": "~3.3.0",
+        "nopt": "~3.0.6",
+        "normalize-git-url": "~3.0.1",
+        "normalize-package-data": "~2.3.5",
+        "npm-cache-filename": "~1.0.2",
+        "npm-install-checks": "~3.0.0",
+        "npm-package-arg": "~4.1.0",
+        "npm-registry-client": "~7.0.9",
+        "npm-user-validate": "~0.1.2",
+        "npmlog": "~2.0.2",
+        "once": "~1.3.3",
+        "opener": "~1.4.1",
+        "osenv": "~0.1.3",
+        "path-is-inside": "~1.0.1",
+        "read": "~1.0.7",
+        "read-cmd-shim": "~1.0.1",
+        "read-installed": "~4.0.3",
+        "read-package-json": "~2.0.3",
+        "read-package-tree": "~5.1.2",
+        "readable-stream": "~2.0.5",
+        "readdir-scoped-modules": "*",
+        "realize-package-specifier": "~3.0.1",
+        "request": "~2.69.0",
+        "retry": "~0.9.0",
+        "rimraf": "~2.5.2",
+        "semver": "~5.1.0",
+        "sha": "~2.0.1",
+        "slide": "~1.1.6",
+        "sorted-object": "~1.0.0",
+        "strip-ansi": "*",
+        "tar": "~2.2.1",
+        "text-table": "~0.2.0",
         "uid-number": "0.0.6",
-        "umask": "1.1.0",
-        "unique-filename": "1.1.0",
-        "unpipe": "1.0.0",
-        "validate-npm-package-license": "3.0.1",
-        "validate-npm-package-name": "2.2.2",
-        "which": "1.2.4",
-        "wrappy": "1.0.1",
-        "write-file-atomic": "1.1.4"
+        "umask": "~1.1.0",
+        "unique-filename": "~1.1.0",
+        "unpipe": "~1.0.0",
+        "validate-npm-package-license": "*",
+        "validate-npm-package-name": "~2.2.2",
+        "which": "~1.2.4",
+        "wrappy": "~1.0.1",
+        "write-file-atomic": "~1.1.4"
       },
       "dependencies": {
         "abbrev": {
@@ -1509,7 +1481,7 @@
           "integrity": "sha1-TYqBYg1ZWHkbW5j4AtMgd3bpVQk=",
           "dev": true,
           "requires": {
-            "dezalgo": "1.0.3"
+            "dezalgo": "^1.0.2"
           }
         },
         "chownr": {
@@ -1522,8 +1494,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.3",
-            "mkdirp": "0.5.1"
+            "graceful-fs": "^4.1.2",
+            "mkdirp": "~0.5.0"
           }
         },
         "columnify": {
@@ -1531,8 +1503,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "strip-ansi": "3.0.0",
-            "wcwidth": "1.0.0"
+            "strip-ansi": "^3.0.0",
+            "wcwidth": "^1.0.0"
           },
           "dependencies": {
             "wcwidth": {
@@ -1540,7 +1512,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "defaults": "1.0.3"
+                "defaults": "^1.0.0"
               },
               "dependencies": {
                 "defaults": {
@@ -1548,7 +1520,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "clone": "1.0.2"
+                    "clone": "^1.0.2"
                   },
                   "dependencies": {
                     "clone": {
@@ -1567,8 +1539,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ini": "1.3.4",
-            "proto-list": "1.2.4"
+            "ini": "^1.3.4",
+            "proto-list": "~1.2.1"
           },
           "dependencies": {
             "proto-list": {
@@ -1589,8 +1561,8 @@
           "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
           "dev": true,
           "requires": {
-            "asap": "2.0.3",
-            "wrappy": "1.0.1"
+            "asap": "^2.0.0",
+            "wrappy": "1"
           },
           "dependencies": {
             "asap": {
@@ -1611,9 +1583,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.3",
-            "path-is-inside": "1.0.1",
-            "rimraf": "2.5.2"
+            "graceful-fs": "^4.1.2",
+            "path-is-inside": "^1.0.1",
+            "rimraf": "^2.2.8"
           }
         },
         "fs-write-stream-atomic": {
@@ -1622,10 +1594,10 @@
           "integrity": "sha1-5Jqt3yiPh9Rv+eiC8hahOrxAd4s=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.3",
-            "iferr": "0.1.5",
-            "imurmurhash": "0.1.4",
-            "readable-stream": "2.0.5"
+            "graceful-fs": "^4.1.2",
+            "iferr": "^0.1.5",
+            "imurmurhash": "^0.1.4",
+            "readable-stream": "1 || 2"
           }
         },
         "fstream": {
@@ -1633,10 +1605,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.3",
-            "inherits": "2.0.1",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.5.2"
+            "graceful-fs": "^4.1.2",
+            "inherits": "~2.0.0",
+            "mkdirp": ">=0.5 0",
+            "rimraf": "2"
           }
         },
         "fstream-npm": {
@@ -1645,8 +1617,8 @@
           "integrity": "sha1-ftDRrBPXaG3Z4b9s64vic79tL4Y=",
           "dev": true,
           "requires": {
-            "fstream-ignore": "1.0.3",
-            "inherits": "2.0.1"
+            "fstream-ignore": "^1.0.0",
+            "inherits": "2"
           },
           "dependencies": {
             "fstream-ignore": {
@@ -1655,9 +1627,9 @@
               "integrity": "sha1-THTZH6iLIrQvT4ahiigg3XnY/N0=",
               "dev": true,
               "requires": {
-                "fstream": "1.0.8",
-                "inherits": "2.0.1",
-                "minimatch": "3.0.0"
+                "fstream": "^1.0.0",
+                "inherits": "2",
+                "minimatch": "^3.0.0"
               },
               "dependencies": {
                 "minimatch": {
@@ -1666,7 +1638,7 @@
                   "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "1.1.2"
+                    "brace-expansion": "^1.0.0"
                   },
                   "dependencies": {
                     "brace-expansion": {
@@ -1675,7 +1647,7 @@
                       "integrity": "sha1-8hRF0EiLZY4nce/YcO/1HfKfBO8=",
                       "dev": true,
                       "requires": {
-                        "balanced-match": "0.3.0",
+                        "balanced-match": "^0.3.0",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -1705,11 +1677,11 @@
           "integrity": "sha1-OyCjV//89GuzhK7W+K6aZH/basQ=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.4",
-            "inherits": "2.0.1",
-            "minimatch": "3.0.0",
-            "once": "1.3.3",
-            "path-is-absolute": "1.0.0"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           },
           "dependencies": {
             "minimatch": {
@@ -1718,7 +1690,7 @@
               "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
               "dev": true,
               "requires": {
-                "brace-expansion": "1.1.3"
+                "brace-expansion": "^1.0.0"
               },
               "dependencies": {
                 "brace-expansion": {
@@ -1727,7 +1699,7 @@
                   "integrity": "sha1-Rr/1ARXUf8mriYVKu4fZgHihCZE=",
                   "dev": true,
                   "requires": {
-                    "balanced-match": "0.3.0",
+                    "balanced-match": "^0.3.0",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -1786,8 +1758,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "once": "1.3.3",
-            "wrappy": "1.0.1"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -1806,14 +1778,14 @@
           "integrity": "sha1-yi/5Rwm22aqtZlM8EaCv9kXxXH0=",
           "dev": true,
           "requires": {
-            "glob": "6.0.4",
-            "npm-package-arg": "4.1.0",
-            "promzard": "0.3.0",
-            "read": "1.0.7",
-            "read-package-json": "2.0.3",
-            "semver": "5.1.0",
-            "validate-npm-package-license": "3.0.1",
-            "validate-npm-package-name": "2.2.2"
+            "glob": "^6.0.0",
+            "npm-package-arg": "^4.0.0",
+            "promzard": "^0.3.0",
+            "read": "~1.0.1",
+            "read-package-json": "1 || 2",
+            "semver": "2.x || 3.x || 4 || 5",
+            "validate-npm-package-license": "^3.0.1",
+            "validate-npm-package-name": "^2.0.1"
           },
           "dependencies": {
             "glob": {
@@ -1822,11 +1794,11 @@
               "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
               "dev": true,
               "requires": {
-                "inflight": "1.0.4",
-                "inherits": "2.0.1",
-                "minimatch": "3.0.0",
-                "once": "1.3.3",
-                "path-is-absolute": "1.0.0"
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               },
               "dependencies": {
                 "minimatch": {
@@ -1835,7 +1807,7 @@
                   "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "1.1.3"
+                    "brace-expansion": "^1.0.0"
                   },
                   "dependencies": {
                     "brace-expansion": {
@@ -1844,7 +1816,7 @@
                       "integrity": "sha1-Rr/1ARXUf8mriYVKu4fZgHihCZE=",
                       "dev": true,
                       "requires": {
-                        "balanced-match": "0.3.0",
+                        "balanced-match": "^0.3.0",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -1878,7 +1850,7 @@
               "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
               "dev": true,
               "requires": {
-                "read": "1.0.7"
+                "read": "1"
               }
             }
           }
@@ -1899,8 +1871,8 @@
           "integrity": "sha1-pEUpQ0ei9TEfWF/jIlZEUwubj64=",
           "dev": true,
           "requires": {
-            "lodash._root": "3.0.1",
-            "lodash._setcache": "4.1.0"
+            "lodash._root": "^3.0.0",
+            "lodash._setcache": "^4.0.0"
           },
           "dependencies": {
             "lodash._root": {
@@ -1932,7 +1904,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._getnative": "3.9.1"
+            "lodash._getnative": "^3.0.0"
           }
         },
         "lodash._getnative": {
@@ -1945,7 +1917,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._baseclone": "4.5.0"
+            "lodash._baseclone": "^4.0.0"
           },
           "dependencies": {
             "lodash._baseclone": {
@@ -1980,9 +1952,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._baseflatten": "4.1.0",
-            "lodash._baseuniq": "4.4.0",
-            "lodash.rest": "4.0.1"
+            "lodash._baseflatten": "^4.0.0",
+            "lodash._baseuniq": "^4.0.0",
+            "lodash.rest": "^4.0.0"
           },
           "dependencies": {
             "lodash._baseflatten": {
@@ -2002,7 +1974,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._baseuniq": "4.4.0"
+            "lodash._baseuniq": "^4.0.0"
           }
         },
         "lodash.without": {
@@ -2010,8 +1982,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "lodash._basedifference": "4.4.0",
-            "lodash.rest": "4.0.1"
+            "lodash._basedifference": "^4.0.0",
+            "lodash.rest": "^4.0.0"
           },
           "dependencies": {
             "lodash._basedifference": {
@@ -2019,7 +1991,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "lodash._setcache": "4.1.0"
+                "lodash._setcache": "^4.0.0"
               },
               "dependencies": {
                 "lodash._setcache": {
@@ -2056,20 +2028,20 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fstream": "1.0.8",
-            "glob": "4.5.3",
-            "graceful-fs": "4.1.3",
-            "minimatch": "1.0.0",
-            "mkdirp": "0.5.1",
-            "nopt": "3.0.6",
-            "npmlog": "2.0.2",
-            "osenv": "0.1.3",
-            "path-array": "1.0.1",
-            "request": "2.69.0",
-            "rimraf": "2.5.2",
-            "semver": "5.1.0",
-            "tar": "2.2.1",
-            "which": "1.2.4"
+            "fstream": "^1.0.0",
+            "glob": "3 || 4",
+            "graceful-fs": "^4.1.2",
+            "minimatch": "1",
+            "mkdirp": "^0.5.0",
+            "nopt": "2 || 3",
+            "npmlog": "0 || 1 || 2",
+            "osenv": "0",
+            "path-array": "^1.0.0",
+            "request": "2",
+            "rimraf": "2",
+            "semver": "2.x || 3.x || 4 || 5",
+            "tar": "^2.0.0",
+            "which": "1"
           },
           "dependencies": {
             "glob": {
@@ -2077,10 +2049,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "inflight": "1.0.4",
-                "inherits": "2.0.1",
-                "minimatch": "2.0.10",
-                "once": "1.3.3"
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^2.0.1",
+                "once": "^1.3.0"
               },
               "dependencies": {
                 "minimatch": {
@@ -2088,7 +2060,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "1.1.3"
+                    "brace-expansion": "^1.0.0"
                   },
                   "dependencies": {
                     "brace-expansion": {
@@ -2096,7 +2068,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "balanced-match": "0.3.0",
+                        "balanced-match": "^0.3.0",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -2121,8 +2093,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "lru-cache": "2.7.3",
-                "sigmund": "1.0.1"
+                "lru-cache": "2",
+                "sigmund": "~1.0.0"
               },
               "dependencies": {
                 "lru-cache": {
@@ -2142,7 +2114,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "array-index": "1.0.0"
+                "array-index": "^1.0.0"
               },
               "dependencies": {
                 "array-index": {
@@ -2150,8 +2122,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "debug": "2.2.0",
-                    "es6-symbol": "3.0.2"
+                    "debug": "^2.2.0",
+                    "es6-symbol": "^3.0.2"
                   },
                   "dependencies": {
                     "debug": {
@@ -2174,8 +2146,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "d": "0.1.1",
-                        "es5-ext": "0.10.11"
+                        "d": "~0.1.1",
+                        "es5-ext": "~0.10.10"
                       },
                       "dependencies": {
                         "d": {
@@ -2183,7 +2155,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "es5-ext": "0.10.11"
+                            "es5-ext": "~0.10.2"
                           }
                         },
                         "es5-ext": {
@@ -2191,8 +2163,8 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "es6-iterator": "2.0.0",
-                            "es6-symbol": "3.0.2"
+                            "es6-iterator": "2",
+                            "es6-symbol": "~3.0.2"
                           },
                           "dependencies": {
                             "es6-iterator": {
@@ -2200,9 +2172,9 @@
                               "bundled": true,
                               "dev": true,
                               "requires": {
-                                "d": "0.1.1",
-                                "es5-ext": "0.10.11",
-                                "es6-symbol": "3.0.2"
+                                "d": "^0.1.1",
+                                "es5-ext": "^0.10.7",
+                                "es6-symbol": "3"
                               }
                             }
                           }
@@ -2220,7 +2192,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "abbrev": "1.0.7"
+            "abbrev": "1"
           }
         },
         "normalize-git-url": {
@@ -2233,10 +2205,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.1.4",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.1.0",
-            "validate-npm-package-license": "3.0.1"
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
           },
           "dependencies": {
             "is-builtin-module": {
@@ -2244,7 +2216,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "builtin-modules": "1.1.1"
+                "builtin-modules": "^1.0.0"
               },
               "dependencies": {
                 "builtin-modules": {
@@ -2267,7 +2239,7 @@
           "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
           "dev": true,
           "requires": {
-            "semver": "5.1.0"
+            "semver": "^2.3.0 || 3.x || 4 || 5"
           }
         },
         "npm-package-arg": {
@@ -2276,8 +2248,8 @@
           "integrity": "sha1-LgFfisAHN8uX+ZfJy/BZ9Cp0Un0=",
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.1.4",
-            "semver": "5.1.0"
+            "hosted-git-info": "^2.1.4",
+            "semver": "4 || 5"
           }
         },
         "npm-registry-client": {
@@ -2286,19 +2258,19 @@
           "integrity": "sha1-G6+G7lKFxObTjUVWII3tVgSSMbs=",
           "dev": true,
           "requires": {
-            "chownr": "1.0.1",
-            "concat-stream": "1.5.1",
-            "graceful-fs": "4.1.3",
-            "mkdirp": "0.5.1",
-            "normalize-package-data": "2.3.5",
-            "npm-package-arg": "4.1.0",
-            "npmlog": "2.0.2",
-            "once": "1.3.3",
-            "request": "2.69.0",
-            "retry": "0.8.0",
-            "rimraf": "2.5.2",
-            "semver": "5.1.0",
-            "slide": "1.1.6"
+            "chownr": "^1.0.1",
+            "concat-stream": "^1.4.6",
+            "graceful-fs": "^4.1.2",
+            "mkdirp": "^0.5.0",
+            "normalize-package-data": "~1.0.1 || ^2.0.0",
+            "npm-package-arg": "^3.0.0 || ^4.0.0",
+            "npmlog": "~2.0.0",
+            "once": "^1.3.0",
+            "request": "^2.47.0",
+            "retry": "^0.8.0",
+            "rimraf": "2",
+            "semver": "2 >=2.2.1 || 3.x || 4 || 5",
+            "slide": "^1.1.3"
           },
           "dependencies": {
             "concat-stream": {
@@ -2307,9 +2279,9 @@
               "integrity": "sha1-87gKz54fSOOHXAaItBtsMWAu6hw=",
               "dev": true,
               "requires": {
-                "inherits": "2.0.1",
-                "readable-stream": "2.0.5",
-                "typedarray": "0.0.6"
+                "inherits": "~2.0.1",
+                "readable-stream": "~2.0.0",
+                "typedarray": "~0.0.5"
               },
               "dependencies": {
                 "typedarray": {
@@ -2339,9 +2311,9 @@
           "integrity": "sha1-0EcCOLlpe3w8TRa96mWgCxKkZKs=",
           "dev": true,
           "requires": {
-            "ansi": "0.3.1",
-            "are-we-there-yet": "1.0.6",
-            "gauge": "1.2.7"
+            "ansi": "~0.3.1",
+            "are-we-there-yet": "~1.0.6",
+            "gauge": "~1.2.5"
           },
           "dependencies": {
             "ansi": {
@@ -2356,8 +2328,8 @@
               "integrity": "sha1-otKMkxAqpsyWJFomy5VN4G7FPww=",
               "dev": true,
               "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.0.5"
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.0 || ^1.1.13"
               },
               "dependencies": {
                 "delegates": {
@@ -2374,11 +2346,11 @@
               "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
               "dev": true,
               "requires": {
-                "ansi": "0.3.1",
-                "has-unicode": "2.0.0",
-                "lodash.pad": "4.1.0",
-                "lodash.padend": "4.2.0",
-                "lodash.padstart": "4.2.0"
+                "ansi": "^0.3.0",
+                "has-unicode": "^2.0.0",
+                "lodash.pad": "^4.1.0",
+                "lodash.padend": "^4.1.0",
+                "lodash.padstart": "^4.1.0"
               },
               "dependencies": {
                 "lodash.pad": {
@@ -2387,8 +2359,8 @@
                   "integrity": "sha1-2746loH8y2mXBHOiJj9QwZasOqk=",
                   "dev": true,
                   "requires": {
-                    "lodash.repeat": "4.0.0",
-                    "lodash.tostring": "4.1.1"
+                    "lodash.repeat": "^4.0.0",
+                    "lodash.tostring": "^4.0.0"
                   }
                 },
                 "lodash.padend": {
@@ -2397,8 +2369,8 @@
                   "integrity": "sha1-uE6MNAHUU4BVxuMhpR467hmIGhg=",
                   "dev": true,
                   "requires": {
-                    "lodash.repeat": "4.0.0",
-                    "lodash.tostring": "4.1.1"
+                    "lodash.repeat": "^4.0.0",
+                    "lodash.tostring": "^4.0.0"
                   }
                 },
                 "lodash.padstart": {
@@ -2407,8 +2379,8 @@
                   "integrity": "sha1-42+J/Ww7UHIhkIdpW3Zd6D7JaYU=",
                   "dev": true,
                   "requires": {
-                    "lodash.repeat": "4.0.0",
-                    "lodash.tostring": "4.1.1"
+                    "lodash.repeat": "^4.0.0",
+                    "lodash.tostring": "^4.0.0"
                   }
                 },
                 "lodash.repeat": {
@@ -2417,7 +2389,7 @@
                   "integrity": "sha1-qvVwsqsL+w3abW6TKR1UswsffSI=",
                   "dev": true,
                   "requires": {
-                    "lodash.tostring": "4.1.1"
+                    "lodash.tostring": "^4.0.0"
                   }
                 },
                 "lodash.tostring": {
@@ -2435,7 +2407,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1.0.1"
+            "wrappy": "1"
           }
         },
         "opener": {
@@ -2448,8 +2420,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "os-homedir": "1.0.1",
-            "os-tmpdir": "1.0.1"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           },
           "dependencies": {
             "os-homedir": {
@@ -2474,7 +2446,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mute-stream": "0.0.5"
+            "mute-stream": "~0.0.4"
           },
           "dependencies": {
             "mute-stream": {
@@ -2489,7 +2461,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.3"
+            "graceful-fs": "^4.1.2"
           }
         },
         "read-installed": {
@@ -2497,13 +2469,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "debuglog": "1.0.1",
-            "graceful-fs": "4.1.3",
-            "read-package-json": "2.0.3",
-            "readdir-scoped-modules": "1.0.2",
-            "semver": "5.1.0",
-            "slide": "1.1.6",
-            "util-extend": "1.0.3"
+            "debuglog": "^1.0.1",
+            "graceful-fs": "^4.1.2",
+            "read-package-json": "^2.0.0",
+            "readdir-scoped-modules": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "slide": "~1.1.3",
+            "util-extend": "^1.0.1"
           },
           "dependencies": {
             "util-extend": {
@@ -2519,10 +2491,10 @@
           "integrity": "sha1-+M7BYnBTtU84SzUyJFReYHVUxdI=",
           "dev": true,
           "requires": {
-            "glob": "6.0.4",
-            "graceful-fs": "4.1.3",
-            "json-parse-helpfulerror": "1.0.3",
-            "normalize-package-data": "2.3.5"
+            "glob": "^6.0.0",
+            "graceful-fs": "^4.1.2",
+            "json-parse-helpfulerror": "^1.0.2",
+            "normalize-package-data": "^2.0.0"
           },
           "dependencies": {
             "glob": {
@@ -2531,11 +2503,11 @@
               "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
               "dev": true,
               "requires": {
-                "inflight": "1.0.4",
-                "inherits": "2.0.1",
-                "minimatch": "3.0.0",
-                "once": "1.3.3",
-                "path-is-absolute": "1.0.0"
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               },
               "dependencies": {
                 "minimatch": {
@@ -2544,7 +2516,7 @@
                   "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
                   "dev": true,
                   "requires": {
-                    "brace-expansion": "1.1.3"
+                    "brace-expansion": "^1.0.0"
                   },
                   "dependencies": {
                     "brace-expansion": {
@@ -2553,7 +2525,7 @@
                       "integrity": "sha1-Rr/1ARXUf8mriYVKu4fZgHihCZE=",
                       "dev": true,
                       "requires": {
-                        "balanced-match": "0.3.0",
+                        "balanced-match": "^0.3.0",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -2587,7 +2559,7 @@
               "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
               "dev": true,
               "requires": {
-                "jju": "1.2.1"
+                "jju": "^1.1.0"
               },
               "dependencies": {
                 "jju": {
@@ -2605,11 +2577,11 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "debuglog": "1.0.1",
-            "dezalgo": "1.0.3",
-            "once": "1.3.3",
-            "read-package-json": "2.0.3",
-            "readdir-scoped-modules": "1.0.2"
+            "debuglog": "^1.0.1",
+            "dezalgo": "^1.0.0",
+            "once": "^1.3.0",
+            "read-package-json": "^2.0.0",
+            "readdir-scoped-modules": "^1.0.0"
           }
         },
         "readable-stream": {
@@ -2617,12 +2589,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.1",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "process-nextick-args": "1.0.6",
-            "string_decoder": "0.10.31",
-            "util-deprecate": "1.0.2"
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
           },
           "dependencies": {
             "core-util-is": {
@@ -2660,10 +2632,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "debuglog": "1.0.1",
-            "dezalgo": "1.0.3",
-            "graceful-fs": "4.1.3",
-            "once": "1.3.3"
+            "debuglog": "^1.0.1",
+            "dezalgo": "^1.0.0",
+            "graceful-fs": "^4.1.2",
+            "once": "^1.3.0"
           }
         },
         "realize-package-specifier": {
@@ -2672,8 +2644,8 @@
           "integrity": "sha1-/eMukmRI44+ZM02Vt7CNUeOpjZ8=",
           "dev": true,
           "requires": {
-            "dezalgo": "1.0.3",
-            "npm-package-arg": "4.1.0"
+            "dezalgo": "^1.0.1",
+            "npm-package-arg": "^4.0.0"
           }
         },
         "request": {
@@ -2681,27 +2653,27 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.2.1",
-            "bl": "1.0.1",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.0",
-            "forever-agent": "0.6.1",
-            "form-data": "1.0.0-rc3",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.9",
-            "node-uuid": "1.4.7",
-            "oauth-sign": "0.8.0",
-            "qs": "6.0.2",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.2.1",
-            "tunnel-agent": "0.4.2"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "bl": "~1.0.0",
+            "caseless": "~0.11.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~1.0.0-rc3",
+            "har-validator": "~2.0.6",
+            "hawk": "~3.1.0",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "node-uuid": "~1.4.7",
+            "oauth-sign": "~0.8.0",
+            "qs": "~6.0.2",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.2.0",
+            "tunnel-agent": "~0.4.1"
           },
           "dependencies": {
             "aws-sign2": {
@@ -2714,7 +2686,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "lru-cache": "2.7.3"
+                "lru-cache": "^2.6.5"
               },
               "dependencies": {
                 "lru-cache": {
@@ -2729,7 +2701,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "readable-stream": "2.0.5"
+                "readable-stream": "~2.0.5"
               }
             },
             "caseless": {
@@ -2742,7 +2714,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
               },
               "dependencies": {
                 "delayed-stream": {
@@ -2767,9 +2739,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "async": "1.5.2",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.9"
+                "async": "^1.4.0",
+                "combined-stream": "^1.0.5",
+                "mime-types": "^2.1.3"
               },
               "dependencies": {
                 "async": {
@@ -2784,10 +2756,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "chalk": "1.1.1",
-                "commander": "2.9.0",
-                "is-my-json-valid": "2.12.4",
-                "pinkie-promise": "2.0.0"
+                "chalk": "^1.1.1",
+                "commander": "^2.9.0",
+                "is-my-json-valid": "^2.12.4",
+                "pinkie-promise": "^2.0.0"
               },
               "dependencies": {
                 "chalk": {
@@ -2795,11 +2767,11 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "ansi-styles": "2.1.0",
-                    "escape-string-regexp": "1.0.4",
-                    "has-ansi": "2.0.0",
-                    "strip-ansi": "3.0.0",
-                    "supports-color": "2.0.0"
+                    "ansi-styles": "^2.1.0",
+                    "escape-string-regexp": "^1.0.2",
+                    "has-ansi": "^2.0.0",
+                    "strip-ansi": "^3.0.0",
+                    "supports-color": "^2.0.0"
                   },
                   "dependencies": {
                     "ansi-styles": {
@@ -2817,7 +2789,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "ansi-regex": "2.0.0"
+                        "ansi-regex": "^2.0.0"
                       }
                     },
                     "supports-color": {
@@ -2832,7 +2804,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "graceful-readlink": "1.0.1"
+                    "graceful-readlink": ">= 1.0.0"
                   },
                   "dependencies": {
                     "graceful-readlink": {
@@ -2847,10 +2819,10 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "generate-function": "2.0.0",
-                    "generate-object-property": "1.2.0",
+                    "generate-function": "^2.0.0",
+                    "generate-object-property": "^1.1.0",
                     "jsonpointer": "2.0.0",
-                    "xtend": "4.0.1"
+                    "xtend": "^4.0.0"
                   },
                   "dependencies": {
                     "generate-function": {
@@ -2863,7 +2835,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "is-property": "1.0.2"
+                        "is-property": "^1.0.0"
                       },
                       "dependencies": {
                         "is-property": {
@@ -2890,7 +2862,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "pinkie": "2.0.1"
+                    "pinkie": "^2.0.0"
                   },
                   "dependencies": {
                     "pinkie": {
@@ -2907,10 +2879,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
+                "boom": "2.x.x",
+                "cryptiles": "2.x.x",
+                "hoek": "2.x.x",
+                "sntp": "1.x.x"
               },
               "dependencies": {
                 "boom": {
@@ -2918,7 +2890,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "hoek": "2.16.3"
+                    "hoek": "2.x.x"
                   }
                 },
                 "cryptiles": {
@@ -2926,7 +2898,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "boom": "2.10.1"
+                    "boom": "2.x.x"
                   }
                 },
                 "hoek": {
@@ -2939,7 +2911,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "hoek": "2.16.3"
+                    "hoek": "2.x.x"
                   }
                 }
               }
@@ -2949,9 +2921,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.2.2",
-                "sshpk": "1.7.3"
+                "assert-plus": "^0.2.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
               },
               "dependencies": {
                 "assert-plus": {
@@ -2994,13 +2966,13 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "asn1": "0.2.3",
-                    "assert-plus": "0.2.0",
-                    "dashdash": "1.12.2",
-                    "ecc-jsbn": "0.1.1",
-                    "jodid25519": "1.0.2",
-                    "jsbn": "0.1.0",
-                    "tweetnacl": "0.13.3"
+                    "asn1": ">=0.2.3 <0.3.0",
+                    "assert-plus": ">=0.2.0 <0.3.0",
+                    "dashdash": ">=1.10.1 <2.0.0",
+                    "ecc-jsbn": ">=0.0.1 <1.0.0",
+                    "jodid25519": ">=1.0.0 <2.0.0",
+                    "jsbn": ">=0.1.0 <0.2.0",
+                    "tweetnacl": ">=0.13.0 <1.0.0"
                   },
                   "dependencies": {
                     "asn1": {
@@ -3013,7 +2985,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "assert-plus": "0.2.0"
+                        "assert-plus": "^0.2.0"
                       }
                     },
                     "ecc-jsbn": {
@@ -3022,7 +2994,7 @@
                       "dev": true,
                       "optional": true,
                       "requires": {
-                        "jsbn": "0.1.0"
+                        "jsbn": "~0.1.0"
                       }
                     },
                     "jodid25519": {
@@ -3031,7 +3003,7 @@
                       "dev": true,
                       "optional": true,
                       "requires": {
-                        "jsbn": "0.1.0"
+                        "jsbn": "~0.1.0"
                       }
                     },
                     "jsbn": {
@@ -3070,7 +3042,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "mime-db": "1.21.0"
+                "mime-db": "~1.21.0"
               },
               "dependencies": {
                 "mime-db": {
@@ -3124,7 +3096,7 @@
           "integrity": "sha1-YrqUf6TAtDY4Oa7+zU8PutYFlyY=",
           "dev": true,
           "requires": {
-            "glob": "7.0.0"
+            "glob": "^7.0.0"
           }
         },
         "semver": {
@@ -3137,8 +3109,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.3",
-            "readable-stream": "2.0.5"
+            "graceful-fs": "^4.1.2",
+            "readable-stream": "^2.0.2"
           }
         },
         "slide": {
@@ -3156,7 +3128,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.0.0"
+            "ansi-regex": "^2.0.0"
           }
         },
         "tar": {
@@ -3164,9 +3136,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "block-stream": "0.0.8",
-            "fstream": "1.0.8",
-            "inherits": "2.0.1"
+            "block-stream": "*",
+            "fstream": "^1.0.2",
+            "inherits": "2"
           },
           "dependencies": {
             "block-stream": {
@@ -3174,7 +3146,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "inherits": "2.0.1"
+                "inherits": "~2.0.0"
               }
             }
           }
@@ -3199,7 +3171,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "unique-slug": "2.0.0"
+            "unique-slug": "^2.0.0"
           },
           "dependencies": {
             "unique-slug": {
@@ -3208,7 +3180,7 @@
               "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
               "dev": true,
               "requires": {
-                "imurmurhash": "0.1.4"
+                "imurmurhash": "^0.1.4"
               }
             }
           }
@@ -3223,8 +3195,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "spdx-correct": "1.0.2",
-            "spdx-expression-parse": "1.0.2"
+            "spdx-correct": "~1.0.0",
+            "spdx-expression-parse": "~1.0.0"
           },
           "dependencies": {
             "spdx-correct": {
@@ -3232,7 +3204,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "spdx-license-ids": "1.2.0"
+                "spdx-license-ids": "^1.0.2"
               },
               "dependencies": {
                 "spdx-license-ids": {
@@ -3247,8 +3219,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "spdx-exceptions": "1.0.4",
-                "spdx-license-ids": "1.2.0"
+                "spdx-exceptions": "^1.0.4",
+                "spdx-license-ids": "^1.0.0"
               },
               "dependencies": {
                 "spdx-exceptions": {
@@ -3286,8 +3258,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-absolute": "0.1.7",
-            "isexe": "1.1.1"
+            "is-absolute": "^0.1.7",
+            "isexe": "^1.1.1"
           },
           "dependencies": {
             "is-absolute": {
@@ -3295,7 +3267,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "is-relative": "0.1.3"
+                "is-relative": "^0.1.0"
               },
               "dependencies": {
                 "is-relative": {
@@ -3323,9 +3295,9 @@
           "integrity": "sha1-sfUtwujcDjywTRh6JfdYo4qQyjs=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.3",
-            "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
+            "graceful-fs": "^4.1.2",
+            "imurmurhash": "^0.1.4",
+            "slide": "^1.1.5"
           }
         }
       }
@@ -3336,7 +3308,7 @@
       "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
       "dev": true,
       "requires": {
-        "path-key": "1.0.0"
+        "path-key": "^1.0.0"
       }
     },
     "npmi": {
@@ -3345,8 +3317,8 @@
       "integrity": "sha1-FddpJzVHVF5oCdzwzhiu1IsCkOI=",
       "dev": true,
       "requires": {
-        "npm": "2.15.12",
-        "semver": "4.3.6"
+        "npm": "^2.1.12",
+        "semver": "^4.1.0"
       },
       "dependencies": {
         "npm": {
@@ -3355,77 +3327,77 @@
           "integrity": "sha1-33w+1aJ3w/nUtdgZsFMR0QogCuY=",
           "dev": true,
           "requires": {
-            "abbrev": "1.0.9",
-            "ansi": "0.3.1",
-            "ansi-regex": "2.0.0",
-            "ansicolors": "0.3.2",
-            "ansistyles": "0.1.3",
-            "archy": "1.0.0",
-            "async-some": "1.0.2",
+            "abbrev": "~1.0.9",
+            "ansi": "~0.3.1",
+            "ansi-regex": "*",
+            "ansicolors": "~0.3.2",
+            "ansistyles": "~0.1.3",
+            "archy": "~1.0.0",
+            "async-some": "~1.0.2",
             "block-stream": "0.0.9",
-            "char-spinner": "1.0.1",
-            "chmodr": "1.0.2",
-            "chownr": "1.0.1",
-            "cmd-shim": "2.0.2",
-            "columnify": "1.5.4",
-            "config-chain": "1.1.10",
-            "dezalgo": "1.0.3",
-            "editor": "1.0.0",
-            "fs-vacuum": "1.2.9",
-            "fs-write-stream-atomic": "1.0.8",
-            "fstream": "1.0.10",
-            "fstream-npm": "1.1.1",
-            "github-url-from-git": "1.4.0",
-            "github-url-from-username-repo": "1.0.2",
-            "glob": "7.0.6",
-            "graceful-fs": "4.1.6",
-            "hosted-git-info": "2.1.5",
-            "imurmurhash": "0.1.4",
-            "inflight": "1.0.5",
-            "inherits": "2.0.3",
-            "ini": "1.3.4",
-            "init-package-json": "1.9.4",
-            "lockfile": "1.0.1",
-            "lru-cache": "4.0.1",
-            "minimatch": "3.0.3",
-            "mkdirp": "0.5.1",
-            "node-gyp": "3.6.0",
-            "nopt": "3.0.6",
-            "normalize-git-url": "3.0.2",
-            "normalize-package-data": "2.3.5",
-            "npm-cache-filename": "1.0.2",
-            "npm-install-checks": "1.0.7",
-            "npm-package-arg": "4.1.0",
-            "npm-registry-client": "7.2.1",
-            "npm-user-validate": "0.1.5",
-            "npmlog": "2.0.4",
-            "once": "1.4.0",
-            "opener": "1.4.1",
-            "osenv": "0.1.3",
-            "path-is-inside": "1.0.1",
-            "read": "1.0.7",
-            "read-installed": "4.0.3",
-            "read-package-json": "2.0.4",
-            "readable-stream": "2.1.5",
-            "realize-package-specifier": "3.0.1",
-            "request": "2.74.0",
-            "retry": "0.10.0",
-            "rimraf": "2.5.4",
-            "semver": "5.1.0",
-            "sha": "2.0.1",
-            "slide": "1.1.6",
-            "sorted-object": "2.0.0",
-            "spdx-license-ids": "1.2.2",
-            "strip-ansi": "3.0.1",
-            "tar": "2.2.1",
-            "text-table": "0.2.0",
+            "char-spinner": "~1.0.1",
+            "chmodr": "~1.0.2",
+            "chownr": "~1.0.1",
+            "cmd-shim": "~2.0.2",
+            "columnify": "~1.5.4",
+            "config-chain": "~1.1.10",
+            "dezalgo": "~1.0.3",
+            "editor": "~1.0.0",
+            "fs-vacuum": "~1.2.9",
+            "fs-write-stream-atomic": "~1.0.8",
+            "fstream": "~1.0.10",
+            "fstream-npm": "~1.1.1",
+            "github-url-from-git": "~1.4.0",
+            "github-url-from-username-repo": "~1.0.2",
+            "glob": "~7.0.6",
+            "graceful-fs": "~4.1.6",
+            "hosted-git-info": "~2.1.5",
+            "imurmurhash": "*",
+            "inflight": "~1.0.4",
+            "inherits": "~2.0.3",
+            "ini": "~1.3.4",
+            "init-package-json": "~1.9.4",
+            "lockfile": "~1.0.1",
+            "lru-cache": "~4.0.1",
+            "minimatch": "~3.0.3",
+            "mkdirp": "~0.5.1",
+            "node-gyp": "~3.6.0",
+            "nopt": "~3.0.6",
+            "normalize-git-url": "~3.0.2",
+            "normalize-package-data": "~2.3.5",
+            "npm-cache-filename": "~1.0.2",
+            "npm-install-checks": "~1.0.7",
+            "npm-package-arg": "~4.1.0",
+            "npm-registry-client": "~7.2.1",
+            "npm-user-validate": "~0.1.5",
+            "npmlog": "~2.0.4",
+            "once": "~1.4.0",
+            "opener": "~1.4.1",
+            "osenv": "~0.1.3",
+            "path-is-inside": "~1.0.0",
+            "read": "~1.0.7",
+            "read-installed": "~4.0.3",
+            "read-package-json": "~2.0.4",
+            "readable-stream": "~2.1.5",
+            "realize-package-specifier": "~3.0.1",
+            "request": "~2.74.0",
+            "retry": "~0.10.0",
+            "rimraf": "~2.5.4",
+            "semver": "~5.1.0",
+            "sha": "~2.0.1",
+            "slide": "~1.1.6",
+            "sorted-object": "~2.0.0",
+            "spdx-license-ids": "~1.2.2",
+            "strip-ansi": "~3.0.1",
+            "tar": "~2.2.1",
+            "text-table": "~0.2.0",
             "uid-number": "0.0.6",
-            "umask": "1.1.0",
-            "validate-npm-package-license": "3.0.1",
-            "validate-npm-package-name": "2.2.2",
-            "which": "1.2.11",
-            "wrappy": "1.0.2",
-            "write-file-atomic": "1.1.4"
+            "umask": "~1.1.0",
+            "validate-npm-package-license": "~3.0.1",
+            "validate-npm-package-name": "~2.2.2",
+            "which": "~1.2.11",
+            "wrappy": "~1.0.2",
+            "write-file-atomic": "~1.1.4"
           },
           "dependencies": {
             "abbrev": {
@@ -3466,7 +3438,7 @@
               "integrity": "sha1-TYqBYg1ZWHkbW5j4AtMgd3bpVQk=",
               "dev": true,
               "requires": {
-                "dezalgo": "1.0.3"
+                "dezalgo": "^1.0.2"
               }
             },
             "block-stream": {
@@ -3474,7 +3446,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
               }
             },
             "char-spinner": {
@@ -3497,8 +3469,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.6",
-                "mkdirp": "0.5.1"
+                "graceful-fs": "^4.1.2",
+                "mkdirp": "~0.5.0"
               }
             },
             "columnify": {
@@ -3506,8 +3478,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "strip-ansi": "3.0.1",
-                "wcwidth": "1.0.0"
+                "strip-ansi": "^3.0.0",
+                "wcwidth": "^1.0.0"
               },
               "dependencies": {
                 "wcwidth": {
@@ -3515,7 +3487,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "defaults": "1.0.3"
+                    "defaults": "^1.0.0"
                   },
                   "dependencies": {
                     "defaults": {
@@ -3523,7 +3495,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "clone": "1.0.2"
+                        "clone": "^1.0.2"
                       },
                       "dependencies": {
                         "clone": {
@@ -3542,8 +3514,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ini": "1.3.4",
-                "proto-list": "1.2.4"
+                "ini": "^1.3.4",
+                "proto-list": "~1.2.1"
               },
               "dependencies": {
                 "proto-list": {
@@ -3559,8 +3531,8 @@
               "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
               "dev": true,
               "requires": {
-                "asap": "2.0.3",
-                "wrappy": "1.0.2"
+                "asap": "^2.0.0",
+                "wrappy": "1"
               },
               "dependencies": {
                 "asap": {
@@ -3581,9 +3553,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.6",
-                "path-is-inside": "1.0.1",
-                "rimraf": "2.5.4"
+                "graceful-fs": "^4.1.2",
+                "path-is-inside": "^1.0.1",
+                "rimraf": "^2.5.2"
               }
             },
             "fs-write-stream-atomic": {
@@ -3591,10 +3563,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.6",
-                "iferr": "0.1.5",
-                "imurmurhash": "0.1.4",
-                "readable-stream": "2.1.5"
+                "graceful-fs": "^4.1.2",
+                "iferr": "^0.1.5",
+                "imurmurhash": "^0.1.4",
+                "readable-stream": "1 || 2"
               },
               "dependencies": {
                 "iferr": {
@@ -3610,10 +3582,10 @@
               "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.6",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.5.4"
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
               }
             },
             "fstream-npm": {
@@ -3621,8 +3593,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "fstream-ignore": "1.0.5",
-                "inherits": "2.0.3"
+                "fstream-ignore": "^1.0.0",
+                "inherits": "2"
               },
               "dependencies": {
                 "fstream-ignore": {
@@ -3630,9 +3602,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "fstream": "1.0.10",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3"
+                    "fstream": "^1.0.0",
+                    "inherits": "2",
+                    "minimatch": "^3.0.0"
                   }
                 }
               }
@@ -3653,12 +3625,12 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.5",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.3",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.0"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.2",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               },
               "dependencies": {
                 "fs.realpath": {
@@ -3693,8 +3665,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
               }
             },
             "inherits": {
@@ -3712,14 +3684,14 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "glob": "6.0.4",
-                "npm-package-arg": "4.1.0",
-                "promzard": "0.3.0",
-                "read": "1.0.7",
-                "read-package-json": "2.0.4",
-                "semver": "5.1.0",
-                "validate-npm-package-license": "3.0.1",
-                "validate-npm-package-name": "2.2.2"
+                "glob": "^6.0.0",
+                "npm-package-arg": "^4.0.0",
+                "promzard": "^0.3.0",
+                "read": "~1.0.1",
+                "read-package-json": "1 || 2",
+                "semver": "2.x || 3.x || 4 || 5",
+                "validate-npm-package-license": "^3.0.1",
+                "validate-npm-package-name": "^2.0.1"
               },
               "dependencies": {
                 "glob": {
@@ -3727,11 +3699,11 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "inflight": "1.0.5",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.0"
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "2 || 3",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "path-is-absolute": {
@@ -3746,7 +3718,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "read": "1.0.7"
+                    "read": "1"
                   }
                 }
               }
@@ -3761,8 +3733,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.0.0"
+                "pseudomap": "^1.0.1",
+                "yallist": "^2.0.0"
               },
               "dependencies": {
                 "pseudomap": {
@@ -3782,7 +3754,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "brace-expansion": "1.1.6"
+                "brace-expansion": "^1.0.0"
               },
               "dependencies": {
                 "brace-expansion": {
@@ -3790,7 +3762,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "balanced-match": "0.4.2",
+                    "balanced-match": "^0.4.1",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -3828,19 +3800,19 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "fstream": "1.0.10",
-                "glob": "7.0.6",
-                "graceful-fs": "4.1.6",
-                "minimatch": "3.0.3",
-                "mkdirp": "0.5.1",
-                "nopt": "3.0.6",
-                "npmlog": "2.0.4",
-                "osenv": "0.1.3",
-                "request": "2.74.0",
-                "rimraf": "2.5.4",
-                "semver": "5.3.0",
-                "tar": "2.2.1",
-                "which": "1.2.11"
+                "fstream": "^1.0.0",
+                "glob": "^7.0.3",
+                "graceful-fs": "^4.1.2",
+                "minimatch": "^3.0.2",
+                "mkdirp": "^0.5.0",
+                "nopt": "2 || 3",
+                "npmlog": "0 || 1 || 2 || 3 || 4",
+                "osenv": "0",
+                "request": "2",
+                "rimraf": "2",
+                "semver": "~5.3.0",
+                "tar": "^2.0.0",
+                "which": "1"
               },
               "dependencies": {
                 "semver": {
@@ -3856,7 +3828,7 @@
               "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
               "dev": true,
               "requires": {
-                "abbrev": "1.0.9"
+                "abbrev": "1"
               }
             },
             "normalize-git-url": {
@@ -3869,10 +3841,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "hosted-git-info": "2.1.5",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.1.0",
-                "validate-npm-package-license": "3.0.1"
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
               },
               "dependencies": {
                 "is-builtin-module": {
@@ -3880,7 +3852,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "builtin-modules": "1.1.0"
+                    "builtin-modules": "^1.0.0"
                   },
                   "dependencies": {
                     "builtin-modules": {
@@ -3902,8 +3874,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "npmlog": "2.0.4",
-                "semver": "5.1.0"
+                "npmlog": "0.1 || 1 || 2",
+                "semver": "^2.3.0 || 3.x || 4 || 5"
               }
             },
             "npm-package-arg": {
@@ -3911,8 +3883,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "hosted-git-info": "2.1.5",
-                "semver": "5.1.0"
+                "hosted-git-info": "^2.1.4",
+                "semver": "4 || 5"
               }
             },
             "npm-registry-client": {
@@ -3920,16 +3892,16 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "concat-stream": "1.5.2",
-                "graceful-fs": "4.1.6",
-                "normalize-package-data": "2.3.5",
-                "npm-package-arg": "4.1.0",
-                "npmlog": "2.0.4",
-                "once": "1.4.0",
-                "request": "2.74.0",
-                "retry": "0.10.0",
-                "semver": "5.1.0",
-                "slide": "1.1.6"
+                "concat-stream": "^1.5.2",
+                "graceful-fs": "^4.1.6",
+                "normalize-package-data": "~1.0.1 || ^2.0.0",
+                "npm-package-arg": "^3.0.0 || ^4.0.0",
+                "npmlog": "~2.0.0 || ~3.1.0",
+                "once": "^1.3.3",
+                "request": "^2.74.0",
+                "retry": "^0.10.0",
+                "semver": "2 >=2.2.1 || 3.x || 4 || 5",
+                "slide": "^1.1.3"
               },
               "dependencies": {
                 "concat-stream": {
@@ -3937,9 +3909,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.0.6",
-                    "typedarray": "0.0.6"
+                    "inherits": "~2.0.1",
+                    "readable-stream": "~2.0.0",
+                    "typedarray": "~0.0.5"
                   },
                   "dependencies": {
                     "readable-stream": {
@@ -3947,12 +3919,12 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "string_decoder": "0.10.31",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "string_decoder": "~0.10.x",
+                        "util-deprecate": "~1.0.1"
                       },
                       "dependencies": {
                         "core-util-is": {
@@ -4006,9 +3978,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi": "0.3.1",
-                "are-we-there-yet": "1.1.2",
-                "gauge": "1.2.7"
+                "ansi": "~0.3.1",
+                "are-we-there-yet": "~1.1.2",
+                "gauge": "~1.2.5"
               },
               "dependencies": {
                 "are-we-there-yet": {
@@ -4016,8 +3988,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "delegates": "1.0.0",
-                    "readable-stream": "2.1.5"
+                    "delegates": "^1.0.0",
+                    "readable-stream": "^2.0.0 || ^1.1.13"
                   },
                   "dependencies": {
                     "delegates": {
@@ -4032,11 +4004,11 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "ansi": "0.3.1",
-                    "has-unicode": "2.0.0",
-                    "lodash.pad": "4.4.0",
-                    "lodash.padend": "4.5.0",
-                    "lodash.padstart": "4.5.0"
+                    "ansi": "^0.3.0",
+                    "has-unicode": "^2.0.0",
+                    "lodash.pad": "^4.1.0",
+                    "lodash.padend": "^4.1.0",
+                    "lodash.padstart": "^4.1.0"
                   },
                   "dependencies": {
                     "has-unicode": {
@@ -4059,9 +4031,9 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "lodash._baseslice": "4.0.0",
-                        "lodash._basetostring": "4.12.0",
-                        "lodash.tostring": "4.1.4"
+                        "lodash._baseslice": "~4.0.0",
+                        "lodash._basetostring": "~4.12.0",
+                        "lodash.tostring": "^4.0.0"
                       }
                     },
                     "lodash.padend": {
@@ -4069,9 +4041,9 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "lodash._baseslice": "4.0.0",
-                        "lodash._basetostring": "4.12.0",
-                        "lodash.tostring": "4.1.4"
+                        "lodash._baseslice": "~4.0.0",
+                        "lodash._basetostring": "~4.12.0",
+                        "lodash.tostring": "^4.0.0"
                       }
                     },
                     "lodash.padstart": {
@@ -4079,9 +4051,9 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "lodash._baseslice": "4.0.0",
-                        "lodash._basetostring": "4.12.0",
-                        "lodash.tostring": "4.1.4"
+                        "lodash._baseslice": "~4.0.0",
+                        "lodash._basetostring": "~4.12.0",
+                        "lodash.tostring": "^4.0.0"
                       }
                     },
                     "lodash.tostring": {
@@ -4098,7 +4070,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
               }
             },
             "opener": {
@@ -4111,8 +4083,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "os-homedir": "1.0.0",
-                "os-tmpdir": "1.0.1"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
               },
               "dependencies": {
                 "os-homedir": {
@@ -4138,7 +4110,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "mute-stream": "0.0.5"
+                "mute-stream": "~0.0.4"
               },
               "dependencies": {
                 "mute-stream": {
@@ -4154,13 +4126,13 @@
               "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
               "dev": true,
               "requires": {
-                "debuglog": "1.0.1",
-                "graceful-fs": "4.1.6",
-                "read-package-json": "2.0.4",
-                "readdir-scoped-modules": "1.0.2",
-                "semver": "5.1.0",
-                "slide": "1.1.6",
-                "util-extend": "1.0.1"
+                "debuglog": "^1.0.1",
+                "graceful-fs": "^4.1.2",
+                "read-package-json": "^2.0.0",
+                "readdir-scoped-modules": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "slide": "~1.1.3",
+                "util-extend": "^1.0.1"
               },
               "dependencies": {
                 "debuglog": {
@@ -4175,10 +4147,10 @@
                   "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
                   "dev": true,
                   "requires": {
-                    "debuglog": "1.0.1",
-                    "dezalgo": "1.0.3",
-                    "graceful-fs": "4.1.6",
-                    "once": "1.4.0"
+                    "debuglog": "^1.0.1",
+                    "dezalgo": "^1.0.0",
+                    "graceful-fs": "^4.1.2",
+                    "once": "^1.3.0"
                   }
                 },
                 "util-extend": {
@@ -4194,10 +4166,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "glob": "6.0.4",
-                "graceful-fs": "4.1.6",
-                "json-parse-helpfulerror": "1.0.3",
-                "normalize-package-data": "2.3.5"
+                "glob": "^6.0.0",
+                "graceful-fs": "^4.1.2",
+                "json-parse-helpfulerror": "^1.0.2",
+                "normalize-package-data": "^2.0.0"
               },
               "dependencies": {
                 "glob": {
@@ -4205,11 +4177,11 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "inflight": "1.0.5",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.3",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.0"
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "2 || 3",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   },
                   "dependencies": {
                     "path-is-absolute": {
@@ -4224,7 +4196,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "jju": "1.3.0"
+                    "jju": "^1.1.0"
                   },
                   "dependencies": {
                     "jju": {
@@ -4241,13 +4213,13 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "buffer-shims": "1.0.0",
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "string_decoder": "0.10.31",
-                "util-deprecate": "1.0.2"
+                "buffer-shims": "^1.0.0",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "string_decoder": "~0.10.x",
+                "util-deprecate": "~1.0.1"
               },
               "dependencies": {
                 "buffer-shims": {
@@ -4287,8 +4259,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "dezalgo": "1.0.3",
-                "npm-package-arg": "4.1.0"
+                "dezalgo": "^1.0.1",
+                "npm-package-arg": "^4.0.0"
               }
             },
             "request": {
@@ -4296,27 +4268,27 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "aws-sign2": "0.6.0",
-                "aws4": "1.4.1",
-                "bl": "1.1.2",
-                "caseless": "0.11.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.0",
-                "forever-agent": "0.6.1",
-                "form-data": "1.0.0-rc4",
-                "har-validator": "2.0.6",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.11",
-                "node-uuid": "1.4.7",
-                "oauth-sign": "0.8.2",
-                "qs": "6.2.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.1",
-                "tunnel-agent": "0.4.3"
+                "aws-sign2": "~0.6.0",
+                "aws4": "^1.2.1",
+                "bl": "~1.1.2",
+                "caseless": "~0.11.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.0",
+                "forever-agent": "~0.6.1",
+                "form-data": "~1.0.0-rc4",
+                "har-validator": "~2.0.6",
+                "hawk": "~3.1.3",
+                "http-signature": "~1.1.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.7",
+                "node-uuid": "~1.4.7",
+                "oauth-sign": "~0.8.1",
+                "qs": "~6.2.0",
+                "stringstream": "~0.0.4",
+                "tough-cookie": "~2.3.0",
+                "tunnel-agent": "~0.4.1"
               },
               "dependencies": {
                 "aws-sign2": {
@@ -4334,7 +4306,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "readable-stream": "2.0.6"
+                    "readable-stream": "~2.0.5"
                   },
                   "dependencies": {
                     "readable-stream": {
@@ -4342,12 +4314,12 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "string_decoder": "0.10.31",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "string_decoder": "~0.10.x",
+                        "util-deprecate": "~1.0.1"
                       },
                       "dependencies": {
                         "core-util-is": {
@@ -4389,7 +4361,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "delayed-stream": "1.0.0"
+                    "delayed-stream": "~1.0.0"
                   },
                   "dependencies": {
                     "delayed-stream": {
@@ -4414,9 +4386,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "async": "1.5.2",
-                    "combined-stream": "1.0.5",
-                    "mime-types": "2.1.11"
+                    "async": "^1.5.2",
+                    "combined-stream": "^1.0.5",
+                    "mime-types": "^2.1.10"
                   },
                   "dependencies": {
                     "async": {
@@ -4431,10 +4403,10 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "chalk": "1.1.3",
-                    "commander": "2.9.0",
-                    "is-my-json-valid": "2.13.1",
-                    "pinkie-promise": "2.0.1"
+                    "chalk": "^1.1.1",
+                    "commander": "^2.9.0",
+                    "is-my-json-valid": "^2.12.4",
+                    "pinkie-promise": "^2.0.0"
                   },
                   "dependencies": {
                     "chalk": {
@@ -4442,11 +4414,11 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                       },
                       "dependencies": {
                         "ansi-styles": {
@@ -4464,7 +4436,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "ansi-regex": "2.0.0"
+                            "ansi-regex": "^2.0.0"
                           }
                         },
                         "supports-color": {
@@ -4479,7 +4451,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "graceful-readlink": "1.0.1"
+                        "graceful-readlink": ">= 1.0.0"
                       },
                       "dependencies": {
                         "graceful-readlink": {
@@ -4494,10 +4466,10 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "generate-function": "2.0.0",
-                        "generate-object-property": "1.2.0",
+                        "generate-function": "^2.0.0",
+                        "generate-object-property": "^1.1.0",
                         "jsonpointer": "2.0.0",
-                        "xtend": "4.0.1"
+                        "xtend": "^4.0.0"
                       },
                       "dependencies": {
                         "generate-function": {
@@ -4510,7 +4482,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "is-property": "1.0.2"
+                            "is-property": "^1.0.0"
                           },
                           "dependencies": {
                             "is-property": {
@@ -4537,7 +4509,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "pinkie": "2.0.4"
+                        "pinkie": "^2.0.0"
                       },
                       "dependencies": {
                         "pinkie": {
@@ -4554,10 +4526,10 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "boom": "2.10.1",
-                    "cryptiles": "2.0.5",
-                    "hoek": "2.16.3",
-                    "sntp": "1.0.9"
+                    "boom": "2.x.x",
+                    "cryptiles": "2.x.x",
+                    "hoek": "2.x.x",
+                    "sntp": "1.x.x"
                   },
                   "dependencies": {
                     "boom": {
@@ -4565,7 +4537,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "hoek": "2.16.3"
+                        "hoek": "2.x.x"
                       }
                     },
                     "cryptiles": {
@@ -4573,7 +4545,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "boom": "2.10.1"
+                        "boom": "2.x.x"
                       }
                     },
                     "hoek": {
@@ -4586,7 +4558,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "hoek": "2.16.3"
+                        "hoek": "2.x.x"
                       }
                     }
                   }
@@ -4596,9 +4568,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "assert-plus": "0.2.0",
-                    "jsprim": "1.3.0",
-                    "sshpk": "1.9.2"
+                    "assert-plus": "^0.2.0",
+                    "jsprim": "^1.2.2",
+                    "sshpk": "^1.7.0"
                   },
                   "dependencies": {
                     "assert-plus": {
@@ -4641,14 +4613,14 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "asn1": "0.2.3",
-                        "assert-plus": "1.0.0",
-                        "dashdash": "1.14.0",
-                        "ecc-jsbn": "0.1.1",
-                        "getpass": "0.1.6",
-                        "jodid25519": "1.0.2",
-                        "jsbn": "0.1.0",
-                        "tweetnacl": "0.13.3"
+                        "asn1": "~0.2.3",
+                        "assert-plus": "^1.0.0",
+                        "dashdash": "^1.12.0",
+                        "ecc-jsbn": "~0.1.1",
+                        "getpass": "^0.1.1",
+                        "jodid25519": "^1.0.0",
+                        "jsbn": "~0.1.0",
+                        "tweetnacl": "~0.13.0"
                       },
                       "dependencies": {
                         "asn1": {
@@ -4666,7 +4638,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "assert-plus": "1.0.0"
+                            "assert-plus": "^1.0.0"
                           }
                         },
                         "ecc-jsbn": {
@@ -4675,7 +4647,7 @@
                           "dev": true,
                           "optional": true,
                           "requires": {
-                            "jsbn": "0.1.0"
+                            "jsbn": "~0.1.0"
                           }
                         },
                         "getpass": {
@@ -4683,7 +4655,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "assert-plus": "1.0.0"
+                            "assert-plus": "^1.0.0"
                           }
                         },
                         "jodid25519": {
@@ -4692,7 +4664,7 @@
                           "dev": true,
                           "optional": true,
                           "requires": {
-                            "jsbn": "0.1.0"
+                            "jsbn": "~0.1.0"
                           }
                         },
                         "jsbn": {
@@ -4731,7 +4703,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "mime-db": "1.23.0"
+                    "mime-db": "~1.23.0"
                   },
                   "dependencies": {
                     "mime-db": {
@@ -4783,7 +4755,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "glob": "7.0.6"
+                "glob": "^7.0.5"
               }
             },
             "semver": {
@@ -4797,8 +4769,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.6",
-                "readable-stream": "2.0.2"
+                "graceful-fs": "^4.1.2",
+                "readable-stream": "^2.0.2"
               },
               "dependencies": {
                 "readable-stream": {
@@ -4806,12 +4778,12 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "core-util-is": "1.0.1",
-                    "inherits": "2.0.3",
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.1",
                     "isarray": "0.0.1",
-                    "process-nextick-args": "1.0.3",
-                    "string_decoder": "0.10.31",
-                    "util-deprecate": "1.0.1"
+                    "process-nextick-args": "~1.0.0",
+                    "string_decoder": "~0.10.x",
+                    "util-deprecate": "~1.0.1"
                   },
                   "dependencies": {
                     "core-util-is": {
@@ -4863,7 +4835,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "2.0.0"
+                "ansi-regex": "^2.0.0"
               }
             },
             "tar": {
@@ -4872,9 +4844,9 @@
               "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
               "dev": true,
               "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.10",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
               }
             },
             "text-table": {
@@ -4898,8 +4870,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "spdx-correct": "1.0.2",
-                "spdx-expression-parse": "1.0.2"
+                "spdx-correct": "~1.0.0",
+                "spdx-expression-parse": "~1.0.0"
               },
               "dependencies": {
                 "spdx-correct": {
@@ -4907,7 +4879,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "spdx-license-ids": "1.2.2"
+                    "spdx-license-ids": "^1.0.2"
                   }
                 },
                 "spdx-expression-parse": {
@@ -4915,8 +4887,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "spdx-exceptions": "1.0.4",
-                    "spdx-license-ids": "1.2.2"
+                    "spdx-exceptions": "^1.0.4",
+                    "spdx-license-ids": "^1.0.0"
                   },
                   "dependencies": {
                     "spdx-exceptions": {
@@ -4950,7 +4922,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "isexe": "1.1.2"
+                "isexe": "^1.1.1"
               },
               "dependencies": {
                 "isexe": {
@@ -4971,9 +4943,9 @@
               "integrity": "sha1-sfUtwujcDjywTRh6JfdYo4qQyjs=",
               "dev": true,
               "requires": {
-                "graceful-fs": "4.1.6",
-                "imurmurhash": "0.1.4",
-                "slide": "1.1.6"
+                "graceful-fs": "^4.1.2",
+                "imurmurhash": "^0.1.4",
+                "slide": "^1.1.5"
               }
             }
           }
@@ -5012,7 +4984,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "optimist": {
@@ -5021,8 +4993,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       }
     },
     "os-homedir": {
@@ -5061,10 +5033,10 @@
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "dev": true,
       "requires": {
-        "got": "7.0.0",
-        "registry-auth-token": "3.3.1",
-        "registry-url": "3.1.0",
-        "semver": "5.1.0"
+        "got": "^6.7.1",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
       }
     },
     "parse-json": {
@@ -5073,7 +5045,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.2.0"
       }
     },
     "parse-passwd": {
@@ -5094,7 +5066,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
@@ -5127,9 +5099,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -5158,7 +5130,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "prepend-http": {
@@ -5179,7 +5151,7 @@
       "integrity": "sha1-J+VF9pYKRKYn2bREZ+NcG2tM4vM=",
       "dev": true,
       "requires": {
-        "forwarded": "0.1.0",
+        "forwarded": "~0.1.0",
         "ipaddr.js": "1.3.0"
       }
     },
@@ -5213,10 +5185,10 @@
       "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
       "dev": true,
       "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.4",
-        "minimist": "0.0.10",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "~0.4.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       }
     },
     "read-pkg": {
@@ -5225,9 +5197,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
@@ -5236,8 +5208,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       }
     },
     "redent": {
@@ -5246,8 +5218,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
       }
     },
     "registry-auth-token": {
@@ -5256,8 +5228,8 @@
       "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
       "dev": true,
       "requires": {
-        "rc": "1.2.1",
-        "safe-buffer": "5.1.0"
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
       }
     },
     "registry-url": {
@@ -5266,7 +5238,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.2.1"
+        "rc": "^1.0.1"
       }
     },
     "repeating": {
@@ -5275,7 +5247,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "rimraf": {
@@ -5284,7 +5256,7 @@
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "safe-buffer": {
@@ -5305,7 +5277,7 @@
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "requires": {
-        "semver": "5.1.0"
+        "semver": "^5.0.3"
       }
     },
     "send": {
@@ -5315,18 +5287,18 @@
       "dev": true,
       "requires": {
         "debug": "2.6.7",
-        "depd": "1.1.0",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.8.0",
+        "depd": "~1.1.0",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
         "fresh": "0.5.0",
-        "http-errors": "1.6.1",
+        "http-errors": "~1.6.1",
         "mime": "1.3.4",
         "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.3.1"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
       }
     },
     "serve-static": {
@@ -5335,9 +5307,9 @@
       "integrity": "sha1-n0uhni8wMMVH+K+ZEHg47DjVseI=",
       "dev": true,
       "requires": {
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.1",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.1",
         "send": "0.15.3"
       }
     },
@@ -5370,7 +5342,7 @@
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "^0.5.6"
       }
     },
     "spdx-correct": {
@@ -5379,7 +5351,7 @@
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-license-ids": "^1.0.2"
       }
     },
     "spdx-expression-parse": {
@@ -5405,8 +5377,8 @@
       "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "3.0.1"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       }
     },
     "strip-ansi": {
@@ -5415,7 +5387,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -5424,7 +5396,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.0"
       }
     },
     "strip-eof": {
@@ -5439,7 +5411,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1"
+        "get-stdin": "^4.0.1"
       }
     },
     "strip-json-comments": {
@@ -5454,7 +5426,7 @@
       "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
       "dev": true,
       "requires": {
-        "has-flag": "1.0.0"
+        "has-flag": "^1.0.0"
       }
     },
     "term-size": {
@@ -5463,23 +5435,7 @@
       "integrity": "sha1-hzYLljlsq1dgljcUzaDQy+7K2co=",
       "dev": true,
       "requires": {
-        "execa": "0.4.0"
-      }
-    },
-    "thenify": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
-      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
-      "requires": {
-        "any-promise": "1.3.0"
-      }
-    },
-    "thenify-all": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
-      "requires": {
-        "thenify": "3.3.0"
+        "execa": "^0.4.0"
       }
     },
     "timed-out": {
@@ -5494,7 +5450,7 @@
       "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.1"
       }
     },
     "trim-newlines": {
@@ -5509,16 +5465,16 @@
       "integrity": "sha1-wTxqMCTjC+EYDdUwOPwgkonUv2k=",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "chalk": "2.3.0",
-        "diff": "3.2.0",
-        "make-error": "1.3.0",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18",
-        "tsconfig": "6.0.0",
-        "v8flags": "3.0.1",
-        "yn": "2.0.0"
+        "arrify": "^1.0.0",
+        "chalk": "^2.0.0",
+        "diff": "^3.1.0",
+        "make-error": "^1.1.1",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.0",
+        "tsconfig": "^6.0.0",
+        "v8flags": "^3.0.0",
+        "yn": "^2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5527,7 +5483,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -5536,9 +5492,9 @@
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "has-flag": {
@@ -5559,7 +5515,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -5570,8 +5526,8 @@
       "integrity": "sha1-aw6DdgA9evGGT434+J3QBZ/80DI=",
       "dev": true,
       "requires": {
-        "strip-bom": "3.0.0",
-        "strip-json-comments": "2.0.1"
+        "strip-bom": "^3.0.0",
+        "strip-json-comments": "^2.0.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -5588,7 +5544,7 @@
       "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.15"
+        "mime-types": "~2.1.15"
       }
     },
     "typescript": {
@@ -5603,7 +5559,7 @@
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "dev": true,
       "requires": {
-        "crypto-random-string": "1.0.0"
+        "crypto-random-string": "^1.0.0"
       }
     },
     "unpipe": {
@@ -5617,14 +5573,14 @@
       "integrity": "sha1-G1g3z5DAc22IYncytmHBOPht5y8=",
       "dev": true,
       "requires": {
-        "boxen": "1.1.0",
-        "chalk": "1.1.3",
-        "configstore": "3.1.0",
-        "import-lazy": "2.1.0",
-        "is-npm": "1.0.0",
-        "latest-version": "3.1.0",
-        "semver-diff": "2.1.0",
-        "xdg-basedir": "3.0.0"
+        "boxen": "^1.0.0",
+        "chalk": "^1.0.0",
+        "configstore": "^3.0.0",
+        "import-lazy": "^2.1.0",
+        "is-npm": "^1.0.0",
+        "latest-version": "^3.0.0",
+        "semver-diff": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
       }
     },
     "url-parse-lax": {
@@ -5633,7 +5589,7 @@
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
       "requires": {
-        "prepend-http": "1.0.4"
+        "prepend-http": "^1.0.1"
       }
     },
     "user-home": {
@@ -5642,7 +5598,7 @@
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.0"
       }
     },
     "utils-merge": {
@@ -5657,7 +5613,7 @@
       "integrity": "sha1-3Oj8N5wX2fLJ6e142JzgAFKxt2s=",
       "dev": true,
       "requires": {
-        "homedir-polyfill": "1.0.1"
+        "homedir-polyfill": "^1.0.1"
       }
     },
     "validate-npm-package-license": {
@@ -5666,8 +5622,8 @@
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "~1.0.0",
+        "spdx-expression-parse": "~1.0.0"
       }
     },
     "vary": {
@@ -5682,7 +5638,7 @@
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "widest-line": {
@@ -5691,7 +5647,7 @@
       "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.1"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -5700,7 +5656,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "string-width": {
@@ -5709,9 +5665,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -5734,9 +5690,9 @@
       "integrity": "sha512-0TZ20a+xcIl4u0+Mj5xDH2yOWdmQiXlKf9Hm+TgDXjTMsEYb+gDrmb8e8UNAzMCitX8NBqG4Z/FUQIyzv/R1JQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "slide": "1.1.6"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "slide": "^1.1.5"
       }
     },
     "xdg-basedir": {

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     "@types/node": "^7.0.31",
     "axios": "^0.16.2",
     "body-parser": "^1.18.2",
-    "file-type": "^7.2.0",
-    "get-audio-duration": "0.0.1"
+    "file-type": "^7.2.0"
   },
   "devDependencies": {
     "@types/express": "^4.0.35",


### PR DESCRIPTION
This should fixed the dependency warning in the main line-bot-sdk-nodejs package (as it's moved to the kitchensink example instead)

[x] `npm run test` all green
