### PR TITLE
Add destination field

### DIFF
--- a/docs/api-reference/middleware.md
+++ b/docs/api-reference/middleware.md
@@ -37,7 +37,8 @@ app.use(middleware(config))
 
 // or directly with handler
 app.post('/webhook', middleware(config), (req, res) => {
-  req.body.events // will include webhook events
+  req.body.events // webhook event objects
+  req.body.destination // user ID of the bot (optional)
   ...
 })
 ```

--- a/docs/guide/webhook.md
+++ b/docs/guide/webhook.md
@@ -67,7 +67,9 @@ const config = {
 }
 
 app.post('/webhook', middleware(config), (req, res) => {
-  res.json(req.body.events) // req.body will be webhook event object
+  req.body.events // webhook event objects
+  req.body.destination // user ID of the bot (optional)
+  ...
 })
 
 app.listen(8080)

--- a/examples/kitchensink/index.js
+++ b/examples/kitchensink/index.js
@@ -31,6 +31,10 @@ app.get('/callback', (req, res) => res.end(`I'm listening. Please access with PO
 
 // webhook callback
 app.post('/callback', line.middleware(config), (req, res) => {
+  if (req.body.destination) {
+    console.log("Destination User ID: " + req.body.destination);
+  }
+
   // req.body.events should be an array of events
   if (!Array.isArray(req.body.events)) {
     return res.status(500).end();

--- a/lib/exceptions.ts
+++ b/lib/exceptions.ts
@@ -31,7 +31,7 @@ export class HTTPError extends Error {
     message: string,
     public statusCode: number,
     public statusMessage: string,
-    private originalError: Error,
+    public originalError: any,
   ) {
     super(message);
   }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -27,7 +27,7 @@ export type WebhookRequestBody = {
   /**
    * User ID of a bot that should receive webhook events. The user ID value is a string that matches the regular expression, U[0-9a-f]{32}.
    */
-  destination?: string;
+  destination: string;
 
   /**
    * Information about the event

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -19,6 +19,23 @@ export type Profile = {
 };
 
 /**
+ * Request body which is sent by webhook.
+ *
+ * @see [Request body](https://developers.line.me/en/reference/messaging-api/#request-body)
+ */
+export type WebhookRequestBody = {
+  /**
+   * User ID of a bot that should receive webhook events. The user ID value is a string that matches the regular expression, U[0-9a-f]{32}.
+   */
+  destination?: string;
+
+  /**
+   * Information about the event
+   */
+  events: Array<WebhookEvent>;
+};
+
+/**
  * JSON objects which contain events generated on the LINE Platform.
  *
  * @see [Webhook event objects](https://developers.line.me/en/reference/messaging-api/#webhook-event-objects)

--- a/test/middleware.spec.ts
+++ b/test/middleware.spec.ts
@@ -17,7 +17,7 @@ const getRecentReq = (): { body: Types.WebhookRequestBody } =>
 describe("middleware", () => {
   const http = (
     headers: any = {
-      "X-Line-Signature": "A3MXA9WcwBk9OdKKjq/gTdmgKxbYwDp8DimD0jEeb5M=",
+      "X-Line-Signature": "wqJD7WAIZhWcXThMCf8jZnwG3Hmn7EF36plkQGkj48w=",
     },
   ) => new HTTPClient(`http://localhost:${TEST_PORT}`, headers);
 
@@ -43,11 +43,11 @@ describe("middleware", () => {
     return http()
       .post(`/webhook`, {
         events: [webhook],
-        destination: "Uhogehoge",
+        destination: "Uaaaabbbbccccddddeeeeffff",
       })
       .then(() => {
         const req = getRecentReq();
-        deepEqual(req.body.destination, "Uhogehoge");
+        deepEqual(req.body.destination, "Uaaaabbbbccccddddeeeeffff");
         deepEqual(req.body.events, [webhook]);
       });
   });
@@ -56,11 +56,11 @@ describe("middleware", () => {
     return http()
       .post(`/mid-text`, {
         events: [webhook],
-        destination: "Uhogehoge",
+        destination: "Uaaaabbbbccccddddeeeeffff",
       })
       .then(() => {
         const req = getRecentReq();
-        deepEqual(req.body.destination, "Uhogehoge");
+        deepEqual(req.body.destination, "Uaaaabbbbccccddddeeeeffff");
         deepEqual(req.body.events, [webhook]);
       });
   });
@@ -69,11 +69,11 @@ describe("middleware", () => {
     return http()
       .post(`/mid-buffer`, {
         events: [webhook],
-        destination: "Uhogehoge",
+        destination: "Uaaaabbbbccccddddeeeeffff",
       })
       .then(() => {
         const req = getRecentReq();
-        deepEqual(req.body.destination, "Uhogehoge");
+        deepEqual(req.body.destination, "Uaaaabbbbccccddddeeeeffff");
         deepEqual(req.body.events, [webhook]);
       });
   });
@@ -82,22 +82,22 @@ describe("middleware", () => {
     return http()
       .post(`/mid-rawbody`, {
         events: [webhook],
-        destination: "Uhogehoge",
+        destination: "Uaaaabbbbccccddddeeeeffff",
       })
       .then(() => {
         const req = getRecentReq();
-        deepEqual(req.body.destination, "Uhogehoge");
+        deepEqual(req.body.destination, "Uaaaabbbbccccddddeeeeffff");
         deepEqual(req.body.events, [webhook]);
       });
   });
 
   it("fails on wrong signature", () => {
     return http({
-      "X-Line-Signature": "a3MXA9WcwBk9OdKKjq/gTdmgKxbYwDp8DimD0jEeb5M=",
+      "X-Line-Signature": "WqJD7WAIZhWcXThMCf8jZnwG3Hmn7EF36plkQGkj48w=",
     })
       .post(`/webhook`, {
         events: [webhook],
-        destination: "Uhogehoge",
+        destination: "Uaaaabbbbccccddddeeeeffff",
       })
       .catch((err: HTTPError) => {
         equal(err.statusCode, 401);
@@ -118,7 +118,7 @@ describe("middleware", () => {
     return http({})
       .post(`/webhook`, {
         events: [webhook],
-        destination: "Uhogehoge",
+        destination: "Uaaaabbbbccccddddeeeeffff",
       })
       .then((res: any) => {
         throw new Error();

--- a/test/middleware.spec.ts
+++ b/test/middleware.spec.ts
@@ -11,13 +11,13 @@ const TEST_PORT = parseInt(process.env.TEST_PORT, 10);
 
 const m = middleware({ channelSecret: "test_channel_secret" });
 
-const getRecentReq = (): any =>
+const getRecentReq = (): { body: Types.WebhookRequestBody } =>
   JSON.parse(readFileSync(join(__dirname, "helpers/request.json")).toString());
 
 describe("middleware", () => {
   const http = (
     headers: any = {
-      "X-Line-Signature": "qeDy61PbQK+aO97Bs8zjaFgYjQxFruGd13pfXPQoBRU=",
+      "X-Line-Signature": "A3MXA9WcwBk9OdKKjq/gTdmgKxbYwDp8DimD0jEeb5M=",
     },
   ) => new HTTPClient(`http://localhost:${TEST_PORT}`, headers);
 
@@ -43,9 +43,11 @@ describe("middleware", () => {
     return http()
       .post(`/webhook`, {
         events: [webhook],
+        destination: "Uhogehoge",
       })
       .then(() => {
         const req = getRecentReq();
+        deepEqual(req.body.destination, "Uhogehoge");
         deepEqual(req.body.events, [webhook]);
       });
   });
@@ -54,9 +56,11 @@ describe("middleware", () => {
     return http()
       .post(`/mid-text`, {
         events: [webhook],
+        destination: "Uhogehoge",
       })
       .then(() => {
         const req = getRecentReq();
+        deepEqual(req.body.destination, "Uhogehoge");
         deepEqual(req.body.events, [webhook]);
       });
   });
@@ -65,9 +69,11 @@ describe("middleware", () => {
     return http()
       .post(`/mid-buffer`, {
         events: [webhook],
+        destination: "Uhogehoge",
       })
       .then(() => {
         const req = getRecentReq();
+        deepEqual(req.body.destination, "Uhogehoge");
         deepEqual(req.body.events, [webhook]);
       });
   });
@@ -76,19 +82,22 @@ describe("middleware", () => {
     return http()
       .post(`/mid-rawbody`, {
         events: [webhook],
+        destination: "Uhogehoge",
       })
       .then(() => {
         const req = getRecentReq();
+        deepEqual(req.body.destination, "Uhogehoge");
         deepEqual(req.body.events, [webhook]);
       });
   });
 
   it("fails on wrong signature", () => {
     return http({
-      "X-Line-Signature": "qeDy61PbQK+aO97Bs8zjbFgYjQxFruGd13pfXPQoBRU=",
+      "X-Line-Signature": "a3MXA9WcwBk9OdKKjq/gTdmgKxbYwDp8DimD0jEeb5M=",
     })
       .post(`/webhook`, {
         events: [webhook],
+        destination: "Uhogehoge",
       })
       .catch((err: HTTPError) => {
         equal(err.statusCode, 401);
@@ -107,7 +116,10 @@ describe("middleware", () => {
 
   it("fails on empty signature", () => {
     return http({})
-      .post(`/webhook`, { events: [webhook] })
+      .post(`/webhook`, {
+        events: [webhook],
+        destination: "Uhogehoge",
+      })
       .then((res: any) => {
         throw new Error();
       })


### PR DESCRIPTION
Resolve #93.

A new `WebhookRequestBody` type has been added with `destination` field in it. Test, doc and kitchensink has been updated for it.

Also a minor fix concerning HTTPError, to change `originalError` field to be public and `any`, is included in this p-r.