### PR TITLE
Bump up version on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,10 @@ jobs:
     - run: npm install
     - name: Update version in package.json, package-lock.json
       run: |
-        sed -i "s/__LINE_BOT_SDK_NODEJS_VERSION__/'${{ github.event.release.tag_name }}'/g" package.json
-        sed -i "s/__LINE_BOT_SDK_NODEJS_VERSION__/'${{ github.event.release.tag_name }}'/g" package-lock.json
+        VERSION=${{ github.event.release.tag_name }}
+        VERSION=${VERSION#v}
+        sed -i "s/__LINE_BOT_SDK_NODEJS_VERSION__/'$VERSION'/g" package.json
+        sed -i "s/__LINE_BOT_SDK_NODEJS_VERSION__/'$VERSION'/g" package-lock.json
     - run: npm run release
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,10 @@ jobs:
         node-version: 18
         registry-url: 'https://registry.npmjs.org'
     - run: npm install
+    - name: Update version in package.json, package-lock.json
+      run: |
+        sed -i "s/__LINE_BOT_SDK_NODEJS_VERSION__/'${{ github.event.release.tag_name }}'/g" package.json
+        sed -i "s/__LINE_BOT_SDK_NODEJS_VERSION__/'${{ github.event.release.tag_name }}'/g" package-lock.json
     - run: npm run release
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,11 +32,12 @@ jobs:
         cache: 'npm'
     - name: Install Dependency
       run: npm ci
+    - name: Test generator
+      run: cd generator; mvn package
+    - name: Generate code
     - run: |
         python3 generate-code.py
     - name: Test Project
       run: npm test
     - name: Test building docs
       run: export NODE_OPTIONS=--openssl-legacy-provider; npm run docs:build
-    - name: Test generator
-      run: cd generator; mvn package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,9 +33,9 @@ jobs:
     - name: Install Dependency
       run: npm ci
     - name: Test generator
-      run: cd generator; mvn package
+      run: cd generator; mvn package; cd ..
     - name: Generate code
-    - run: |
+      run: |
         python3 generate-code.py
     - name: Test Project
       run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@line/bot-sdk",
-  "version": "7.7.0",
+  "version": "__LINE_BOT_SDK_NODEJS_VERSION__",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@line/bot-sdk",
-  "version": "8.0.0",
+  "version": "__LINE_BOT_SDK_NODEJS_VERSION__",
   "description": "Node.js SDK for LINE Messaging API",
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
When we create release, we need to bump up version manually(like https://github.com/line/line-bot-sdk-nodejs/pull/515). This pull request automates it as line-bot-sdk-java and line-bot-sdk-python.

Resolve https://github.com/line/line-bot-sdk-nodejs/issues/494