### PR TITLE
Add build-sdk command in echo-bot-ts example

### DIFF
--- a/examples/echo-bot-ts/package.json
+++ b/examples/echo-bot-ts/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "clean": "rimraf ./dist",
     "build": "npm run clean && tsc",
+    "build-sdk": "cd ../../; npm i; npm run build",
     "start": "node dist/index.js"
   },
   "author": "Nicholas Dwiarto <nicholasdwiarto@yahoo.com> (https://nicholasdw.com)",


### PR DESCRIPTION
example project requires us to run `npm run build-sdk` but there is no such a command.

https://github.com/line/line-bot-sdk-nodejs/blob/314e628d6e90f4cf9bb16033e5f606e7f4301f37/examples/echo-bot-ts/README.md?plain=1#L27-L30