### PR TITLE
Suggest using `--save` in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Node.js SDK for LINE Messaging API
 Using [npm](https://www.npmjs.com/):
 
 ``` bash
-$ npm install @line/bot-sdk
+$ npm install @line/bot-sdk --save
 ```
 
 ### Documentation


### PR DESCRIPTION
This will cause "@line/bot-sdk" to be automatically added in `package.json`, which should be the most common usage.