### PR TITLE
Handle rawBody provided by Google Cloud Functions

### DIFF
--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -14,6 +14,10 @@ export type Middleware = (
   next: NextCallback,
 ) => void;
 
+function isValidBody(body: any): body is string | Buffer {
+  return typeof body === "string" || Buffer.isBuffer(body);
+}
+
 export default function middleware(config: Types.MiddlewareConfig): Middleware {
   if (!config.channelSecret) {
     throw new Error("no channel secret");
@@ -31,7 +35,17 @@ export default function middleware(config: Types.MiddlewareConfig): Middleware {
       return;
     }
 
-    const validate = (body: string | Buffer) => {
+    let getBody: Promise<string | Buffer>;
+    if (isValidBody(req.body)) {
+      getBody = Promise.resolve(req.body);
+    } else {
+      // body may not be parsed yet, parse it to a buffer
+      getBody = new Promise(resolve => {
+        raw({ type: "*/*" })(req as any, res as any, () => resolve(req.body));
+      });
+    }
+
+    getBody.then(body => {
       if (!validateSignature(body, secret, signature)) {
         next(
           new SignatureValidationFailed(
@@ -50,13 +64,6 @@ export default function middleware(config: Types.MiddlewareConfig): Middleware {
       } catch (err) {
         next(new JSONParseError(err.message, strBody));
       }
-    };
-
-    if (typeof req.body === "string" || Buffer.isBuffer(req.body)) {
-      return validate(req.body);
-    }
-
-    // if body is not parsed yet, parse it to a buffer
-    raw({ type: "*/*" })(req as any, res as any, () => validate(req.body));
+    });
   };
 }

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -14,8 +14,8 @@ export type Middleware = (
   next: NextCallback,
 ) => void;
 
-function isValidBody(body: any): body is string | Buffer {
-  return typeof body === "string" || Buffer.isBuffer(body);
+function isValidBody(body?: any): body is string | Buffer {
+  return (body && typeof body === "string") || Buffer.isBuffer(body);
 }
 
 export default function middleware(config: Types.MiddlewareConfig): Middleware {
@@ -36,7 +36,10 @@ export default function middleware(config: Types.MiddlewareConfig): Middleware {
     }
 
     let getBody: Promise<string | Buffer>;
-    if (isValidBody(req.body)) {
+    if (isValidBody((req as any).rawBody)) {
+      // rawBody is provided in Google Cloud Functions and others
+      getBody = Promise.resolve((req as any).rawBody);
+    } else if (isValidBody(req.body)) {
       getBody = Promise.resolve(req.body);
     } else {
       // body may not be parsed yet, parse it to a buffer

--- a/test/helpers/test-server.ts
+++ b/test/helpers/test-server.ts
@@ -19,6 +19,13 @@ function listen(port: number, middleware?: express.RequestHandler) {
         bodyParser.text({ type: "*/*" })(req, res, next);
       } else if (req.path === "/mid-buffer") {
         bodyParser.raw({ type: "*/*" })(req, res, next);
+      } else if (req.path === "/mid-rawbody") {
+        bodyParser.raw({ type: "*/*" })(req, res, err => {
+          if (err) return next(err);
+          (req as any).rawBody = req.body;
+          delete req.body;
+          next();
+        });
       } else if (req.path === "/mid-json") {
         bodyParser.json({ type: "*/*" })(req, res, next);
       } else {

--- a/test/middleware.spec.ts
+++ b/test/middleware.spec.ts
@@ -72,6 +72,17 @@ describe("middleware", () => {
       });
   });
 
+  it("succeed with pre-parsed buffer in rawBody", () => {
+    return http()
+      .post(`/mid-rawbody`, {
+        events: [webhook],
+      })
+      .then(() => {
+        const req = getRecentReq();
+        deepEqual(req.body.events, [webhook]);
+      });
+  });
+
   it("fails on wrong signature", () => {
     return http({
       "X-Line-Signature": "qeDy61PbQK+aO97Bs8zjbFgYjQxFruGd13pfXPQoBRU=",


### PR DESCRIPTION
Resolve #6.

Use `rawBody` as body if it's provided. A test case is also added.