### PR TITLE
chore: getLineRequestId -> x-line-request-id plain object

### DIFF
--- a/docs/api-reference/client.md
+++ b/docs/api-reference/client.md
@@ -12,9 +12,9 @@ class Client {
   constructor(config: ClientConfig) {}
 
   // Message
-  pushMessage(to: string, messages: Message | Message[], notificationDisabled: boolean = false): Promise<MessageAPIBasicResponse>
-  replyMessage(replyToken: string, messages: Message | Message[], notificationDisabled: boolean = false): Promise<MessageAPIBasicResponse>
-  multicast(to: string[], messages: Message | Message[], notificationDisabled: boolean = false): Promise<MessageAPIBasicResponse>
+  pushMessage(to: string, messages: Message | Message[], notificationDisabled: boolean = false): Promise<MessageAPIResponseBase>
+  replyMessage(replyToken: string, messages: Message | Message[], notificationDisabled: boolean = false): Promise<MessageAPIResponseBase>
+  multicast(to: string[], messages: Message | Message[], notificationDisabled: boolean = false): Promise<MessageAPIResponseBase>
   broadcast(messages: Message | Message[], notificationDisabled: boolean = false): Promise<any>
   getMessageContent(messageId: string): Promise<Readable>
 
@@ -88,7 +88,7 @@ in [the Client guide](../guide/client.md).
 
 ### Message
 
-#### `pushMessage(to: string, messages: Message | Message[], notificationDisabled: boolean = false): Promise<MessageAPIBasicResponse>`
+#### `pushMessage(to: string, messages: Message | Message[], notificationDisabled: boolean = false): Promise<MessageAPIResponseBase>`
 
 It corresponds to the [Push message](https://developers.line.me/en/docs/messaging-api/reference/#send-push-message) API.
 
@@ -101,7 +101,7 @@ client.pushMessage('user_or_group_or_room_id', {
 })
 ```
 
-#### `replyMessage(replyToken: string, messages: Message | Message[], notificationDisabled: boolean = false): Promise<MessageAPIBasicResponse>`
+#### `replyMessage(replyToken: string, messages: Message | Message[], notificationDisabled: boolean = false): Promise<MessageAPIResponseBase>`
 
 It corresponds to the [Reply message](https://developers.line.me/en/docs/messaging-api/reference/#send-reply-message) API.
 
@@ -116,7 +116,7 @@ client.replyMessage(event.replyToken, {
 })
 ```
 
-#### `multicast(to: string[], messages: Message | Message[], notificationDisabled: boolean = false): Promise<MessageAPIBasicResponse>`
+#### `multicast(to: string[], messages: Message | Message[], notificationDisabled: boolean = false): Promise<MessageAPIResponseBase>`
 
 It corresponds to the [Multicast](https://developers.line.me/en/docs/messaging-api/reference/#send-multicast-messages) API.
 

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -74,7 +74,7 @@ export default class Client {
   public async broadcast(
     messages: Types.Message | Types.Message[],
     notificationDisabled: boolean = false,
-  ): Promise<any> {
+  ): Promise<Types.MessageAPIResponseBase> {
     return this.http.post("/message/broadcast", {
       messages: toArray(messages),
       notificationDisabled,

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -35,32 +35,12 @@ export default class Client {
     );
   }
 
-  private setLineRequestId(response: object, lineRequestId: string): boolean {
-    return Reflect.defineProperty(response, "getLineRequestId", {
-      enumerable: false,
-      value: (): string => {
-        return lineRequestId;
-      },
-    });
-  }
-
-  private async postMessagingAPI(
-    url: string,
-    body?: any,
-  ): Promise<Types.MessageAPIResponseBase> {
-    const res = await this.http.postJson(url, body);
-    // header names are lower-cased
-    // https://nodejs.org/api/http.html#http_message_headers
-    this.setLineRequestId(res.data, res.headers["x-line-request-id"]);
-    return res.data as Types.MessageAPIResponseBase;
-  }
-
   public pushMessage(
     to: string,
     messages: Types.Message | Types.Message[],
     notificationDisabled: boolean = false,
   ): Promise<Types.MessageAPIResponseBase> {
-    return this.postMessagingAPI("/message/push", {
+    return this.http.post("/message/push", {
       messages: toArray(messages),
       to,
       notificationDisabled,
@@ -72,7 +52,7 @@ export default class Client {
     messages: Types.Message | Types.Message[],
     notificationDisabled: boolean = false,
   ): Promise<Types.MessageAPIResponseBase> {
-    return this.postMessagingAPI("/message/reply", {
+    return this.http.post("/message/reply", {
       messages: toArray(messages),
       replyToken,
       notificationDisabled,
@@ -84,7 +64,7 @@ export default class Client {
     messages: Types.Message | Types.Message[],
     notificationDisabled: boolean = false,
   ): Promise<Types.MessageAPIResponseBase> {
-    return this.postMessagingAPI("/message/multicast", {
+    return this.http.post("/message/multicast", {
       messages: toArray(messages),
       to,
       notificationDisabled,

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -1,14 +1,23 @@
-import axios, { AxiosInstance, AxiosError } from "axios";
+import axios, { AxiosInstance, AxiosError, AxiosResponse } from "axios";
 import { Readable } from "stream";
 import { HTTPError, ReadError, RequestError } from "./exceptions";
 import * as fileType from "file-type";
 
 const pkg = require("../package.json");
 
+type httpClientConfig = {
+  baseURL?: string;
+  defaultHeaders?: any;
+  responseParser?: <T>(res: AxiosResponse) => T;
+};
+
 export default class HTTPClient {
   private instance: AxiosInstance;
+  private config: httpClientConfig;
 
-  constructor(baseURL?: string, defaultHeaders?: any) {
+  constructor(config: httpClientConfig = {}) {
+    this.config = config;
+    const { baseURL, defaultHeaders } = config;
     this.instance = axios.create({
       baseURL,
       headers: Object.assign({}, defaultHeaders, {
@@ -39,14 +48,10 @@ export default class HTTPClient {
     const res = await this.instance.post(url, body, {
       headers: { "Content-Type": "application/json" },
     });
-    let resBody = {
-      ...res.data,
-    };
-    if (res.headers["x-line-request-id"]) {
-      resBody["x-line-request-id"] = res.headers["x-line-request-id"];
-    }
 
-    return resBody;
+    const { responseParser } = this.config;
+    if (responseParser) return responseParser<T>(res);
+    else return res.data;
   }
 
   public async postBinary<T>(

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -1,5 +1,4 @@
 import axios, { AxiosInstance, AxiosError } from "axios";
-import { AxiosResponse } from "axios";
 import { Readable } from "stream";
 import { HTTPError, ReadError, RequestError } from "./exceptions";
 import * as fileType from "file-type";
@@ -36,15 +35,18 @@ export default class HTTPClient {
     return res.data as Readable;
   }
 
-  public postJson(url: string, body?: any): Promise<AxiosResponse> {
-    return this.instance.post(url, body, {
+  public async post<T>(url: string, body?: any): Promise<T> {
+    const res = await this.instance.post(url, body, {
       headers: { "Content-Type": "application/json" },
     });
-  }
+    let resBody = {
+      ...res.data,
+    };
+    if (res.headers["x-line-request-id"]) {
+      resBody["x-line-request-id"] = res.headers["x-line-request-id"];
+    }
 
-  public async post<T>(url: string, body?: any): Promise<T> {
-    const res = await this.postJson(url, body);
-    return res.data;
+    return resBody;
   }
 
   public async postBinary<T>(

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1802,5 +1802,5 @@ export type NumberOfSentBroadcastMessages = {
 };
 
 export type MessageAPIResponseBase = {
-  getLineRequestId: () => string;
+  "x-line-request-id"?: string;
 };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1801,6 +1801,7 @@ export type NumberOfSentBroadcastMessages = {
   success?: number;
 };
 
+export const LINE_REQUEST_ID_HTTP_HEADER_NAME = "x-line-request-id";
 export type MessageAPIResponseBase = {
-  "x-line-request-id"?: string;
+  [LINE_REQUEST_ID_HTTP_HEADER_NAME]?: string;
 };

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -53,8 +53,7 @@ describe("client", () => {
     equal(req.method, "POST");
     equal(req.body.replyToken, "test_reply_token");
     deepEqual(req.body.messages, [testMsg]);
-    deepEqual(res, {});
-    equal(res.getLineRequestId(), "X-Line-Request-Id");
+    equal(res["x-line-request-id"], "X-Line-Request-Id");
   });
 
   it("push", async () => {
@@ -65,8 +64,7 @@ describe("client", () => {
     equal(req.method, "POST");
     equal(req.body.to, "test_user_id");
     deepEqual(req.body.messages, [testMsg]);
-    deepEqual(res, {});
-    equal(res.getLineRequestId(), "X-Line-Request-Id");
+    equal(res["x-line-request-id"], "X-Line-Request-Id");
   });
 
   it("multicast", async () => {
@@ -82,8 +80,7 @@ describe("client", () => {
       "test_user_id_3",
     ]);
     deepEqual(req.body.messages, [testMsg, testMsg]);
-    deepEqual(res, {});
-    equal(res.getLineRequestId(), "X-Line-Request-Id");
+    equal(res["x-line-request-id"], "X-Line-Request-Id");
   });
 
   it("broadcast", async () => {
@@ -93,7 +90,6 @@ describe("client", () => {
     equal(req.path, "/message/broadcast");
     equal(req.method, "POST");
     deepEqual(req.body.messages, [testMsg, testMsg]);
-    deepEqual(res, {});
   });
 
   it("getProfile", async () => {
@@ -114,7 +110,6 @@ describe("client", () => {
     equal(req.headers.authorization, "Bearer test_channel_access_token");
     equal(req.path, "/group/test_group_id/member/test_user_id");
     equal(req.method, "GET");
-    deepEqual(res, {});
   });
 
   it("getRoomMemberProfile", async () => {
@@ -176,7 +171,6 @@ describe("client", () => {
     equal(req.method, "GET");
 
     const res = JSON.parse(data);
-    deepEqual(res, {});
   });
 
   it("leaveGroup", async () => {

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -110,6 +110,7 @@ describe("client", () => {
     equal(req.headers.authorization, "Bearer test_channel_access_token");
     equal(req.path, "/group/test_group_id/member/test_user_id");
     equal(req.method, "GET");
+    deepEqual(res, {});
   });
 
   it("getRoomMemberProfile", async () => {

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -90,6 +90,7 @@ describe("client", () => {
     equal(req.path, "/message/broadcast");
     equal(req.method, "POST");
     deepEqual(req.body.messages, [testMsg, testMsg]);
+    equal(res["x-line-request-id"], "X-Line-Request-Id");
   });
 
   it("getProfile", async () => {
@@ -172,6 +173,7 @@ describe("client", () => {
     equal(req.method, "GET");
 
     const res = JSON.parse(data);
+    deepEqual(res, {});
   });
 
   it("leaveGroup", async () => {

--- a/test/http.spec.ts
+++ b/test/http.spec.ts
@@ -14,8 +14,11 @@ const getRecentReq = (): any =>
   JSON.parse(readFileSync(join(__dirname, "helpers/request.json")).toString());
 
 describe("http", () => {
-  const http = new HTTPClient(`http://localhost:${TEST_PORT}`, {
-    "test-header-key": "Test-Header-Value",
+  const http = new HTTPClient({
+    baseURL: `http://localhost:${TEST_PORT}`,
+    defaultHeaders: {
+      "test-header-key": "Test-Header-Value",
+    },
   });
 
   before(() => listen(TEST_PORT));

--- a/test/http.spec.ts
+++ b/test/http.spec.ts
@@ -153,4 +153,14 @@ describe("http", () => {
       equal(err.code, "ENOTFOUND");
     }
   });
+
+  it("will generate default params", async () => {
+    const http = new HTTPClient();
+    const res = await http.get<any>(`http://localhost:${TEST_PORT}/get`);
+    const req = getRecentReq();
+    equal(req.method, "GET");
+    equal(req.path, "/get");
+    equal(req.headers["user-agent"], `${pkg.name}/${pkg.version}`);
+    deepEqual(res, {});
+  });
 });

--- a/test/middleware.spec.ts
+++ b/test/middleware.spec.ts
@@ -19,7 +19,11 @@ describe("middleware", () => {
     headers: any = {
       "X-Line-Signature": "wqJD7WAIZhWcXThMCf8jZnwG3Hmn7EF36plkQGkj48w=",
     },
-  ) => new HTTPClient(`http://localhost:${TEST_PORT}`, headers);
+  ) =>
+    new HTTPClient({
+      baseURL: `http://localhost:${TEST_PORT}`,
+      defaultHeaders: headers,
+    });
 
   before(() => listen(TEST_PORT, m));
   after(() => close());


### PR DESCRIPTION
As I've discussed with @kawasako sann, we've decided to maintain the plain object of the response of the message API.