### PR TITLE
TemplateImageColumn -> TemplateImageColumn[]

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -344,29 +344,29 @@ export type TextEventMessage = {
 
 export type ContentProvider<WithPreview extends boolean = true> =
   | {
-      /**
-       * The content is provided by LINE.
-       *
-       * The data itself can be retrieved from the content API.
-       */
-      type: "line";
-    }
+    /**
+     * The content is provided by LINE.
+     *
+     * The data itself can be retrieved from the content API.
+     */
+    type: "line";
+  }
   | {
-      /**
-       * The content is provided by a provider other than LINE
-       */
-      type: "external";
-      /**
-       * URL of the content. Only included when contentProvider.type is external.
-       */
-      originalContentUrl: string;
-      /**
-       * URL of the content preview. Only included when contentProvider.type is external.
-       *
-       * For contents without preview (e.g. audio), it's undefined.
-       */
-      previewImageUrl: WithPreview extends true ? string : undefined;
-    };
+    /**
+     * The content is provided by a provider other than LINE
+     */
+    type: "external";
+    /**
+     * URL of the content. Only included when contentProvider.type is external.
+     */
+    originalContentUrl: string;
+    /**
+     * URL of the content preview. Only included when contentProvider.type is external.
+     *
+     * For contents without preview (e.g. audio), it's undefined.
+     */
+    previewImageUrl: WithPreview extends true ? string : undefined;
+  };
 
 /**
  * Message object which contains the image content sent from the source.
@@ -1040,16 +1040,16 @@ export type FlexIcon = {
    * The default value is `md`.
    */
   size?:
-    | "xxs"
-    | "xs"
-    | "sm"
-    | "md"
-    | "lg"
-    | "xl"
-    | "xxl"
-    | "3xl"
-    | "4xl"
-    | "5xl";
+  | "xxs"
+  | "xs"
+  | "sm"
+  | "md"
+  | "lg"
+  | "xl"
+  | "xxl"
+  | "3xl"
+  | "4xl"
+  | "5xl";
   /**
    * Aspect ratio of the icon. The default value is `1:1`.
    */
@@ -1120,34 +1120,34 @@ export type FlexImage = {
    * The default value is `md`.
    */
   size?:
-    | "xxs"
-    | "xs"
-    | "sm"
-    | "md"
-    | "lg"
-    | "xl"
-    | "xxl"
-    | "3xl"
-    | "4xl"
-    | "5xl"
-    | "full";
+  | "xxs"
+  | "xs"
+  | "sm"
+  | "md"
+  | "lg"
+  | "xl"
+  | "xxl"
+  | "3xl"
+  | "4xl"
+  | "5xl"
+  | "full";
   /**
    * Aspect ratio of the image.
    * The default value is `1:1`.
    */
   aspectRatio?:
-    | "1:1"
-    | "1.51:1"
-    | "1.91:1"
-    | "4:3"
-    | "16:9"
-    | "20:13"
-    | "2:1"
-    | "3:1"
-    | "3:4"
-    | "9:16"
-    | "1:2"
-    | "1:3";
+  | "1:1"
+  | "1.51:1"
+  | "1.91:1"
+  | "4:3"
+  | "16:9"
+  | "20:13"
+  | "2:1"
+  | "3:1"
+  | "3:4"
+  | "9:16"
+  | "1:2"
+  | "1:3";
   /**
    * Style of the image. Specify one of the following values:
    *
@@ -1239,16 +1239,16 @@ export type FlexText = {
    * The default value is `md`.
    */
   size?:
-    | "xxs"
-    | "xs"
-    | "sm"
-    | "md"
-    | "lg"
-    | "xl"
-    | "xxl"
-    | "3xl"
-    | "4xl"
-    | "5xl";
+  | "xxs"
+  | "xs"
+  | "sm"
+  | "md"
+  | "lg"
+  | "xl"
+  | "xxl"
+  | "3xl"
+  | "4xl"
+  | "5xl";
   /**
    * Horizontal alignment style. Specify one of the following values:
    *

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -344,29 +344,29 @@ export type TextEventMessage = {
 
 export type ContentProvider<WithPreview extends boolean = true> =
   | {
-    /**
-     * The content is provided by LINE.
-     *
-     * The data itself can be retrieved from the content API.
-     */
-    type: "line";
-  }
+      /**
+       * The content is provided by LINE.
+       *
+       * The data itself can be retrieved from the content API.
+       */
+      type: "line";
+    }
   | {
-    /**
-     * The content is provided by a provider other than LINE
-     */
-    type: "external";
-    /**
-     * URL of the content. Only included when contentProvider.type is external.
-     */
-    originalContentUrl: string;
-    /**
-     * URL of the content preview. Only included when contentProvider.type is external.
-     *
-     * For contents without preview (e.g. audio), it's undefined.
-     */
-    previewImageUrl: WithPreview extends true ? string : undefined;
-  };
+      /**
+       * The content is provided by a provider other than LINE
+       */
+      type: "external";
+      /**
+       * URL of the content. Only included when contentProvider.type is external.
+       */
+      originalContentUrl: string;
+      /**
+       * URL of the content preview. Only included when contentProvider.type is external.
+       *
+       * For contents without preview (e.g. audio), it's undefined.
+       */
+      previewImageUrl: WithPreview extends true ? string : undefined;
+    };
 
 /**
  * Message object which contains the image content sent from the source.
@@ -1040,16 +1040,16 @@ export type FlexIcon = {
    * The default value is `md`.
    */
   size?:
-  | "xxs"
-  | "xs"
-  | "sm"
-  | "md"
-  | "lg"
-  | "xl"
-  | "xxl"
-  | "3xl"
-  | "4xl"
-  | "5xl";
+    | "xxs"
+    | "xs"
+    | "sm"
+    | "md"
+    | "lg"
+    | "xl"
+    | "xxl"
+    | "3xl"
+    | "4xl"
+    | "5xl";
   /**
    * Aspect ratio of the icon. The default value is `1:1`.
    */
@@ -1120,34 +1120,34 @@ export type FlexImage = {
    * The default value is `md`.
    */
   size?:
-  | "xxs"
-  | "xs"
-  | "sm"
-  | "md"
-  | "lg"
-  | "xl"
-  | "xxl"
-  | "3xl"
-  | "4xl"
-  | "5xl"
-  | "full";
+    | "xxs"
+    | "xs"
+    | "sm"
+    | "md"
+    | "lg"
+    | "xl"
+    | "xxl"
+    | "3xl"
+    | "4xl"
+    | "5xl"
+    | "full";
   /**
    * Aspect ratio of the image.
    * The default value is `1:1`.
    */
   aspectRatio?:
-  | "1:1"
-  | "1.51:1"
-  | "1.91:1"
-  | "4:3"
-  | "16:9"
-  | "20:13"
-  | "2:1"
-  | "3:1"
-  | "3:4"
-  | "9:16"
-  | "1:2"
-  | "1:3";
+    | "1:1"
+    | "1.51:1"
+    | "1.91:1"
+    | "4:3"
+    | "16:9"
+    | "20:13"
+    | "2:1"
+    | "3:1"
+    | "3:4"
+    | "9:16"
+    | "1:2"
+    | "1:3";
   /**
    * Style of the image. Specify one of the following values:
    *
@@ -1239,16 +1239,16 @@ export type FlexText = {
    * The default value is `md`.
    */
   size?:
-  | "xxs"
-  | "xs"
-  | "sm"
-  | "md"
-  | "lg"
-  | "xl"
-  | "xxl"
-  | "3xl"
-  | "4xl"
-  | "5xl";
+    | "xxs"
+    | "xs"
+    | "sm"
+    | "md"
+    | "lg"
+    | "xl"
+    | "xxl"
+    | "3xl"
+    | "4xl"
+    | "5xl";
   /**
    * Horizontal alignment style. Specify one of the following values:
    *

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -344,29 +344,29 @@ export type TextEventMessage = {
 
 export type ContentProvider<WithPreview extends boolean = true> =
   | {
-      /**
-       * The content is provided by LINE.
-       *
-       * The data itself can be retrieved from the content API.
-       */
-      type: "line";
-    }
+    /**
+     * The content is provided by LINE.
+     *
+     * The data itself can be retrieved from the content API.
+     */
+    type: "line";
+  }
   | {
-      /**
-       * The content is provided by a provider other than LINE
-       */
-      type: "external";
-      /**
-       * URL of the content. Only included when contentProvider.type is external.
-       */
-      originalContentUrl: string;
-      /**
-       * URL of the content preview. Only included when contentProvider.type is external.
-       *
-       * For contents without preview (e.g. audio), it's undefined.
-       */
-      previewImageUrl: WithPreview extends true ? string : undefined;
-    };
+    /**
+     * The content is provided by a provider other than LINE
+     */
+    type: "external";
+    /**
+     * URL of the content. Only included when contentProvider.type is external.
+     */
+    originalContentUrl: string;
+    /**
+     * URL of the content preview. Only included when contentProvider.type is external.
+     *
+     * For contents without preview (e.g. audio), it's undefined.
+     */
+    previewImageUrl: WithPreview extends true ? string : undefined;
+  };
 
 /**
  * Message object which contains the image content sent from the source.
@@ -1040,16 +1040,16 @@ export type FlexIcon = {
    * The default value is `md`.
    */
   size?:
-    | "xxs"
-    | "xs"
-    | "sm"
-    | "md"
-    | "lg"
-    | "xl"
-    | "xxl"
-    | "3xl"
-    | "4xl"
-    | "5xl";
+  | "xxs"
+  | "xs"
+  | "sm"
+  | "md"
+  | "lg"
+  | "xl"
+  | "xxl"
+  | "3xl"
+  | "4xl"
+  | "5xl";
   /**
    * Aspect ratio of the icon. The default value is `1:1`.
    */
@@ -1120,34 +1120,34 @@ export type FlexImage = {
    * The default value is `md`.
    */
   size?:
-    | "xxs"
-    | "xs"
-    | "sm"
-    | "md"
-    | "lg"
-    | "xl"
-    | "xxl"
-    | "3xl"
-    | "4xl"
-    | "5xl"
-    | "full";
+  | "xxs"
+  | "xs"
+  | "sm"
+  | "md"
+  | "lg"
+  | "xl"
+  | "xxl"
+  | "3xl"
+  | "4xl"
+  | "5xl"
+  | "full";
   /**
    * Aspect ratio of the image.
    * The default value is `1:1`.
    */
   aspectRatio?:
-    | "1:1"
-    | "1.51:1"
-    | "1.91:1"
-    | "4:3"
-    | "16:9"
-    | "20:13"
-    | "2:1"
-    | "3:1"
-    | "3:4"
-    | "9:16"
-    | "1:2"
-    | "1:3";
+  | "1:1"
+  | "1.51:1"
+  | "1.91:1"
+  | "4:3"
+  | "16:9"
+  | "20:13"
+  | "2:1"
+  | "3:1"
+  | "3:4"
+  | "9:16"
+  | "1:2"
+  | "1:3";
   /**
    * Style of the image. Specify one of the following values:
    *
@@ -1239,16 +1239,16 @@ export type FlexText = {
    * The default value is `md`.
    */
   size?:
-    | "xxs"
-    | "xs"
-    | "sm"
-    | "md"
-    | "lg"
-    | "xl"
-    | "xxl"
-    | "3xl"
-    | "4xl"
-    | "5xl";
+  | "xxs"
+  | "xs"
+  | "sm"
+  | "md"
+  | "lg"
+  | "xl"
+  | "xxl"
+  | "3xl"
+  | "4xl"
+  | "5xl";
   /**
    * Horizontal alignment style. Specify one of the following values:
    *
@@ -1479,7 +1479,7 @@ export type TemplateImageCarousel = {
   /**
    * Array of columns (Max: 10)
    */
-  columns: TemplateImageColumn;
+  columns: TemplateImageColumn[];
 };
 
 export type TemplateImageColumn = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@line/bot-sdk",
-  "version": "6.8.0",
+  "version": "6.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6807,8 +6807,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6829,14 +6828,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6851,20 +6848,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6981,8 +6975,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6994,7 +6987,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7009,7 +7001,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7017,14 +7008,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7043,7 +7032,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7124,8 +7112,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7137,7 +7124,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7223,8 +7209,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7260,7 +7245,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7280,7 +7264,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7324,14 +7307,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },


### PR DESCRIPTION
```
const message: line.TemplateMessage = {
  "type": "template",
  "altText": "this is a image carousel template",
  "template": <line.TemplateImageCarousel>{
      "type": "image_carousel",
     // type error below columns property
      "columns": [
          {
            "imageUrl": "https://example.com/bot/images/item1.jpg",
            "action": {
              "type": "postback",
              "label": "Buy",
              "data": "action=buy&itemid=111"
            }
          },
          {
            "imageUrl": "https://example.com/bot/images/item2.jpg",
            "action": {
              "type": "message",
              "label": "Yes",
              "text": "yes"
            }
          },
          {
            "imageUrl": "https://example.com/bot/images/item3.jpg",
            "action": {
              "type": "uri",
              "label": "View detail",
              "uri": "http://example.com/page/222"
            }
          }
      ]
  }
}
```

columns in <line.TemplateImageCarousel> must be array, but it is not array in library.
so I fixed it.

thanks.