### PR TITLE
Add Emojis in text messages

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -292,9 +292,7 @@ export default class Client {
     return ensureJSON(res);
   }
 
-  public async getRichMenuAlias(
-    richMenuAliasId: string,
-  ): Promise<any> {
+  public async getRichMenuAlias(richMenuAliasId: string): Promise<any> {
     const res = await this.http.get<any>(
       `${MESSAGING_API_PREFIX}/richmenu/alias/${richMenuAliasId}`,
     );

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -577,13 +577,25 @@ export type TextMessage = MessageCommon & {
   /**
    * Message text. You can include the following emoji:
    *
+   * - LINE emojis. Use a $ character as a placeholder and specify the product ID and emoji ID of the LINE emoji you want to use in the emojis property.
    * - Unicode emoji
-   * - LINE original emoji
+   * - (Deprecated) LINE original unicode emojis
    *   ([Unicode codepoint table for LINE original emoji](https://developers.line.biz/media/messaging-api/emoji-list.pdf))
    *
-   * Max: 2000 characters
+   * Max: 5000 characters
    */
   text: string;
+
+  /**
+   * One or more LINE emoji.
+   *
+   * Max: 20 LINE emoji
+   */
+     emojis?: {
+      index: number;
+      productId: string;
+      emojiId: string;
+    }[];
 };
 
 /**

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -591,11 +591,11 @@ export type TextMessage = MessageCommon & {
    *
    * Max: 20 LINE emoji
    */
-     emojis?: {
-      index: number;
-      productId: string;
-      emojiId: string;
-    }[];
+  emojis?: {
+    index: number;
+    productId: string;
+    emojiId: string;
+  }[];
 };
 
 /**
@@ -2100,7 +2100,7 @@ export type Size = {
  * When a control associated with this action is tapped, the URI specified in
  * the `uri` property is opened.
  */
- export type RichMenuSwitchAction = {
+export type RichMenuSwitchAction = {
   type: "richmenuswitch";
   /**
    * Action label. Optional for rich menus. Read when the user's device accessibility feature is enabled.
@@ -2115,7 +2115,7 @@ export type Size = {
    * String returned by the postback.data property of the postback event via a webhook
    * Max character limit: 300
    */
-   data: string;
+  data: string;
 };
 
 /**


### PR DESCRIPTION
I found my original implementation #214 (Issue: #211) was incomplete, which didn't add emojis to `TextMessage` but Webhooks event instead (accidentally solved #219 though).

This PR fixes the missing emojis in TextMessage, and also fixes few code formatting issues by `npm run format`.

Sorry for the trouble!