### PR TITLE
add missing label property to ImageMapActionBase type

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -712,6 +712,11 @@ export type FlexMessage = MessageCommon & {
 export type ImageMapAction = ImageMapURIAction | ImageMapMessageAction;
 
 export type ImageMapActionBase = {
+  /**
+   * Spoken when the accessibility feature is enabled on the client device. (Max: 50 characters)
+   * Supported on LINE 8.2.0 and later for iOS.
+   */
+  label?: string;
   /** Defined tappable area */
   area: Area;
 };


### PR DESCRIPTION
Add optional `label` property that list on official documentations:

<img width="724" alt="螢幕快照 2019-12-13 下午7 06 06" src="https://user-images.githubusercontent.com/3382565/70795824-aca8ac00-1ddb-11ea-9fea-d60d855cc233.png">
<img width="724" alt="螢幕快照 2019-12-13 下午7 06 16" src="https://user-images.githubusercontent.com/3382565/70795827-ad414280-1ddb-11ea-94ef-156533dcd7a1.png">
