### PR TITLE
Support Channel access token 2.1 Key IDs

### DIFF
--- a/docs/api-reference/oauth.md
+++ b/docs/api-reference/oauth.md
@@ -14,9 +14,9 @@ class OAuth {
   issueChannelAccessTokenV2_1(
     client_assertion: string,
   ): Promise<Types.ChannelAccessToken>
-  getIssuedChannelAccessTokenV2_1(
+  getChannelAccessTokenKeyIdsV2_1(
     client_assertion: string,
-  ): Promise<{ access_tokens: string[] }>
+  ): Promise<{ key_ids: string[] }>
   revokeChannelAccessTokenV2_1(
     client_id: string,
     client_secret: string,
@@ -66,7 +66,6 @@ It corresponds to the [Issue channel access token](https://developers.line.biz/e
 const { access_token, expires_in, token_type } = await oauth.issueAccessToken("client_id", "client_secret");
 ```
 
-
 #### `revokeAccessToken(access_token: string): Promise<{}>`
 
 It corresponds to the [Revoke channel access token](https://developers.line.biz/en/reference/messaging-api/#revoke-channel-access-token) API.
@@ -76,14 +75,13 @@ It corresponds to the [Revoke channel access token](https://developers.line.biz/
 await oauth.revokeAccessToken("access_token");
 ```
 
-
 #### issueChannelAccessTokenV2_1(client_assertion: string): Promise<Types.ChannelAccessToken>
 
 It corresponds to the [Issue channel access token v2.1](https://developers.line.biz/en/reference/messaging-api/#issue-channel-access-token-v2-1) API.
 
-#### getIssuedChannelAccessTokenV2_1(client_assertion: string): Promise<{ access_tokens: string[] }>
+#### getChannelAccessTokenKeyIdsV2_1(client_assertion: string): Promise<{ key_ids: string[] }>
 
-It corresponds to the [Get Issued channel access token v2.1](https://developers.line.biz/en/reference/messaging-api/#get-issued-channel-access-tokens-v2-1) API.
+It corresponds to the [Get all valid channel access token key IDs v2.1](https://developers.line.biz/en/reference/messaging-api/#get-all-issued-channel-access-token-key-ids-v2-1) API.
 
 #### revokeChannelAccessTokenV2_1(client_id: string, client_secret: string, access_token: string): Promise<{}>
 

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -627,10 +627,10 @@ export class OAuth {
     });
   }
 
-  public getIssuedChannelAccessTokenV2_1(
+  public getChannelAccessTokenKeyIdsV2_1(
     client_assertion: string,
-  ): Promise<{ access_tokens: string[] }> {
-    return this.http.get(`${OAUTH_BASE_PREFIX_V2_1}/tokens`, {
+  ): Promise<{ key_ids: string[] }> {
+    return this.http.get(`${OAUTH_BASE_PREFIX_V2_1}/tokens/kid`, {
       client_assertion_type:
         "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
       client_assertion,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2430,6 +2430,7 @@ export type ChannelAccessToken = {
   access_token: string;
   expires_in: number;
   token_type: "Bearer";
+  key_id?: string;
 };
 
 /**

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -902,12 +902,6 @@ describe("oauth", () => {
   afterEach(() => nock.cleanAll());
   after(() => nock.enableNetConnect());
 
-  const accessTokenReply = {
-    access_token: "access_token",
-    expires_in: 2592000,
-    token_type: "Bearer",
-  };
-
   const interceptionOption = {
     reqheaders: {
       "content-type": "application/x-www-form-urlencoded",
@@ -916,19 +910,25 @@ describe("oauth", () => {
   };
 
   it("issueAccessToken", async () => {
-    const client_id = "test_client_id",
-      client_secret = "test_client_secret";
+    const client_id = "test_client_id";
+    const client_secret = "test_client_secret";
+    const reply = {
+      access_token: "access_token",
+      expires_in: 2592000,
+      token_type: "Bearer",
+    };
+
     const scope = nock(OAUTH_BASE_PREFIX, interceptionOption)
       .post("/accessToken", {
         grant_type: "client_credentials",
         client_id,
         client_secret,
       })
-      .reply(200, accessTokenReply);
+      .reply(200, reply);
 
     const res = await oauth.issueAccessToken(client_id, client_secret);
     equal(scope.isDone(), true);
-    deepEqual(res, accessTokenReply);
+    deepEqual(res, reply);
   });
 
   it("revokeAccessToken", async () => {
@@ -944,6 +944,12 @@ describe("oauth", () => {
 
   it("issueChannelAccessTokenV2_1", async () => {
     const client_assertion = "client_assertion";
+    const reply = {
+      access_token: "access_token",
+      expires_in: 2592000,
+      token_type: "Bearer",
+      key_id: "key_id",
+    };
 
     const scope = nock(OAUTH_BASE_PREFIX_V2_1, interceptionOption)
       .post("/token", {
@@ -952,31 +958,31 @@ describe("oauth", () => {
           "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
         client_assertion,
       })
-      .reply(200, accessTokenReply);
+      .reply(200, reply);
 
     const res = await oauth.issueChannelAccessTokenV2_1(client_assertion);
     equal(scope.isDone(), true);
-    deepEqual(res, accessTokenReply);
+    deepEqual(res, reply);
   });
 
-  it("getIssuedChannelAccessTokenV2_1", async () => {
+  it("getChannelAccessTokenKeyIdsV2_1", async () => {
     const client_assertion = "client_assertion";
-    const accessTokenReply = {
-      access_tokens: ["test_access_tokens"],
+    const reply = {
+      key_ids: ["key_id"],
     };
 
     const scope = nock(OAUTH_BASE_PREFIX_V2_1)
-      .get("/tokens")
+      .get("/tokens/kid")
       .query({
         client_assertion_type:
           "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
         client_assertion,
       })
-      .reply(200, accessTokenReply);
+      .reply(200, reply);
 
-    const res = await oauth.getIssuedChannelAccessTokenV2_1(client_assertion);
+    const res = await oauth.getChannelAccessTokenKeyIdsV2_1(client_assertion);
     equal(scope.isDone(), true);
-    deepEqual(res, accessTokenReply);
+    deepEqual(res, reply);
   });
 
   it("revokeChannelAccessTokenV2_1", async () => {


### PR DESCRIPTION
https://developers.line.biz/en/news/2020/06/22/new-channel-access-token-endpoint-and-deprecation/

related: #223, #210 

Closes #232 