### PR TITLE
Add support of mention for all

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -405,7 +405,18 @@ export type TextEventMessage = {
        * 8 is the length.
        */
       length: number;
-      userId: string;
+      /**
+       * Mentioned target.
+       *
+       * - `user`: User.
+       * - `all`: Entire group.
+       */
+      type: "user" | "all";
+      /**
+       * User ID of the mentioned user. Only included if mention.mentions[].type is user
+       * and the user consents to the LINE Official Account obtaining their user profile information.
+       */
+      userId?: string;
     }[];
   };
 } & EventMessageBase;


### PR DESCRIPTION
Based on today's announcement, I make tweaks to type definition to adopt this API change.

- [Messaging API now includes @All in the mention property of the webhooks](https://developers.line.biz/en/news/2023/03/08/messaging-api-updated/)