### PR TITLE
Node version up and use async await

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - 6
   - 8
   - 10
+  - 12
 before_install:
   - npm i -g npm@6.4.1
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ node_js:
   - 10
   - 12
 before_install:
-  - npm i -g npm@6.4.1
+  - npm i -g npm@6.9.0
 install:
   - npm ci

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ reading them beforehand.
 
 ## Requirements
 
-* **Node.js** 6 or higher
+* **Node.js** 8 or higher
 
 ## Contributing
 

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -7,7 +7,7 @@ function toArray<T>(maybeArr: T | T[]): T[] {
   return Array.isArray(maybeArr) ? maybeArr : [maybeArr];
 }
 
-function checkJSON<T>(raw: T): T {
+function ensureJSON<T>(raw: T): T {
   if (typeof raw === "object") {
     return raw;
   } else {
@@ -35,7 +35,7 @@ export default class Client {
     );
   }
 
-  public pushMessage(
+  public async pushMessage(
     to: string,
     messages: Types.Message | Types.Message[],
   ): Promise<any> {
@@ -45,7 +45,7 @@ export default class Client {
     });
   }
 
-  public replyMessage(
+  public async replyMessage(
     replyToken: string,
     messages: Types.Message | Types.Message[],
   ): Promise<any> {
@@ -55,7 +55,7 @@ export default class Client {
     });
   }
 
-  public multicast(
+  public async multicast(
     to: string[],
     messages: Types.Message | Types.Message[],
   ): Promise<any> {
@@ -65,63 +65,65 @@ export default class Client {
     });
   }
 
-  public getProfile(userId: string): Promise<Types.Profile> {
-    return this.http.get<Types.Profile>(`/profile/${userId}`).then(checkJSON);
+  public async getProfile(userId: string): Promise<Types.Profile> {
+    const profile = await this.http.get<Types.Profile>(`/profile/${userId}`);
+    return ensureJSON(profile);
   }
 
-  private getChatMemberProfile(
+  private async getChatMemberProfile(
     chatType: ChatType,
     chatId: string,
     userId: string,
   ): Promise<Types.Profile> {
-    return this.http
-      .get<Types.Profile>(`/${chatType}/${chatId}/member/${userId}`)
-      .then(checkJSON);
+    const profile = await this.http.get<Types.Profile>(
+      `/${chatType}/${chatId}/member/${userId}`,
+    );
+    return ensureJSON(profile);
   }
 
-  public getGroupMemberProfile(
+  public async getGroupMemberProfile(
     groupId: string,
     userId: string,
   ): Promise<Types.Profile> {
     return this.getChatMemberProfile("group", groupId, userId);
   }
 
-  public getRoomMemberProfile(
+  public async getRoomMemberProfile(
     roomId: string,
     userId: string,
   ): Promise<Types.Profile> {
     return this.getChatMemberProfile("room", roomId, userId);
   }
 
-  private getChatMemberIds(
+  private async getChatMemberIds(
     chatType: ChatType,
     chatId: string,
   ): Promise<string[]> {
-    const load = (start?: string): Promise<string[]> =>
-      this.http
-        .get(`/${chatType}/${chatId}/members/ids`, start ? { start } : null)
-        .then(checkJSON)
-        .then((res: { memberIds: string[]; next?: string }) => {
-          if (!res.next) {
-            return res.memberIds;
-          }
+    let memberIds: string[] = [];
 
-          return load(res.next).then(extraIds =>
-            res.memberIds.concat(extraIds),
-          );
-        });
-    return load();
+    let start: string;
+    do {
+      const res = await this.http.get<{ memberIds: string[]; next?: string }>(
+        `/${chatType}/${chatId}/members/ids`,
+        start ? { start } : null,
+      );
+      ensureJSON(res);
+      memberIds = memberIds.concat(res.memberIds);
+      start = res.next;
+    } while (start);
+
+    return memberIds;
   }
 
-  public getGroupMemberIds(groupId: string): Promise<string[]> {
+  public async getGroupMemberIds(groupId: string): Promise<string[]> {
     return this.getChatMemberIds("group", groupId);
   }
 
-  public getRoomMemberIds(roomId: string): Promise<string[]> {
+  public async getRoomMemberIds(roomId: string): Promise<string[]> {
     return this.getChatMemberIds("room", roomId);
   }
 
-  public getMessageContent(messageId: string): Promise<Readable> {
+  public async getMessageContent(messageId: string): Promise<Readable> {
     return this.http.getStream(`/message/${messageId}/content`);
   }
 
@@ -129,47 +131,49 @@ export default class Client {
     return this.http.post(`/${chatType}/${chatId}/leave`);
   }
 
-  public leaveGroup(groupId: string): Promise<any> {
+  public async leaveGroup(groupId: string): Promise<any> {
     return this.leaveChat("group", groupId);
   }
 
-  public leaveRoom(roomId: string): Promise<any> {
+  public async leaveRoom(roomId: string): Promise<any> {
     return this.leaveChat("room", roomId);
   }
 
-  public getRichMenu(richMenuId: string): Promise<Types.RichMenuResponse> {
-    return this.http
-      .get<Types.RichMenuResponse>(`/richmenu/${richMenuId}`)
-      .then(checkJSON);
+  public async getRichMenu(
+    richMenuId: string,
+  ): Promise<Types.RichMenuResponse> {
+    const res = await this.http.get<Types.RichMenuResponse>(
+      `/richmenu/${richMenuId}`,
+    );
+    return ensureJSON(res);
   }
 
-  public createRichMenu(richMenu: Types.RichMenu): Promise<string> {
-    return this.http
-      .post<any>("/richmenu", richMenu)
-      .then(checkJSON)
-      .then(res => res.richMenuId);
+  public async createRichMenu(richMenu: Types.RichMenu): Promise<string> {
+    const res = await this.http.post<any>("/richmenu", richMenu);
+    return ensureJSON(res).richMenuId;
   }
 
-  public deleteRichMenu(richMenuId: string): Promise<any> {
+  public async deleteRichMenu(richMenuId: string): Promise<any> {
     return this.http.delete(`/richmenu/${richMenuId}`);
   }
 
-  public getRichMenuIdOfUser(userId: string): Promise<string> {
-    return this.http
-      .get<any>(`/user/${userId}/richmenu`)
-      .then(checkJSON)
-      .then(res => res.richMenuId);
+  public async getRichMenuIdOfUser(userId: string): Promise<string> {
+    const res = await this.http.get<any>(`/user/${userId}/richmenu`);
+    return ensureJSON(res).richMenuId;
   }
 
-  public linkRichMenuToUser(userId: string, richMenuId: string): Promise<any> {
+  public async linkRichMenuToUser(
+    userId: string,
+    richMenuId: string,
+  ): Promise<any> {
     return this.http.post(`/user/${userId}/richmenu/${richMenuId}`);
   }
 
-  public unlinkRichMenuFromUser(userId: string): Promise<any> {
+  public async unlinkRichMenuFromUser(userId: string): Promise<any> {
     return this.http.delete(`/user/${userId}/richmenu`);
   }
 
-  public linkRichMenuToMultipleUsers(
+  public async linkRichMenuToMultipleUsers(
     richMenuId: string,
     userIds: string[],
   ): Promise<any> {
@@ -179,17 +183,19 @@ export default class Client {
     });
   }
 
-  public unlinkRichMenusFromMultipleUsers(userIds: string[]): Promise<any> {
+  public async unlinkRichMenusFromMultipleUsers(
+    userIds: string[],
+  ): Promise<any> {
     return this.http.post("/richmenu/bulk/unlink", {
       userIds,
     });
   }
 
-  public getRichMenuImage(richMenuId: string): Promise<Readable> {
+  public async getRichMenuImage(richMenuId: string): Promise<Readable> {
     return this.http.getStream(`/richmenu/${richMenuId}/content`);
   }
 
-  public setRichMenuImage(
+  public async setRichMenuImage(
     richMenuId: string,
     data: Buffer | Readable,
     contentType?: string,
@@ -201,62 +207,53 @@ export default class Client {
     );
   }
 
-  public getRichMenuList(): Promise<Array<Types.RichMenuResponse>> {
-    return this.http
-      .get<any>(`/richmenu/list`)
-      .then(checkJSON)
-      .then(res => res.richmenus);
+  public async getRichMenuList(): Promise<Array<Types.RichMenuResponse>> {
+    const res = await this.http.get<any>(`/richmenu/list`);
+    return ensureJSON(res).richmenus;
   }
 
-  public setDefaultRichMenu(richMenuId: string): Promise<{}> {
+  public async setDefaultRichMenu(richMenuId: string): Promise<{}> {
     return this.http.post(`/user/all/richmenu/${richMenuId}`);
   }
 
-  public getDefaultRichMenuId(): Promise<string> {
-    return this.http
-      .get<any>("/user/all/richmenu")
-      .then(checkJSON)
-      .then(res => res.richMenuId);
+  public async getDefaultRichMenuId(): Promise<string> {
+    const res = await this.http.get<any>("/user/all/richmenu");
+    return ensureJSON(res).richMenuId;
   }
 
-  public deleteDefaultRichMenu(): Promise<{}> {
+  public async deleteDefaultRichMenu(): Promise<{}> {
     return this.http.delete("/user/all/richmenu");
   }
 
-  public getLinkToken(userId: string): Promise<string> {
-    return this.http
-      .post<any>(`/user/${userId}/linkToken`)
-      .then(checkJSON)
-      .then(res => res.linkToken);
+  public async getLinkToken(userId: string): Promise<string> {
+    const res = await this.http.post<any>(`/user/${userId}/linkToken`);
+    return ensureJSON(res).linkToken;
   }
 
-  public getNumberOfSentReplyMessages(
+  public async getNumberOfSentReplyMessages(
     date: string,
   ): Promise<Types.NumberOfMessagesSentResponse> {
-    return this.http
-      .get<Types.NumberOfMessagesSentResponse>(
-        `/message/delivery/reply?date=${date}`,
-      )
-      .then(checkJSON);
+    const res = await this.http.get<Types.NumberOfMessagesSentResponse>(
+      `/message/delivery/reply?date=${date}`,
+    );
+    return ensureJSON(res);
   }
 
-  public getNumberOfSentPushMessages(
+  public async getNumberOfSentPushMessages(
     date: string,
   ): Promise<Types.NumberOfMessagesSentResponse> {
-    return this.http
-      .get<Types.NumberOfMessagesSentResponse>(
-        `/message/delivery/push?date=${date}`,
-      )
-      .then(checkJSON);
+    const res = await this.http.get<Types.NumberOfMessagesSentResponse>(
+      `/message/delivery/push?date=${date}`,
+    );
+    return ensureJSON(res);
   }
 
-  public getNumberOfSentMulticastMessages(
+  public async getNumberOfSentMulticastMessages(
     date: string,
   ): Promise<Types.NumberOfMessagesSentResponse> {
-    return this.http
-      .get<Types.NumberOfMessagesSentResponse>(
-        `/message/delivery/multicast?date=${date}`,
-      )
-      .then(checkJSON);
+    const res = await this.http.get<Types.NumberOfMessagesSentResponse>(
+      `/message/delivery/multicast?date=${date}`,
+    );
+    return ensureJSON(res);
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "6.7.0",
   "description": "Node.js SDK for LINE Messaging API",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -46,354 +46,320 @@ describe("client", () => {
     ],
   };
 
-  it("reply", () => {
-    return client.replyMessage("test_reply_token", testMsg).then((res: any) => {
-      const req = getRecentReq();
-      equal(req.headers.authorization, "Bearer test_channel_access_token");
-      equal(req.path, "/message/reply");
-      equal(req.method, "POST");
-      equal(req.body.replyToken, "test_reply_token");
-      deepEqual(req.body.messages, [testMsg]);
-      deepEqual(res, {});
-    });
+  it("reply", async () => {
+    const res = await client.replyMessage("test_reply_token", testMsg);
+    const req = getRecentReq();
+    equal(req.headers.authorization, "Bearer test_channel_access_token");
+    equal(req.path, "/message/reply");
+    equal(req.method, "POST");
+    equal(req.body.replyToken, "test_reply_token");
+    deepEqual(req.body.messages, [testMsg]);
+    deepEqual(res, {});
   });
 
-  it("push", () => {
-    return client.pushMessage("test_user_id", testMsg).then((res: any) => {
-      const req = getRecentReq();
-      equal(req.headers.authorization, "Bearer test_channel_access_token");
-      equal(req.path, "/message/push");
-      equal(req.method, "POST");
-      equal(req.body.to, "test_user_id");
-      deepEqual(req.body.messages, [testMsg]);
-      deepEqual(res, {});
-    });
+  it("push", async () => {
+    const res = await client.pushMessage("test_user_id", testMsg);
+    const req = getRecentReq();
+    equal(req.headers.authorization, "Bearer test_channel_access_token");
+    equal(req.path, "/message/push");
+    equal(req.method, "POST");
+    equal(req.body.to, "test_user_id");
+    deepEqual(req.body.messages, [testMsg]);
+    deepEqual(res, {});
   });
 
-  it("multicast", () => {
+  it("multicast", async () => {
     const ids = ["test_user_id_1", "test_user_id_2", "test_user_id_3"];
-    return client.multicast(ids, [testMsg, testMsg]).then((res: any) => {
-      const req = getRecentReq();
-      equal(req.headers.authorization, "Bearer test_channel_access_token");
-      equal(req.path, "/message/multicast");
-      equal(req.method, "POST");
-      deepEqual(req.body.to, [
-        "test_user_id_1",
-        "test_user_id_2",
-        "test_user_id_3",
-      ]);
-      deepEqual(req.body.messages, [testMsg, testMsg]);
-      deepEqual(res, {});
+    const res = await client.multicast(ids, [testMsg, testMsg]);
+    const req = getRecentReq();
+    equal(req.headers.authorization, "Bearer test_channel_access_token");
+    equal(req.path, "/message/multicast");
+    equal(req.method, "POST");
+    deepEqual(req.body.to, [
+      "test_user_id_1",
+      "test_user_id_2",
+      "test_user_id_3",
+    ]);
+    deepEqual(req.body.messages, [testMsg, testMsg]);
+    deepEqual(res, {});
+  });
+
+  it("getProfile", async () => {
+    const res = await client.getProfile("test_user_id");
+    const req = getRecentReq();
+    equal(req.headers.authorization, "Bearer test_channel_access_token");
+    equal(req.path, "/profile/test_user_id");
+    equal(req.method, "GET");
+    deepEqual(res, {});
+  });
+
+  it("getGroupMemberProfile", async () => {
+    const res = await client.getGroupMemberProfile(
+      "test_group_id",
+      "test_user_id",
+    );
+    const req = getRecentReq();
+    equal(req.headers.authorization, "Bearer test_channel_access_token");
+    equal(req.path, "/group/test_group_id/member/test_user_id");
+    equal(req.method, "GET");
+    deepEqual(res, {});
+  });
+
+  it("getRoomMemberProfile", async () => {
+    const res = await client.getRoomMemberProfile(
+      "test_room_id",
+      "test_user_id",
+    );
+    const req = getRecentReq();
+    equal(req.headers.authorization, "Bearer test_channel_access_token");
+    equal(req.path, "/room/test_room_id/member/test_user_id");
+    equal(req.method, "GET");
+    deepEqual(res, {});
+  });
+
+  it("getGroupMemberIds", async () => {
+    const ids = await client.getGroupMemberIds("test_group_id");
+    const req = getRecentReq();
+    equal(req.headers.authorization, "Bearer test_channel_access_token");
+    equal(req.path, "/group/test_group_id/members/ids");
+    equal(req.method, "GET");
+    deepEqual(ids, [
+      "group-test_group_id-0",
+      "group-test_group_id-1",
+      "group-test_group_id-2",
+      "group-test_group_id-3",
+      "group-test_group_id-4",
+      "group-test_group_id-5",
+      "group-test_group_id-6",
+      "group-test_group_id-7",
+      "group-test_group_id-8",
+    ]);
+  });
+
+  it("getRoomMemberIds", async () => {
+    const ids = await client.getRoomMemberIds("test_room_id");
+    const req = getRecentReq();
+    equal(req.headers.authorization, "Bearer test_channel_access_token");
+    equal(req.path, "/room/test_room_id/members/ids");
+    equal(req.method, "GET");
+    deepEqual(ids, [
+      "room-test_room_id-0",
+      "room-test_room_id-1",
+      "room-test_room_id-2",
+      "room-test_room_id-3",
+      "room-test_room_id-4",
+      "room-test_room_id-5",
+      "room-test_room_id-6",
+      "room-test_room_id-7",
+      "room-test_room_id-8",
+    ]);
+  });
+
+  it("getMessageContent", async () => {
+    const stream = await client.getMessageContent("test_message_id");
+    const data = await getStreamData(stream);
+    const req = getRecentReq();
+    equal(req.headers.authorization, "Bearer test_channel_access_token");
+    equal(req.path, "/message/test_message_id/content");
+    equal(req.method, "GET");
+
+    const res = JSON.parse(data);
+    deepEqual(res, {});
+  });
+
+  it("leaveGroup", async () => {
+    const res = await client.leaveGroup("test_group_id");
+    const req = getRecentReq();
+    equal(req.headers.authorization, "Bearer test_channel_access_token");
+    equal(req.path, "/group/test_group_id/leave");
+    equal(req.method, "POST");
+    deepEqual(res, {});
+  });
+
+  it("leaveRoom", async () => {
+    const res = await client.leaveRoom("test_room_id");
+    const req = getRecentReq();
+    equal(req.headers.authorization, "Bearer test_channel_access_token");
+    equal(req.path, "/room/test_room_id/leave");
+    equal(req.method, "POST");
+    deepEqual(res, {});
+  });
+
+  it("getRichMenu", async () => {
+    const res = await client.getRichMenu("test_rich_menu_id");
+    const req = getRecentReq();
+    equal(req.headers.authorization, "Bearer test_channel_access_token");
+    equal(req.path, "/richmenu/test_rich_menu_id");
+    equal(req.method, "GET");
+    deepEqual(res, {});
+  });
+
+  it("createRichMenu", async () => {
+    await client.createRichMenu(richMenu);
+    const req = getRecentReq();
+    equal(req.headers.authorization, "Bearer test_channel_access_token");
+    equal(req.path, "/richmenu");
+    equal(req.method, "POST");
+    deepEqual(req.body, richMenu);
+  });
+
+  it("deleteRichMenu", async () => {
+    const res = await client.deleteRichMenu("test_rich_menu_id");
+    const req = getRecentReq();
+    equal(req.headers.authorization, "Bearer test_channel_access_token");
+    equal(req.path, "/richmenu/test_rich_menu_id");
+    equal(req.method, "DELETE");
+    deepEqual(res, {});
+  });
+
+  it("getRichMenuIdOfUser", async () => {
+    await client.getRichMenuIdOfUser("test_user_id");
+    const req = getRecentReq();
+    equal(req.headers.authorization, "Bearer test_channel_access_token");
+    equal(req.path, "/user/test_user_id/richmenu");
+    equal(req.method, "GET");
+  });
+
+  it("linkRichMenuToUser", async () => {
+    const res = await client.linkRichMenuToUser(
+      "test_user_id",
+      "test_rich_menu_id",
+    );
+    const req = getRecentReq();
+    equal(req.headers.authorization, "Bearer test_channel_access_token");
+    equal(req.path, "/user/test_user_id/richmenu/test_rich_menu_id");
+    equal(req.method, "POST");
+    deepEqual(res, {});
+  });
+
+  it("unlinkRichMenuFromUser", async () => {
+    const res = await client.unlinkRichMenuFromUser("test_user_id");
+    const req = getRecentReq();
+    equal(req.headers.authorization, "Bearer test_channel_access_token");
+    equal(req.path, "/user/test_user_id/richmenu");
+    equal(req.method, "DELETE");
+    deepEqual(res, {});
+  });
+
+  it("linkRichMenuToMultipleUsers", async () => {
+    const res = await client.linkRichMenuToMultipleUsers("test_rich_menu_id", [
+      "test_user_id",
+    ]);
+    const req = getRecentReq();
+    equal(req.headers.authorization, "Bearer test_channel_access_token");
+    equal(req.path, "/richmenu/bulk/link");
+    equal(req.method, "POST");
+    deepEqual(res, {});
+    deepEqual(req.body, {
+      richMenuId: "test_rich_menu_id",
+      userIds: ["test_user_id"],
     });
   });
 
-  it("getProfile", () => {
-    return client.getProfile("test_user_id").then((res: any) => {
-      const req = getRecentReq();
-      equal(req.headers.authorization, "Bearer test_channel_access_token");
-      equal(req.path, "/profile/test_user_id");
-      equal(req.method, "GET");
-      deepEqual(res, {});
+  it("unlinkRichMenusFromMultipleUsers", async () => {
+    const res = await client.unlinkRichMenusFromMultipleUsers(["test_user_id"]);
+    const req = getRecentReq();
+    equal(req.headers.authorization, "Bearer test_channel_access_token");
+    equal(req.path, "/richmenu/bulk/unlink");
+    equal(req.method, "POST");
+    deepEqual(res, {});
+    deepEqual(req.body, {
+      userIds: ["test_user_id"],
     });
   });
 
-  it("getGroupMemberProfile", () => {
-    return client
-      .getGroupMemberProfile("test_group_id", "test_user_id")
-      .then((res: any) => {
-        const req = getRecentReq();
-        equal(req.headers.authorization, "Bearer test_channel_access_token");
-        equal(req.path, "/group/test_group_id/member/test_user_id");
-        equal(req.method, "GET");
-        deepEqual(res, {});
-      });
-  });
-
-  it("getRoomMemberProfile", () => {
-    return client
-      .getRoomMemberProfile("test_room_id", "test_user_id")
-      .then((res: any) => {
-        const req = getRecentReq();
-        equal(req.headers.authorization, "Bearer test_channel_access_token");
-        equal(req.path, "/room/test_room_id/member/test_user_id");
-        equal(req.method, "GET");
-        deepEqual(res, {});
-      });
-  });
-
-  it("getGroupMemberIds", () => {
-    return client.getGroupMemberIds("test_group_id").then((ids: string[]) => {
-      const req = getRecentReq();
-      equal(req.headers.authorization, "Bearer test_channel_access_token");
-      equal(req.path, "/group/test_group_id/members/ids");
-      equal(req.method, "GET");
-      deepEqual(ids, [
-        "group-test_group_id-0",
-        "group-test_group_id-1",
-        "group-test_group_id-2",
-        "group-test_group_id-3",
-        "group-test_group_id-4",
-        "group-test_group_id-5",
-        "group-test_group_id-6",
-        "group-test_group_id-7",
-        "group-test_group_id-8",
-      ]);
-    });
-  });
-
-  it("getRoomMemberIds", () => {
-    return client.getRoomMemberIds("test_room_id").then((ids: string[]) => {
-      const req = getRecentReq();
-      equal(req.headers.authorization, "Bearer test_channel_access_token");
-      equal(req.path, "/room/test_room_id/members/ids");
-      equal(req.method, "GET");
-      deepEqual(ids, [
-        "room-test_room_id-0",
-        "room-test_room_id-1",
-        "room-test_room_id-2",
-        "room-test_room_id-3",
-        "room-test_room_id-4",
-        "room-test_room_id-5",
-        "room-test_room_id-6",
-        "room-test_room_id-7",
-        "room-test_room_id-8",
-      ]);
-    });
-  });
-
-  it("getMessageContent", () => {
-    return client
-      .getMessageContent("test_message_id")
-      .then((s: Readable) => getStreamData(s))
-      .then((data: string) => {
-        const req = getRecentReq();
-        equal(req.headers.authorization, "Bearer test_channel_access_token");
-        equal(req.path, "/message/test_message_id/content");
-        equal(req.method, "GET");
-
-        const res = JSON.parse(data);
-        deepEqual(res, {});
-      });
-  });
-
-  it("leaveGroup", () => {
-    return client.leaveGroup("test_group_id").then((res: any) => {
-      const req = getRecentReq();
-      equal(req.headers.authorization, "Bearer test_channel_access_token");
-      equal(req.path, "/group/test_group_id/leave");
-      equal(req.method, "POST");
-      deepEqual(res, {});
-    });
-  });
-
-  it("leaveRoom", () => {
-    return client.leaveRoom("test_room_id").then((res: any) => {
-      const req = getRecentReq();
-      equal(req.headers.authorization, "Bearer test_channel_access_token");
-      equal(req.path, "/room/test_room_id/leave");
-      equal(req.method, "POST");
-      deepEqual(res, {});
-    });
-  });
-
-  it("getRichMenu", () => {
-    return client.getRichMenu("test_rich_menu_id").then((res: any) => {
-      const req = getRecentReq();
-      equal(req.headers.authorization, "Bearer test_channel_access_token");
-      equal(req.path, "/richmenu/test_rich_menu_id");
-      equal(req.method, "GET");
-      deepEqual(res, {});
-    });
-  });
-
-  it("createRichMenu", () => {
-    return client.createRichMenu(richMenu).then(() => {
-      const req = getRecentReq();
-      equal(req.headers.authorization, "Bearer test_channel_access_token");
-      equal(req.path, "/richmenu");
-      equal(req.method, "POST");
-      deepEqual(req.body, richMenu);
-    });
-  });
-
-  it("deleteRichMenu", () => {
-    return client.deleteRichMenu("test_rich_menu_id").then((res: any) => {
-      const req = getRecentReq();
-      equal(req.headers.authorization, "Bearer test_channel_access_token");
-      equal(req.path, "/richmenu/test_rich_menu_id");
-      equal(req.method, "DELETE");
-      deepEqual(res, {});
-    });
-  });
-
-  it("getRichMenuIdOfUser", () => {
-    return client.getRichMenuIdOfUser("test_user_id").then(() => {
-      const req = getRecentReq();
-      equal(req.headers.authorization, "Bearer test_channel_access_token");
-      equal(req.path, "/user/test_user_id/richmenu");
-      equal(req.method, "GET");
-    });
-  });
-
-  it("linkRichMenuToUser", () => {
-    return client
-      .linkRichMenuToUser("test_user_id", "test_rich_menu_id")
-      .then((res: any) => {
-        const req = getRecentReq();
-        equal(req.headers.authorization, "Bearer test_channel_access_token");
-        equal(req.path, "/user/test_user_id/richmenu/test_rich_menu_id");
-        equal(req.method, "POST");
-        deepEqual(res, {});
-      });
-  });
-
-  it("unlinkRichMenuFromUser", () => {
-    return client.unlinkRichMenuFromUser("test_user_id").then((res: any) => {
-      const req = getRecentReq();
-      equal(req.headers.authorization, "Bearer test_channel_access_token");
-      equal(req.path, "/user/test_user_id/richmenu");
-      equal(req.method, "DELETE");
-      deepEqual(res, {});
-    });
-  });
-
-  it("linkRichMenuToMultipleUsers", () => {
-    return client
-      .linkRichMenuToMultipleUsers("test_rich_menu_id", ["test_user_id"])
-      .then((res: any) => {
-        const req = getRecentReq();
-        equal(req.headers.authorization, "Bearer test_channel_access_token");
-        equal(req.path, "/richmenu/bulk/link");
-        equal(req.method, "POST");
-        deepEqual(res, {});
-        deepEqual(req.body, {
-          richMenuId: "test_rich_menu_id",
-          userIds: ["test_user_id"],
-        });
-      });
-  });
-
-  it("unlinkRichMenusFromMultipleUsers", () => {
-    return client
-      .unlinkRichMenusFromMultipleUsers(["test_user_id"])
-      .then((res: any) => {
-        const req = getRecentReq();
-        equal(req.headers.authorization, "Bearer test_channel_access_token");
-        equal(req.path, "/richmenu/bulk/unlink");
-        equal(req.method, "POST");
-        deepEqual(res, {});
-        deepEqual(req.body, {
-          userIds: ["test_user_id"],
-        });
-      });
-  });
-
-  it("setRichMenuImage", () => {
+  it("setRichMenuImage", async () => {
     const filepath = join(__dirname, "/helpers/line-icon.png");
     const buffer = readFileSync(filepath);
-    return client
-      .setRichMenuImage("test_rich_menu_id", buffer)
-      .then((res: any) => {
-        const req = getRecentReq();
-        equal(req.headers.authorization, "Bearer test_channel_access_token");
-        equal(req.path, "/richmenu/test_rich_menu_id/content");
-        equal(req.method, "POST");
-        deepEqual(res, {});
-      });
+    const res = await client.setRichMenuImage("test_rich_menu_id", buffer);
+    const req = getRecentReq();
+    equal(req.headers.authorization, "Bearer test_channel_access_token");
+    equal(req.path, "/richmenu/test_rich_menu_id/content");
+    equal(req.method, "POST");
+    deepEqual(res, {});
   });
 
-  it("getRichMenuImage", () => {
-    return client
-      .getRichMenuImage("test_rich_menu_id")
-      .then((s: Readable) => getStreamData(s))
-      .then((data: string) => {
-        const req = getRecentReq();
-        equal(req.headers.authorization, "Bearer test_channel_access_token");
-        equal(req.path, "/richmenu/test_rich_menu_id/content");
-        equal(req.method, "GET");
+  it("getRichMenuImage", async () => {
+    const stream = await client.getRichMenuImage("test_rich_menu_id");
+    const data = await getStreamData(stream);
+    const req = getRecentReq();
+    equal(req.headers.authorization, "Bearer test_channel_access_token");
+    equal(req.path, "/richmenu/test_rich_menu_id/content");
+    equal(req.method, "GET");
 
-        const res = JSON.parse(data);
-        deepEqual(res, {});
-      });
+    const res = JSON.parse(data);
+    deepEqual(res, {});
   });
 
-  it("getRichMenuList", () => {
-    return client.getRichMenuList().then(() => {
-      const req = getRecentReq();
-      equal(req.headers.authorization, "Bearer test_channel_access_token");
-      equal(req.path, "/richmenu/list");
-      equal(req.method, "GET");
-    });
+  it("getRichMenuList", async () => {
+    await client.getRichMenuList();
+    const req = getRecentReq();
+    equal(req.headers.authorization, "Bearer test_channel_access_token");
+    equal(req.path, "/richmenu/list");
+    equal(req.method, "GET");
   });
 
-  it("setDefaultRichMenu", () => {
-    return client.setDefaultRichMenu("test_rich_menu_id").then((res: any) => {
-      const req = getRecentReq();
-      equal(req.headers.authorization, "Bearer test_channel_access_token");
-      equal(req.path, "/user/all/richmenu/test_rich_menu_id");
-      equal(req.method, "POST");
-      deepEqual(res, {});
-    });
+  it("setDefaultRichMenu", async () => {
+    const res = await client.setDefaultRichMenu("test_rich_menu_id");
+    const req = getRecentReq();
+    equal(req.headers.authorization, "Bearer test_channel_access_token");
+    equal(req.path, "/user/all/richmenu/test_rich_menu_id");
+    equal(req.method, "POST");
+    deepEqual(res, {});
   });
 
-  it("getDefaultRichMenuId", () => {
-    return client.getDefaultRichMenuId().then(() => {
-      const req = getRecentReq();
-      equal(req.headers.authorization, "Bearer test_channel_access_token");
-      equal(req.path, "/user/all/richmenu");
-      equal(req.method, "GET");
-    });
+  it("getDefaultRichMenuId", async () => {
+    await client.getDefaultRichMenuId();
+    const req = getRecentReq();
+    equal(req.headers.authorization, "Bearer test_channel_access_token");
+    equal(req.path, "/user/all/richmenu");
+    equal(req.method, "GET");
   });
 
-  it("deleteDefaultRichMenu", () => {
-    return client.deleteDefaultRichMenu().then((res: any) => {
-      const req = getRecentReq();
-      equal(req.headers.authorization, "Bearer test_channel_access_token");
-      equal(req.path, "/user/all/richmenu");
-      equal(req.method, "DELETE");
-      deepEqual(res, {});
-    });
+  it("deleteDefaultRichMenu", async () => {
+    const res = await client.deleteDefaultRichMenu();
+    const req = getRecentReq();
+    equal(req.headers.authorization, "Bearer test_channel_access_token");
+    equal(req.path, "/user/all/richmenu");
+    equal(req.method, "DELETE");
+    deepEqual(res, {});
   });
 
-  it("getLinkToken", () => {
-    return client.getLinkToken("test_user_id").then(() => {
-      const req = getRecentReq();
-      equal(req.headers.authorization, "Bearer test_channel_access_token");
-      equal(req.path, "/user/test_user_id/linkToken");
-      equal(req.method, "POST");
-    });
+  it("getLinkToken", async () => {
+    await client.getLinkToken("test_user_id");
+    const req = getRecentReq();
+    equal(req.headers.authorization, "Bearer test_channel_access_token");
+    equal(req.path, "/user/test_user_id/linkToken");
+    equal(req.method, "POST");
   });
 
-  it("getNumberOfSentReplyMessages", () => {
+  it("getNumberOfSentReplyMessages", async () => {
     const date = "20191231";
-    return client.getNumberOfSentReplyMessages(date).then(() => {
-      const req = getRecentReq();
-      equal(req.headers.authorization, "Bearer test_channel_access_token");
-      equal(req.path, "/message/delivery/reply");
-      equal(req.query.date, date);
-      equal(req.method, "GET");
-    });
+    await client.getNumberOfSentReplyMessages(date);
+    const req = getRecentReq();
+    equal(req.headers.authorization, "Bearer test_channel_access_token");
+    equal(req.path, "/message/delivery/reply");
+    equal(req.query.date, date);
+    equal(req.method, "GET");
   });
 
-  it("getNumberOfSentPushMessages", () => {
+  it("getNumberOfSentPushMessages", async () => {
     const date = "20191231";
-    return client.getNumberOfSentPushMessages(date).then(() => {
-      const req = getRecentReq();
-      equal(req.headers.authorization, "Bearer test_channel_access_token");
-      equal(req.path, "/message/delivery/push");
-      equal(req.query.date, date);
-      equal(req.method, "GET");
-    });
+    await client.getNumberOfSentPushMessages(date);
+    const req = getRecentReq();
+    equal(req.headers.authorization, "Bearer test_channel_access_token");
+    equal(req.path, "/message/delivery/push");
+    equal(req.query.date, date);
+    equal(req.method, "GET");
   });
 
-  it("getNumberOfSentMulticastMessages", () => {
+  it("getNumberOfSentMulticastMessages", async () => {
     const date = "20191231";
-    return client.getNumberOfSentMulticastMessages(date).then(() => {
-      const req = getRecentReq();
-      equal(req.headers.authorization, "Bearer test_channel_access_token");
-      equal(req.path, "/message/delivery/multicast");
-      equal(req.query.date, date);
-      equal(req.method, "GET");
-    });
+    await client.getNumberOfSentMulticastMessages(date);
+    const req = getRecentReq();
+    equal(req.headers.authorization, "Bearer test_channel_access_token");
+    equal(req.path, "/message/delivery/multicast");
+    equal(req.query.date, date);
+    equal(req.method, "GET");
   });
 });

--- a/test/http.spec.ts
+++ b/test/http.spec.ts
@@ -21,145 +21,133 @@ describe("http", () => {
   before(() => listen(TEST_PORT));
   after(() => close());
 
-  it("get", () => {
-    return http.get(`/get`).then((res: any) => {
-      const req = getRecentReq();
-      equal(req.method, "GET");
-      equal(req.path, "/get");
-      equal(req.headers["test-header-key"], "Test-Header-Value");
-      equal(req.headers["user-agent"], `${pkg.name}/${pkg.version}`);
-      deepEqual(res, {});
-    });
+  it("get", async () => {
+    const res = await http.get<any>(`/get`);
+    const req = getRecentReq();
+    equal(req.method, "GET");
+    equal(req.path, "/get");
+    equal(req.headers["test-header-key"], "Test-Header-Value");
+    equal(req.headers["user-agent"], `${pkg.name}/${pkg.version}`);
+    deepEqual(res, {});
   });
 
-  it("get with query", () => {
-    return http.get(`/get`, { x: 10 }).then((res: any) => {
-      const req = getRecentReq();
-      equal(req.method, "GET");
-      equal(req.path, "/get");
-      equal(req.query.x, "10");
-      equal(req.headers["test-header-key"], "Test-Header-Value");
-      equal(req.headers["user-agent"], `${pkg.name}/${pkg.version}`);
-      deepEqual(res, {});
-    });
+  it("get with query", async () => {
+    const res = await http.get<any>(`/get`, { x: 10 });
+    const req = getRecentReq();
+    equal(req.method, "GET");
+    equal(req.path, "/get");
+    equal(req.query.x, "10");
+    equal(req.headers["test-header-key"], "Test-Header-Value");
+    equal(req.headers["user-agent"], `${pkg.name}/${pkg.version}`);
+    deepEqual(res, {});
   });
 
-  it("post without body", () => {
-    return http.post(`/post`).then((res: any) => {
-      const req = getRecentReq();
-      equal(req.method, "POST");
-      equal(req.path, "/post");
-      equal(req.headers["test-header-key"], "Test-Header-Value");
-      equal(req.headers["user-agent"], `${pkg.name}/${pkg.version}`);
-      deepEqual(res, {});
-    });
+  it("post without body", async () => {
+    const res = await http.post<any>(`/post`);
+    const req = getRecentReq();
+    equal(req.method, "POST");
+    equal(req.path, "/post");
+    equal(req.headers["test-header-key"], "Test-Header-Value");
+    equal(req.headers["user-agent"], `${pkg.name}/${pkg.version}`);
+    deepEqual(res, {});
   });
 
-  it("post with body", () => {
+  it("post with body", async () => {
     const testBody = {
       id: 12345,
       message: "hello, body!",
     };
 
-    return http.post(`/post/body`, testBody).then((res: any) => {
-      const req = getRecentReq();
-      equal(req.method, "POST");
-      equal(req.path, "/post/body");
-      equal(req.headers["test-header-key"], "Test-Header-Value");
-      equal(req.headers["user-agent"], `${pkg.name}/${pkg.version}`);
-      deepEqual(req.body, testBody);
-      deepEqual(res, {});
-    });
+    const res = await http.post<any>(`/post/body`, testBody);
+    const req = getRecentReq();
+    equal(req.method, "POST");
+    equal(req.path, "/post/body");
+    equal(req.headers["test-header-key"], "Test-Header-Value");
+    equal(req.headers["user-agent"], `${pkg.name}/${pkg.version}`);
+    deepEqual(req.body, testBody);
+    deepEqual(res, {});
   });
 
-  it("getStream", () => {
-    return http
-      .getStream(`/stream.txt`)
-      .then(s => getStreamData(s))
-      .then(result => {
-        equal(result, "hello, stream!\n");
-      });
+  it("getStream", async () => {
+    const stream = await http.getStream(`/stream.txt`);
+    const data = await getStreamData(stream);
+    equal(data, "hello, stream!\n");
   });
 
-  it("delete", () => {
-    return http.delete(`/delete`).then(() => {
-      const req = getRecentReq();
-      equal(req.method, "DELETE");
-      equal(req.path, "/delete");
-      equal(req.headers["test-header-key"], "Test-Header-Value");
-      equal(req.headers["user-agent"], `${pkg.name}/${pkg.version}`);
-    });
+  it("delete", async () => {
+    await http.delete(`/delete`);
+    const req = getRecentReq();
+    equal(req.method, "DELETE");
+    equal(req.path, "/delete");
+    equal(req.headers["test-header-key"], "Test-Header-Value");
+    equal(req.headers["user-agent"], `${pkg.name}/${pkg.version}`);
   });
 
-  it("delete with query", () => {
-    return http.delete(`/delete`, { x: 10 }).then(() => {
-      const req = getRecentReq();
-      equal(req.method, "DELETE");
-      equal(req.path, "/delete");
-      equal(req.query.x, "10");
-      equal(req.headers["test-header-key"], "Test-Header-Value");
-      equal(req.headers["user-agent"], `${pkg.name}/${pkg.version}`);
-    });
+  it("delete with query", async () => {
+    await http.delete(`/delete`, { x: 10 });
+    const req = getRecentReq();
+    equal(req.method, "DELETE");
+    equal(req.path, "/delete");
+    equal(req.query.x, "10");
+    equal(req.headers["test-header-key"], "Test-Header-Value");
+    equal(req.headers["user-agent"], `${pkg.name}/${pkg.version}`);
   });
 
-  it("postBinary", () => {
+  it("postBinary", async () => {
     const filepath = join(__dirname, "/helpers/line-icon.png");
     const buffer = readFileSync(filepath);
-    return http.postBinary(`/post/binary`, buffer).then(() => {
-      const req = getRecentReq();
-      equal(req.method, "POST");
-      equal(req.path, "/post/binary");
-      equal(req.body, buffer.toString("base64"));
-      equal(req.headers["test-header-key"], "Test-Header-Value");
-      equal(req.headers["user-agent"], `${pkg.name}/${pkg.version}`);
-      equal(req.headers["content-type"], "image/png");
-      equal(req.headers["content-length"], buffer.length);
-    });
+    await http.postBinary(`/post/binary`, buffer);
+    const req = getRecentReq();
+    equal(req.method, "POST");
+    equal(req.path, "/post/binary");
+    equal(req.body, buffer.toString("base64"));
+    equal(req.headers["test-header-key"], "Test-Header-Value");
+    equal(req.headers["user-agent"], `${pkg.name}/${pkg.version}`);
+    equal(req.headers["content-type"], "image/png");
+    equal(req.headers["content-length"], buffer.length);
   });
 
-  it("postBinary with specific content type", () => {
+  it("postBinary with specific content type", async () => {
     const filepath = join(__dirname, "/helpers/line-icon.png");
     const buffer = readFileSync(filepath);
-    return http.postBinary(`/post/binary`, buffer, "image/jpeg").then(() => {
-      const req = getRecentReq();
-      equal(req.body, buffer.toString("base64"));
-      equal(req.headers["test-header-key"], "Test-Header-Value");
-      equal(req.headers["content-type"], "image/jpeg");
-      equal(req.headers["content-length"], buffer.length);
-    });
+    await http.postBinary(`/post/binary`, buffer, "image/jpeg");
+    const req = getRecentReq();
+    equal(req.body, buffer.toString("base64"));
+    equal(req.headers["test-header-key"], "Test-Header-Value");
+    equal(req.headers["content-type"], "image/jpeg");
+    equal(req.headers["content-length"], buffer.length);
   });
 
-  it("postBinary with stream", () => {
+  it("postBinary with stream", async () => {
     const filepath = join(__dirname, "/helpers/line-icon.png");
     const stream = createReadStream(filepath);
-    return http.postBinary(`/post/binary`, stream).then(() => {
-      const buffer = readFileSync(filepath);
+    await http.postBinary(`/post/binary`, stream);
+    const buffer = readFileSync(filepath);
 
-      const req = getRecentReq();
-      equal(req.body, buffer.toString("base64"));
-      equal(req.headers["test-header-key"], "Test-Header-Value");
-      equal(req.headers["content-type"], "image/png");
-      equal(req.headers["content-length"], buffer.length);
-    });
+    const req = getRecentReq();
+    equal(req.body, buffer.toString("base64"));
+    equal(req.headers["test-header-key"], "Test-Header-Value");
+    equal(req.headers["content-type"], "image/png");
+    equal(req.headers["content-length"], buffer.length);
   });
 
-  it("fail with 404", () => {
-    return http
-      .get(`/404`)
-      .then(() => ok(false))
-      .catch((err: HTTPError) => {
-        ok(err instanceof HTTPError);
-        equal(err.statusCode, 404);
-      });
+  it("fail with 404", async () => {
+    try {
+      await http.get(`/404`);
+      ok(false);
+    } catch (err) {
+      ok(err instanceof HTTPError);
+      equal(err.statusCode, 404);
+    }
   });
 
-  it("fail with wrong addr", () => {
-    return http
-      .get("http://domain.invalid", {})
-      .then(() => ok(false))
-      .catch((err: RequestError) => {
-        ok(err instanceof RequestError);
-        equal(err.code, "ENOTFOUND");
-      });
+  it("fail with wrong addr", async () => {
+    try {
+      await http.get("http://domain.invalid");
+      ok(false);
+    } catch (err) {
+      ok(err instanceof RequestError);
+      equal(err.code, "ENOTFOUND");
+    }
   });
 });

--- a/test/middleware.spec.ts
+++ b/test/middleware.spec.ts
@@ -1,4 +1,4 @@
-import { deepEqual, equal } from "assert";
+import { deepEqual, equal, ok } from "assert";
 import { readFileSync } from "fs";
 import { join } from "path";
 import { HTTPError } from "../lib/exceptions";
@@ -39,96 +39,92 @@ describe("middleware", () => {
     type: "message",
   };
 
-  it("succeed", () => {
-    return http()
-      .post(`/webhook`, {
-        events: [webhook],
-        destination: "Uaaaabbbbccccddddeeeeffff",
-      })
-      .then(() => {
-        const req = getRecentReq();
-        deepEqual(req.body.destination, "Uaaaabbbbccccddddeeeeffff");
-        deepEqual(req.body.events, [webhook]);
-      });
+  it("succeed", async () => {
+    await http().post(`/webhook`, {
+      events: [webhook],
+      destination: "Uaaaabbbbccccddddeeeeffff",
+    });
+    const req = getRecentReq();
+    deepEqual(req.body.destination, "Uaaaabbbbccccddddeeeeffff");
+    deepEqual(req.body.events, [webhook]);
   });
 
-  it("succeed with pre-parsed string", () => {
-    return http()
-      .post(`/mid-text`, {
-        events: [webhook],
-        destination: "Uaaaabbbbccccddddeeeeffff",
-      })
-      .then(() => {
-        const req = getRecentReq();
-        deepEqual(req.body.destination, "Uaaaabbbbccccddddeeeeffff");
-        deepEqual(req.body.events, [webhook]);
-      });
+  it("succeed with pre-parsed string", async () => {
+    await http().post(`/mid-text`, {
+      events: [webhook],
+      destination: "Uaaaabbbbccccddddeeeeffff",
+    });
+    const req = getRecentReq();
+    deepEqual(req.body.destination, "Uaaaabbbbccccddddeeeeffff");
+    deepEqual(req.body.events, [webhook]);
   });
 
-  it("succeed with pre-parsed buffer", () => {
-    return http()
-      .post(`/mid-buffer`, {
-        events: [webhook],
-        destination: "Uaaaabbbbccccddddeeeeffff",
-      })
-      .then(() => {
-        const req = getRecentReq();
-        deepEqual(req.body.destination, "Uaaaabbbbccccddddeeeeffff");
-        deepEqual(req.body.events, [webhook]);
-      });
+  it("succeed with pre-parsed buffer", async () => {
+    await http().post(`/mid-buffer`, {
+      events: [webhook],
+      destination: "Uaaaabbbbccccddddeeeeffff",
+    });
+    const req = getRecentReq();
+    deepEqual(req.body.destination, "Uaaaabbbbccccddddeeeeffff");
+    deepEqual(req.body.events, [webhook]);
   });
 
-  it("succeed with pre-parsed buffer in rawBody", () => {
-    return http()
-      .post(`/mid-rawbody`, {
-        events: [webhook],
-        destination: "Uaaaabbbbccccddddeeeeffff",
-      })
-      .then(() => {
-        const req = getRecentReq();
-        deepEqual(req.body.destination, "Uaaaabbbbccccddddeeeeffff");
-        deepEqual(req.body.events, [webhook]);
-      });
+  it("succeed with pre-parsed buffer in rawBody", async () => {
+    await http().post(`/mid-rawbody`, {
+      events: [webhook],
+      destination: "Uaaaabbbbccccddddeeeeffff",
+    });
+    const req = getRecentReq();
+    deepEqual(req.body.destination, "Uaaaabbbbccccddddeeeeffff");
+    deepEqual(req.body.events, [webhook]);
   });
 
-  it("fails on wrong signature", () => {
-    return http({
-      "X-Line-Signature": "WqJD7WAIZhWcXThMCf8jZnwG3Hmn7EF36plkQGkj48w=",
-    })
-      .post(`/webhook`, {
+  it("fails on wrong signature", async () => {
+    try {
+      await http({
+        "X-Line-Signature": "WqJD7WAIZhWcXThMCf8jZnwG3Hmn7EF36plkQGkj48w=",
+      }).post(`/webhook`, {
         events: [webhook],
         destination: "Uaaaabbbbccccddddeeeeffff",
-      })
-      .catch((err: HTTPError) => {
+      });
+      ok(false);
+    } catch (err) {
+      if (err instanceof HTTPError) {
         equal(err.statusCode, 401);
-      });
+      } else {
+        throw err;
+      }
+    }
   });
 
-  it("fails on invalid JSON", () => {
-    return http({
-      "X-Line-Signature": "Z8YlPpm0lQOqPipiCHVbiuwIDIzRzD7w5hvHgmwEuEs=",
-    })
-      .post(`/webhook`, "i am not jason")
-      .catch((err: HTTPError) => {
+  it("fails on invalid JSON", async () => {
+    try {
+      await http({
+        "X-Line-Signature": "Z8YlPpm0lQOqPipiCHVbiuwIDIzRzD7w5hvHgmwEuEs=",
+      }).post(`/webhook`, "i am not jason");
+      ok(false);
+    } catch (err) {
+      if (err instanceof HTTPError) {
         equal(err.statusCode, 400);
-      });
+      } else {
+        throw err;
+      }
+    }
   });
 
-  it("fails on empty signature", () => {
-    return http({})
-      .post(`/webhook`, {
+  it("fails on empty signature", async () => {
+    try {
+      await http({}).post(`/webhook`, {
         events: [webhook],
         destination: "Uaaaabbbbccccddddeeeeffff",
-      })
-      .then((res: any) => {
-        throw new Error();
-      })
-      .catch((err: any) => {
-        if (err instanceof HTTPError) {
-          equal(err.statusCode, 401);
-        } else {
-          throw err;
-        }
       });
+      ok(false);
+    } catch (err) {
+      if (err instanceof HTTPError) {
+        equal(err.statusCode, 401);
+      } else {
+        throw err;
+      }
+    }
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es6",
+    "target": "es2017",
     "noImplicitAny": true,
     "outDir": "dist",
     "rootDirs": ["lib", "test"],


### PR DESCRIPTION
Resolve #131 and #126.

By the Node.js LTS schedule, Node.js 6 has been deprecated and 12 has been released.

This pull request updates npm and Travis configs for the upgrades.

Also, later parts of this p-r applies async-await to the code base because it's supported natively from Node.js 8.