### PR TITLE
fix: fix typo in type name FriendDemographics

### DIFF
--- a/docs/api-reference/client.md
+++ b/docs/api-reference/client.md
@@ -61,7 +61,7 @@ class Client {
   // Insight
   getNumberOfMessageDeliveries(date: string): Promise<Types.NumberOfMessageDeliveriesResponse>
   getNumberOfFollowers(date: string): Promise<Types.NumberOfFollowersResponse>
-  getFriendDemographics(): Promise<Types.FriendDemoGraphics>
+  getFriendDemographics(): Promise<Types.FriendDemographics>
 }
 ```
 
@@ -515,6 +515,6 @@ It corresponds to the [Get number of message deliveries](https://developers.line
 It corresponds to the [Get number of followers](https://developers.line.biz/en/reference/messaging-api/#get-number-of-followers) API.
 
 
-#### `getFriendDemographics(): Promise<Types.FriendDemoGraphics>`
+#### `getFriendDemographics(): Promise<Types.FriendDemographics>`
 
 It corresponds to the [Get friend demographics](https://developers.line.biz/en/reference/messaging-api/#get-demographic) API.

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -335,8 +335,8 @@ export default class Client {
     return ensureJSON(res);
   }
 
-  public async getFriendDemographics(): Promise<Types.FriendDemoGraphics> {
-    const res = await this.http.get<Types.FriendDemoGraphics>(
+  public async getFriendDemographics(): Promise<Types.FriendDemographics> {
+    const res = await this.http.get<Types.FriendDemographics>(
       `/insight/demographic`,
     );
     return ensureJSON(res);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2022,7 +2022,7 @@ type PercentageAble = {
   percentage: number;
 };
 
-export type FriendDemoGraphics = {
+export type FriendDemographics = {
   /**
    * `true` if friend demographic information is available.
    */


### PR DESCRIPTION
I think it's a typo to spell `FriendDemoGraphic`, so I changed that to `FriendDemographics`.
Type introduced in #161 .