### PR TITLE
Add 'test/**/*.ts' to tsconfig.json includes for type error in editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "format:check": "npm run prettier -- -l",
     "clean": "rm -rf dist/*",
     "prebuild": "npm run format:check && npm run clean",
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "docs": "vuepress dev docs",
     "docs:build": "vuepress build docs",
     "docs:deploy": "./scripts/deploy-docs.sh",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "lib/**/*.ts"
+  ],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,6 @@
     "declaration": true
   },
   "include": [
-    "lib/**/*.ts"
+    "lib/**/*.ts", "test/**/*.ts"
   ]
 }


### PR DESCRIPTION
TypeScript type error that was occurring in the VSCode.

This issue was resolved by modifying the `tsconfig.json` file to `includes` `"test/**/*.ts" `in the includes field. This change will prevent the type error in the future.

<img width="613" alt="Screen Shot 2023-05-27 at 22 01 17" src="https://github.com/line/line-bot-sdk-nodejs/assets/34151621/71b4c6b8-abdd-4711-b490-e19bd59e904b">

However, by adding a directory to the `includes` in `tsconfig.json`, the structure under `dist/` ended up being divided into `dist/lib/` and `dist/test/`. Therefore, I propose the idea of managing the common configuration file for the editor and type checking separately from the configuration file for building. For this purpose, I have created a `tsconfig.build.json` for building.
