### PR TITLE
Feature: add exception handler to handle middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2589,6 +2589,15 @@
         "@types/node": "*"
       }
     },
+    "@types/finalhandler": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/finalhandler/-/finalhandler-1.1.0.tgz",
+      "integrity": "sha512-iMD07b+UPNuqA6cm3yjbTJUfFfZNZpDc6MGQGK60jy5sdqX1W4wUC5RAi3FhaW72+RmVnzYxba8byPP9FWL8/w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/mime": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-0.0.29.tgz",
@@ -6125,6 +6134,21 @@
         "vary": "~1.1.2"
       },
       "dependencies": {
+        "finalhandler": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+          "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.2",
+            "statuses": "~1.4.0",
+            "unpipe": "~1.0.0"
+          }
+        },
         "mime-db": {
           "version": "1.33.0",
           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
@@ -6606,24 +6630,30 @@
       }
     },
     "finalhandler": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.4.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
       },
       "dependencies": {
+        "parseurl": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+          "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+          "dev": true
+        },
         "statuses": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
           "dev": true
         }
       }
@@ -6801,8 +6831,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6823,14 +6852,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6845,20 +6872,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6975,8 +6999,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6988,7 +7011,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7003,7 +7025,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7011,14 +7032,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7037,7 +7056,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7118,8 +7136,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7131,7 +7148,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7217,8 +7233,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7254,7 +7269,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7274,7 +7288,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7318,14 +7331,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -46,9 +46,11 @@
   },
   "devDependencies": {
     "@types/express": "^4.0.35",
+    "@types/finalhandler": "^1.1.0",
     "@types/mocha": "^2.2.41",
     "del-cli": "^1.1.0",
     "express": "^4.16.3",
+    "finalhandler": "^1.1.2",
     "husky": "^0.14.3",
     "mocha": "^5.2.0",
     "nyc": "^13.3.0",

--- a/test/helpers/test-server.ts
+++ b/test/helpers/test-server.ts
@@ -7,6 +7,7 @@ import {
   JSONParseError,
   SignatureValidationFailed,
 } from "../../lib/exceptions";
+import * as finalhandler from "finalhandler";
 
 let server: Server = null;
 
@@ -98,7 +99,11 @@ function listen(port: number, middleware?: express.RequestHandler) {
         res.status(400).send(err.raw);
         return;
       }
-      next(err);
+      // https://github.com/expressjs/express/blob/master/lib/application.js#L162
+      // express will record error in console when
+      // there is no other handler to handle error & it is in test environment
+      // use final handler the same as in express application.js
+      finalhandler(req, res)(err);
     },
   );
 

--- a/test/middleware.spec.ts
+++ b/test/middleware.spec.ts
@@ -79,6 +79,41 @@ describe("middleware", () => {
     deepEqual(req.body.events, [webhook]);
   });
 
+  it("fails on parsing raw as it's a not valid request and should be catched", async () => {
+    try {
+      await http({
+        "X-Line-Signature": "wqJD7WAIZhWcXThMCf8jZnwG3Hmn7EF36plkQGkj48w=",
+        "Content-Encoding": 1,
+      }).post(`/webhook`, {
+        events: [webhook],
+        destination: "Uaaaabbbbccccddddeeeeffff",
+      });
+      ok(false);
+    } catch (err) {
+      if (err instanceof HTTPError) {
+        equal(err.statusCode, 415);
+      } else {
+        throw err;
+      }
+    }
+  });
+
+  it("fails on pre-parsed json", async () => {
+    try {
+      await http().post(`/mid-json`, {
+        events: [webhook],
+        destination: "Uaaaabbbbccccddddeeeeffff",
+      });
+      ok(false);
+    } catch (err) {
+      if (err instanceof HTTPError) {
+        equal(err.statusCode, 500);
+      } else {
+        throw err;
+      }
+    }
+  });
+
   it("fails on wrong signature", async () => {
     try {
       await http({


### PR DESCRIPTION
So #138 is a problem when he use the bodyParser before LINE bot middleware which validates the signature.

I thought the use case is wrong so we don't need to fix anything.
But when I see `raw bodyParser` in  middleware didn't catch the error so it will always parse the body whatever a request is valid or not.

I've fixed this problem.