### PR TITLE
Do not run nyc on `npm test` task.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   ],
   "scripts": {
     "pretest": "npm run format && npm run build",
-    "test": "TEST_PORT=1234 TS_NODE_CACHE=0 nyc mocha",
+    "test": "TEST_PORT=1234 TS_NODE_CACHE=0 mocha",
+    "covtest": "TEST_PORT=1234 TS_NODE_CACHE=0 nyc mocha",
     "prettier": "prettier \"{lib,test}/**/*.ts\"",
     "format": "npm run prettier -- --write",
     "format:check": "npm run prettier -- -l",


### PR DESCRIPTION
Since, nyc 15.0+ is unstable...
https://github.com/istanbuljs/nyc/issues/1263