### PR TITLE
Add quote message property to message types

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -429,7 +429,12 @@ export type TextEventMessage = {
       userId?: string;
     }[];
   };
-} & EventMessageBase;
+  /**
+   * Message ID of a quoted message. Only included when the received message quotes a past message.
+   */
+  quotedMessageId?: string;
+} & QuotableMessage &
+  EventMessageBase;
 
 export type ContentProvider<WithPreview extends boolean = true> =
   | {
@@ -486,7 +491,8 @@ export type ImageEventMessage = {
      */
     total: number;
   };
-} & EventMessageBase;
+} & QuotableMessage &
+  EventMessageBase;
 
 /**
  * Message object which contains the video content sent from the source.
@@ -495,7 +501,8 @@ export type ImageEventMessage = {
 export type VideoEventMessage = {
   type: "video";
   contentProvider: ContentProvider;
-} & EventMessageBase;
+} & QuotableMessage &
+  EventMessageBase;
 
 /**
  * Message object which contains the audio content sent from the source.
@@ -552,7 +559,12 @@ export type StickerEventMessage = {
    * Max character limit: 100
    */
   text?: string;
-} & EventMessageBase;
+  /**
+   * Message ID of a quoted message. Only included when the received message quotes a past message.
+   */
+  quotedMessageId?: string;
+} & QuotableMessage &
+  EventMessageBase;
 
 export type Postback = {
   data: string;
@@ -632,34 +644,49 @@ export type MessageCommon = {
   sender?: Sender;
 };
 
+type QuotableMessage = {
+  /**
+   * Quote token to quote this message.
+   */
+  quoteToken: string;
+};
+
+type CanQuoteMessage = {
+  /**
+   * Quote token of the message you want to quote.
+   */
+  quoteText?: string;
+};
+
 /**
  * @see [Text message](https://developers.line.biz/en/reference/messaging-api/#text-message)
  */
-export type TextMessage = MessageCommon & {
-  type: "text";
-  /**
-   * Message text. You can include the following emoji:
-   *
-   * - LINE emojis. Use a $ character as a placeholder and specify the product ID and emoji ID of the LINE emoji you want to use in the emojis property.
-   * - Unicode emoji
-   * - (Deprecated) LINE original unicode emojis
-   *   ([Unicode codepoint table for LINE original emoji](https://developers.line.biz/media/messaging-api/emoji-list.pdf))
-   *
-   * Max: 5000 characters
-   */
-  text: string;
+export type TextMessage = MessageCommon &
+  CanQuoteMessage & {
+    type: "text";
+    /**
+     * Message text. You can include the following emoji:
+     *
+     * - LINE emojis. Use a $ character as a placeholder and specify the product ID and emoji ID of the LINE emoji you want to use in the emojis property.
+     * - Unicode emoji
+     * - (Deprecated) LINE original unicode emojis
+     *   ([Unicode codepoint table for LINE original emoji](https://developers.line.biz/media/messaging-api/emoji-list.pdf))
+     *
+     * Max: 5000 characters
+     */
+    text: string;
 
-  /**
-   * One or more LINE emoji.
-   *
-   * Max: 20 LINE emoji
-   */
-  emojis?: {
-    index: number;
-    productId: string;
-    emojiId: string;
-  }[];
-};
+    /**
+     * One or more LINE emoji.
+     *
+     * Max: 20 LINE emoji
+     */
+    emojis?: {
+      index: number;
+      productId: string;
+      emojiId: string;
+    }[];
+  };
 
 /**
  * @see [Image message](https://developers.line.biz/en/reference/messaging-api/#image-message)
@@ -753,22 +780,23 @@ export type LocationMessage = MessageCommon & {
 /**
  * @see [Sticker message](https://developers.line.biz/en/reference/messaging-api/#sticker-message)
  */
-export type StickerMessage = MessageCommon & {
-  type: "sticker";
-  /**
-   * Package ID for a set of stickers.
-   * For information on package IDs, see the
-   * [Sticker list](https://developers.line.biz/media/messaging-api/sticker_list.pdf).
-   */
-  packageId: string;
-  /**
-   * Sticker ID.
-   * For a list of sticker IDs for stickers that can be sent with the Messaging
-   * API, see the
-   * [Sticker list](https://developers.line.biz/media/messaging-api/sticker_list.pdf).
-   */
-  stickerId: string;
-};
+export type StickerMessage = MessageCommon &
+  CanQuoteMessage & {
+    type: "sticker";
+    /**
+     * Package ID for a set of stickers.
+     * For information on package IDs, see the
+     * [Sticker list](https://developers.line.biz/media/messaging-api/sticker_list.pdf).
+     */
+    packageId: string;
+    /**
+     * Sticker ID.
+     * For a list of sticker IDs for stickers that can be sent with the Messaging
+     * API, see the
+     * [Sticker list](https://developers.line.biz/media/messaging-api/sticker_list.pdf).
+     */
+    stickerId: string;
+  };
 
 /**
  * @see [Imagemap message](https://developers.line.biz/en/reference/messaging-api/#imagemap-message)

--- a/test/middleware.spec.ts
+++ b/test/middleware.spec.ts
@@ -19,6 +19,7 @@ describe("middleware", () => {
     message: {
       id: "test_event_message_id",
       text: "this is test message.😄😅😢😞😄😅😢😞",
+      quoteToken: "test_quote_token",
       type: "text",
     },
     replyToken: "test_reply_token",
@@ -35,7 +36,7 @@ describe("middleware", () => {
     type: "message",
   };
   const webhookSignature = {
-    "X-Line-Signature": "Ey7AjSuSI2GfTDQHICAiRLLJ+GSMseISNYaQ6qXSjrU=",
+    "X-Line-Signature": "eRdWYcVCzZV3MVZ3M9/rHJCl/a3oSbsRb04cLovpVwM=",
   };
 
   const http = (headers: any = { ...webhookSignature }) =>


### PR DESCRIPTION
There are two types of message that can quote a past message: text and sticker. This commit adds the `quotedMessageId` property to the TextMessage and StickerMessage types.

It also adds the `quoteToken` property to the QuotableMessage type which is implemented by the TextEventMessage, StickerEventMessage, ImageEventMessage, and VideoEventMessage types.

Following partial responses are the examples of the quote message I have received from LINE.

TextEventMessage

    message: {
      type: 'text',
      id: '739816233962536',
      quoteToken: 'SiLB-hQpo03eYKs8QIUZXIdkXd5jQ18WpElOf1F9Vgy0h403Cj-5o6nVoogKbwMrNz9z29TJEo6882_oXlMeAFtj3xGvl_JTH5sXzaVJJhDwUY6MBpNZivMkfzvqSRUkEz2DHA7D0cEw',
      text: 'test'
    }

StickerEventMessage

    message: {
      type: 'sticker',
      id: '739858565045032',
      quoteToken: 'Tob7KynRFeGiGl5ekRqTXW0brLv5lG9RJBCatcYUk6oUVGJEEJoseFuayl0Dli2UxYwD7Rf2NlhEVmaPlWYcCMmogeXBIb-K3oC392WY7Gy1ZFQLVNhSjRR_uuqSOd5_aua5Zu33Jq2w',
      stickerId: '8768850',
      packageId: '781128',
      stickerResourceType: 'STATIC',
      keywords: [ 'Surprised', '!!' ]
    }

ImageEventMessage

    message: {
      type: 'image',
      id: '739846531591299',
      quoteToken: 'iSxGqzgbGvHXpPaBaJC86_xsZJOWID-UXSz2d1kTINipV30OYIKRxYLshDS6T6uretaPWpdM2tde04yHRB89jiKxJpxDl_Ux9lF6bzOumalBs4JC7-mjT2V-wJzWod_03dk7iS9qrO1A',
      contentProvider: { type: 'line' }
    }

VideoEventMessage

    message: {
      type: 'video',
      id: '739859176903919',
      quoteToken: 'OowxxHrmCNg2scypnPnfo5SA4wGY4VkQbQbXd2PseyJmd_hIoEPQG-pJyCKo17HcP3rrCxierp03h0hWkrZgcuxjcoKD5O44cuI9d28AecRnEuBq88jAwWFBJdhBXbEjp77p21hT5Anw',
      duration: 2168,
      contentProvider: { type: 'line' }
    }

News:
https://developers.line.biz/en/news/2023/09/14/send-and-receive-quote-messages-using-the-messaging-api/

Resolve #461