### PR TITLE
Add keywords to Sticker event

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -480,6 +480,7 @@ export type StickerEventMessage = {
     | "POPUP"
     | "POPUP_SOUND"
     | "NAME_TEXT";
+  keywords: string[];
 } & EventMessageBase;
 
 export type Postback = {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -479,7 +479,8 @@ export type StickerEventMessage = {
     | "ANIMATION_SOUND"
     | "POPUP"
     | "POPUP_SOUND"
-    | "NAME_TEXT";
+    | "NAME_TEXT"
+    | "PER_STICKER_TEXT";
   keywords: string[];
 } & EventMessageBase;
 


### PR DESCRIPTION
This closes #266. I also noticed that there's a missing `stickerResourceType` so I added in a seperate commit.