### PR TITLE
Update supported nodejs versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         # https://nodejs.org/en/about/releases/
-        node: [ '14', '16', '18', '20' ]
+        node: [ '14', '16', '18' ]
       fail-fast: false
 
     name: Node.js ${{ matrix.node }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,8 @@ jobs:
 
     strategy:
       matrix:
-        node: [ '10', '12', '14', '16' ]
+        # https://nodejs.org/en/about/releases/
+        node: [ '14', '16', '18', '20' ]
       fail-fast: false
 
     name: Node.js ${{ matrix.node }}


### PR DESCRIPTION
Drop node 10,12 support since these versions are EOL.
Add support for 18, 20.

https://nodejs.org/en/about/releases/