### PR TITLE
Fix http method of updateRichMenuAlias

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -326,7 +326,7 @@ export default class Client {
     richMenuAliasId: string,
     richMenuId: string,
   ): Promise<{}> {
-    const res = await this.http.put<{}>(
+    const res = await this.http.post<{}>(
       `${MESSAGING_API_PREFIX}/richmenu/alias/${richMenuAliasId}`,
       {
         richMenuId,

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -503,7 +503,7 @@ describe("client", () => {
   it("updateRichMenuAlias", async () => {
     const richMenuId = "test_rich_menu_id";
     const richMenuAliasId = "test_rich_menu_alias_id";
-    const scope = mockPut(
+    const scope = mockPost(
       MESSAGING_API_PREFIX,
       "/richmenu/alias/test_rich_menu_alias_id",
       { richMenuId },


### PR DESCRIPTION
### Motivation
When executing updateRichMenuAlias function, 405(Method Not Allowed) error occurred.
```
Error: Request failed with status code 405
```

In api document, HTTP method of this api is POST.
https://developers.line.biz/en/reference/messaging-api/#update-rich-menu-alias

However, PUT method is used in this SDK.

### Modifications
HTTP method PUT => POST