### PR TITLE
Fix unhandled rejection on validating signature

### DIFF
--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -48,25 +48,27 @@ export default function middleware(config: Types.MiddlewareConfig): Middleware {
       });
     }
 
-    getBody.then(body => {
-      if (!validateSignature(body, secret, signature)) {
-        next(
-          new SignatureValidationFailed(
-            "signature validation failed",
-            signature,
-          ),
-        );
-        return;
-      }
+    getBody
+      .then(body => {
+        if (!validateSignature(body, secret, signature)) {
+          next(
+            new SignatureValidationFailed(
+              "signature validation failed",
+              signature,
+            ),
+          );
+          return;
+        }
 
-      const strBody = Buffer.isBuffer(body) ? body.toString() : body;
+        const strBody = Buffer.isBuffer(body) ? body.toString() : body;
 
-      try {
-        req.body = JSON.parse(strBody);
-        next();
-      } catch (err) {
-        next(new JSONParseError(err.message, strBody));
-      }
-    });
+        try {
+          req.body = JSON.parse(strBody);
+          next();
+        } catch (err) {
+          next(new JSONParseError(err.message, strBody));
+        }
+      })
+      .catch(next);
   };
 }


### PR DESCRIPTION
Hello. I made a fix for the routing of the middleware.

We already added the `body-parser` middleware globally to the `express` for many other routers. When we add the middleware of line-bot, the req.body is already an `object` when the routing reaches the middleware of line-bot. The `validateSignature` function throws an exception because `hmac.update` does not accepts `object`. The Promise rejects the exception, but nobody catches it, the routing does not handled properly.

So I add an error handling on the middleware.