### PR TITLE
add richmenu alias api[issue 290]

### DIFF
--- a/docs/api-reference/client.md
+++ b/docs/api-reference/client.md
@@ -50,6 +50,11 @@ class Client {
   getRichMenu(richMenuId: string): Promise<RichMenuResponse>
   createRichMenu(richMenu: RichMenu): Promise<string>
   deleteRichMenu(richMenuId: string): Promise<any>
+  getRichMenuAliasList(): Promise<any>
+  getRichMenuAlias(richMenuAliasId: string): Promise<any>
+  createRichMenuAlias(richMenuId: string, richMenuAliasId: string): Promise<any>
+  deleteRichMenuAlias(richMenuAliasId: string): Promise<any>
+  updateRichMenuAlias(richMenuAliasId: string, richMenuId: string): Promise<any>
   getRichMenuIdOfUser(userId: string): Promise<string>
   linkRichMenuToUser(userId: string, richMenuId: string): Promise<any>
   unlinkRichMenuFromUser(userId: string, richMenuId: string): Promise<any>
@@ -465,6 +470,54 @@ The argument is a rich menu ID.
 
 ``` js
 client.deleteRichMenu('rich_menu_id')
+```
+
+#### `getRichMenuAliasList(): Promise<any>`
+
+It corresponds to the [Get list of rich menu alias](https://developers.line.biz/en/reference/messaging-api/#get-rich-menu-alias-list) API.
+
+``` js
+client.getRichMenuAliasList()
+```
+
+#### `getRichMenuAlias(richMenuAliasId: string): Promise<any>`
+
+It corresponds to the [Get rich menu alias information](https://developers.line.biz/en/reference/messaging-api/#get-rich-menu-alias-by-id) API.
+
+The argument is a rich menu alias ID.
+
+``` js
+client.getRichMenuAlias('rich_menu_alias_id')
+```
+
+#### `createRichMenuAlias(richMenuId: string, richMenuAliasId: string): Promise<any>`
+
+It corresponds to the [Create rich menu alias](https://developers.line.biz/en/reference/messaging-api/#create-rich-menu-alias) API.
+
+The argument is a rich menu ID and a rich menu alias ID.
+
+``` js
+client.createRichMenuAlias('rich_menu_id', 'rich_menu_alias_id')
+```
+
+#### `deleteRichMenuAlias(richMenuAliasId: string): Promise<any>`
+
+It corresponds to the [Delete rich menu alias](https://developers.line.biz/en/reference/messaging-api/#delete-rich-menu-alias) API.
+
+The argument is a rich menu alias ID.
+
+``` js
+client.deleteRichMenuAlias('rich_menu_alias_id')
+```
+
+#### `updateRichMenuAlias(richMenuAliasId: string, richMenuId: string): Promise<any>`
+
+It corresponds to the [Update rich menu alias](https://developers.line.biz/en/reference/messaging-api/#update-rich-menu-alias) API.
+
+The argument is a rich menu alias ID and a rich menu ID.
+
+``` js
+client.updateRichMenuAlias('rich_menu_alias_id', 'rich_menu_id')
 ```
 
 #### `getRichMenuIdOfUser(userId: string): Promise<string>`

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -268,6 +268,55 @@ export default class Client {
     return this.http.delete(`${MESSAGING_API_PREFIX}/richmenu/${richMenuId}`);
   }
 
+  public async getRichMenuAliasList(): Promise<any> {
+    const res = await this.http.get<any>(
+      `${MESSAGING_API_PREFIX}/richmenu/alias/list`,
+    );
+    return ensureJSON(res);
+  }
+
+  public async getRichMenuAlias(
+    richMenuAliasId: string,
+  ): Promise<any> {
+    const res = await this.http.get<any>(
+      `${MESSAGING_API_PREFIX}/richmenu/alias/${richMenuAliasId}`,
+    );
+    return ensureJSON(res);
+  }
+
+  public async createRichMenuAlias(
+    richMenuId: string,
+    richMenuAliasId: string,
+  ): Promise<any> {
+    const res = await this.http.post<any>(
+      `${MESSAGING_API_PREFIX}/richmenu/alias`,
+      {
+        richMenuId,
+        richMenuAliasId,
+      },
+    );
+    return ensureJSON(res);
+  }
+
+  public async deleteRichMenuAlias(richMenuAliasId: string): Promise<any> {
+    return this.http.delete(
+      `${MESSAGING_API_PREFIX}/richmenu/alias/${richMenuAliasId}`,
+    );
+  }
+
+  public async updateRichMenuAlias(
+    richMenuAliasId: string,
+    richMenuId: string,
+  ): Promise<any> {
+    const res = await this.http.put<{}>(
+      `${MESSAGING_API_PREFIX}/richmenu/alias/${richMenuAliasId}`,
+      {
+        richMenuId,
+      },
+    );
+    return ensureJSON(res);
+  }
+
   public async getRichMenuIdOfUser(userId: string): Promise<string> {
     const res = await this.http.get<any>(
       `${MESSAGING_API_PREFIX}/user/${userId}/richmenu`,

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -455,6 +455,60 @@ describe("client", () => {
     deepEqual(res, {});
   });
 
+  it("getRichMenuAliasList", async () => {
+    const scope = mockGet(MESSAGING_API_PREFIX, "/richmenu/alias/list");
+    const res = await client.getRichMenuAliasList();
+    equal(scope.isDone(), true);
+    deepEqual(res, {});
+  });
+
+  it("getRichMenuAlias", async () => {
+    const richMenuAliasId = "test_rich_menu_alias_id";
+    const scope = mockGet(
+      MESSAGING_API_PREFIX,
+      `/richmenu/alias/${richMenuAliasId}`,
+    );
+    const res = await client.getRichMenuAlias(richMenuAliasId);
+    equal(scope.isDone(), true);
+    deepEqual(res, {});
+  });
+
+  it("createRichMenuAlias", async () => {
+    const richMenuId = "test_rich_menu_id";
+    const richMenuAliasId = "test_rich_menu_alias_id";
+    const scope = mockPost(MESSAGING_API_PREFIX, "/richmenu/alias", {
+      richMenuId,
+      richMenuAliasId,
+    });
+    await client.createRichMenuAlias(richMenuId, richMenuAliasId);
+
+    equal(scope.isDone(), true);
+  });
+
+  it("deleteRichMenuAlias", async () => {
+    const scope = mockDelete(
+      MESSAGING_API_PREFIX,
+      "/richmenu/alias/test_rich_menu_alias_id",
+    );
+    const res = await client.deleteRichMenuAlias("test_rich_menu_alias_id");
+    equal(scope.isDone(), true);
+    deepEqual(res, {});
+  });
+
+  it("updateRichMenuAlias", async () => {
+    const richMenuId = "test_rich_menu_id";
+    const richMenuAliasId = "test_rich_menu_alias_id";
+    const scope = mockPut(
+      MESSAGING_API_PREFIX,
+      "/richmenu/alias/test_rich_menu_alias_id",
+      { richMenuId },
+    );
+
+    const res = await client.updateRichMenuAlias(richMenuAliasId, richMenuId);
+    equal(scope.isDone(), true);
+    deepEqual(res, {});
+  });
+
   it("getRichMenuIdOfUser", async () => {
     const scope = mockGet(MESSAGING_API_PREFIX, "/user/test_user_id/richmenu");
     await client.getRichMenuIdOfUser("test_user_id");


### PR DESCRIPTION
support https://github.com/line/line-bot-sdk-nodejs/issues/290

support new 5 apis. richmenu alias create/delete/update/get, and richmenu alias lists