### PR TITLE
Add UpToRemainingQuota parameter to narrowcast API

### DIFF
--- a/docs/api-reference/client.md
+++ b/docs/api-reference/client.md
@@ -25,6 +25,7 @@ class Client {
     recipient?: ReceieptObject,
     filter?: { demographic: DemographicFilterObject },
     limit?: { max?: number, upToRemainingQuota?: boolean },
+    notificationDisabled?: boolean,
   ): Promise<MessageAPIResponseBase>
   broadcast(messages: Message | Message[], notificationDisabled: boolean = false): Promise<MessageAPIResponseBase>
   getMessageContent(messageId: string): Promise<Readable>

--- a/docs/api-reference/client.md
+++ b/docs/api-reference/client.md
@@ -24,7 +24,7 @@ class Client {
     messages: Message | Message[],
     recipient?: ReceieptObject,
     filter?: { demographic: DemographicFilterObject },
-    limit?: { max: number },
+    limit?: { max?: number, upToRemainingQuota?: boolean },
   ): Promise<MessageAPIResponseBase>
   broadcast(messages: Message | Message[], notificationDisabled: boolean = false): Promise<MessageAPIResponseBase>
   getMessageContent(messageId: string): Promise<Readable>
@@ -162,7 +162,7 @@ interface ClientConfig {
 
 ## Common Specifications
 
-Regarding to things like [Retrying an API request](https://developers.line.biz/en/reference/messaging-api/#retry-api-request), there's an API called `setRequestOptionOnce`. 
+Regarding to things like [Retrying an API request](https://developers.line.biz/en/reference/messaging-api/#retry-api-request), there's an API called `setRequestOptionOnce`.
 When you call this first and call the API support that request option, then it will be set to that request and will be cleared automatically.
 
 ## Methods

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -111,7 +111,7 @@ export default class Client {
     messages: Types.Message | Types.Message[],
     recipient?: Types.ReceieptObject,
     filter?: { demographic: Types.DemographicFilterObject },
-    limit?: { max: number },
+    limit?: { max?: number, upToRemainingQuota?: boolean },
     notificationDisabled: boolean = false,
   ): Promise<Types.MessageAPIResponseBase> {
     return this.http.post(

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -112,7 +112,7 @@ export default class Client {
     recipient?: Types.ReceieptObject,
     filter?: { demographic: Types.DemographicFilterObject },
     limit?: { max?: number, upToRemainingQuota?: boolean },
-    notificationDisabled: boolean = false,
+    notificationDisabled?: boolean,
   ): Promise<Types.MessageAPIResponseBase> {
     return this.http.post(
       `${MESSAGING_API_PREFIX}/message/narrowcast`,

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -242,7 +242,6 @@ describe("client", () => {
       recipient,
       filter,
       limit,
-      notificationDisabled: false,
     });
 
     const res = await client.narrowcast(


### PR DESCRIPTION
Closes #247

Also, [according to the documentation](https://developers.line.biz/en/reference/messaging-api/#send-narrowcast-message), `notificationDisabled` is optional, and I corrected in this PR as well.