### PR TITLE
Make pictureUrl optional in GroupSummaryResponse 

### DIFF
--- a/lib/exceptions.ts
+++ b/lib/exceptions.ts
@@ -1,11 +1,17 @@
 export class SignatureValidationFailed extends Error {
-  constructor(message: string, public signature?: string) {
+  constructor(
+    message: string,
+    public signature?: string,
+  ) {
     super(message);
   }
 }
 
 export class JSONParseError extends Error {
-  constructor(message: string, public raw: any) {
+  constructor(
+    message: string,
+    public raw: any,
+  ) {
     super(message);
   }
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2834,7 +2834,7 @@ export type VerifyIDToken = {
 export type GroupSummaryResponse = {
   groupId: string;
   groupName: string;
-  pictureUrl: string;
+  pictureUrl?: string;
 };
 
 /**

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2829,7 +2829,7 @@ export type VerifyIDToken = {
 /**
  * Response body of get group summary.
  *
- * @see [Get group summary](https://developers.line.biz/ja/reference/messaging-api/#get-group-summary)
+ * @see [Get group summary](https://developers.line.biz/en/reference/messaging-api/#get-group-summary)
  */
 export type GroupSummaryResponse = {
   groupId: string;


### PR DESCRIPTION
We have a case where the `pictureUrl` is not available. This commit
makes the `pictureUrl` optional in the `GroupSummaryResponse` type.
The documentation for the `GroupSummaryResponse` type has also proven
this to be the case.

See https://developers.line.biz/en/reference/messaging-api/#get-group-summary-response