### PR TITLE
Accept label in richmenu area actions

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1961,7 +1961,7 @@ export type RichMenu = {
    * which define the coordinates and size of tappable areas
    * (Max: 20 area objects)
    */
-  areas: Array<{ bounds: Area; action: Action<{}> }>;
+  areas: Array<{ bounds: Area; action: Action<{ label?: string }> }>;
 };
 
 export type RichMenuResponse = { richMenuId: string } & RichMenu;


### PR DESCRIPTION
Postback action object has a `label` property which is optional for rich menus.

https://developers.line.biz/en/reference/messaging-api/#postback-action

> Optional for rich menus. Spoken when the accessibility feature is enabled on the client device. Max character limit: 20. Supported on LINE 8.2.0 or later for iOS.