### PR TITLE
Add v2.1 OAuth endpoint constant

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -13,6 +13,7 @@ import {
   MESSAGING_API_PREFIX,
   DATA_API_PREFIX,
   OAUTH_BASE_PREFIX,
+  OAUTH_BASE_PREFIX_V2_1,
 } from "./endpoints";
 
 export default class Client {
@@ -618,7 +619,7 @@ export class OAuth {
   public issueChannelAccessTokenV2_1(
     client_assertion: string,
   ): Promise<Types.ChannelAccessToken> {
-    return this.http.postForm(`${OAUTH_BASE_PREFIX}/v2.1/token`, {
+    return this.http.postForm(`${OAUTH_BASE_PREFIX_V2_1}/token`, {
       grant_type: "client_credentials",
       client_assertion_type:
         "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
@@ -629,7 +630,7 @@ export class OAuth {
   public getIssuedChannelAccessTokenV2_1(
     client_assertion: string,
   ): Promise<{ access_tokens: string[] }> {
-    return this.http.get(`${OAUTH_BASE_PREFIX}/v2.1/tokens`, {
+    return this.http.get(`${OAUTH_BASE_PREFIX_V2_1}/tokens`, {
       client_assertion_type:
         "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
       client_assertion,
@@ -641,7 +642,7 @@ export class OAuth {
     client_secret: string,
     access_token: string,
   ): Promise<{}> {
-    return this.http.postForm(`${OAUTH_BASE_PREFIX}/v2.1/revoke`, {
+    return this.http.postForm(`${OAUTH_BASE_PREFIX_V2_1}/revoke`, {
       client_id,
       client_secret,
       access_token,

--- a/lib/endpoints.ts
+++ b/lib/endpoints.ts
@@ -1,3 +1,4 @@
 export const MESSAGING_API_PREFIX = `https://api.line.me/v2/bot`;
 export const DATA_API_PREFIX = `https://api-data.line.me/v2/bot`;
 export const OAUTH_BASE_PREFIX = `https://api.line.me/v2/oauth`;
+export const OAUTH_BASE_PREFIX_V2_1 = `https://api.line.me/oauth2/v2.1`;

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -9,6 +9,7 @@ import * as nock from "nock";
 import {
   MESSAGING_API_PREFIX,
   OAUTH_BASE_PREFIX,
+  OAUTH_BASE_PREFIX_V2_1,
   DATA_API_PREFIX,
 } from "../lib/endpoints";
 
@@ -944,8 +945,8 @@ describe("oauth", () => {
   it("issueChannelAccessTokenV2_1", async () => {
     const client_assertion = "client_assertion";
 
-    const scope = nock(OAUTH_BASE_PREFIX, interceptionOption)
-      .post("/v2.1/token", {
+    const scope = nock(OAUTH_BASE_PREFIX_V2_1, interceptionOption)
+      .post("/token", {
         grant_type: "client_credentials",
         client_assertion_type:
           "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
@@ -964,8 +965,8 @@ describe("oauth", () => {
       access_tokens: ["test_access_tokens"],
     };
 
-    const scope = nock(OAUTH_BASE_PREFIX)
-      .get("/v2.1/tokens")
+    const scope = nock(OAUTH_BASE_PREFIX_V2_1)
+      .get("/tokens")
       .query({
         client_assertion_type:
           "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
@@ -982,8 +983,8 @@ describe("oauth", () => {
     const client_id = "test_client_id",
       client_secret = "test_client_secret",
       access_token = "test_channel_access_token";
-    const scope = nock(OAUTH_BASE_PREFIX, interceptionOption)
-      .post("/v2.1/revoke", { client_id, client_secret, access_token })
+    const scope = nock(OAUTH_BASE_PREFIX_V2_1, interceptionOption)
+      .post("/revoke", { client_id, client_secret, access_token })
       .reply(200, {});
 
     const res = await oauth.revokeChannelAccessTokenV2_1(


### PR DESCRIPTION
Currently, this SDK uses `https://api.line.me/v2/oauth/v2.1/` for OAuth v2.1 APIs, but according to the [documentation](https://developers.line.biz/en/reference/messaging-api/#issue-channel-access-token-v2-1), it should be `https://api.line.me/oauth2/v2.1` instead. 