### PR TITLE
Remove polyfills for Node.js 6

### DIFF
--- a/lib/validate-signature.ts
+++ b/lib/validate-signature.ts
@@ -1,17 +1,13 @@
 import { createHmac, timingSafeEqual } from "crypto";
 
 function s2b(str: string, encoding: string): Buffer {
-  if (Buffer.from) {
-    try {
-      return Buffer.from(str, encoding);
-    } catch (err) {
-      if (err.name === "TypeError") {
-        return new Buffer(str, encoding);
-      }
-      throw err;
+  try {
+    return Buffer.from(str, encoding);
+  } catch (err) {
+    if (err.name === "TypeError") {
+      return new Buffer(str, encoding);
     }
-  } else {
-    return new Buffer(str, encoding);
+    throw err;
   }
 }
 
@@ -19,16 +15,7 @@ function safeCompare(a: Buffer, b: Buffer): boolean {
   if (a.length !== b.length) {
     return false;
   }
-
-  if (timingSafeEqual) {
-    return timingSafeEqual(a, b);
-  } else {
-    let result = 0;
-    for (let i = 0; i < a.length; i++) {
-      result |= a[i] ^ b[i];
-    }
-    return result === 0;
-  }
+  return timingSafeEqual(a, b);
 }
 
 export default function validateSignature(


### PR DESCRIPTION
`timingSafeEqual` was added in Node.js v6.6.0, `Buffer.from` was added in v5.10.0.
As now Node.js 8 is the minimal supported version, we could remove the polyfills for older versions.

References:
https://nodejs.org/api/crypto.html#crypto_crypto_timingsafeequal_a_b
https://nodejs.org/api/buffer.html#buffer_class_method_buffer_from_array