### PR TITLE
Fix form parameter and delete it only when undefined

### DIFF
--- a/generator/src/main/resources/line-bot-sdk-nodejs-generator/apiBody/normal.pebble
+++ b/generator/src/main/resources/line-bot-sdk-nodejs-generator/apiBody/normal.pebble
@@ -14,7 +14,7 @@
         {% endfor %}
         };
         Object.keys(formParams).forEach((key: keyof typeof formParams) => {
-          if (formParams[key] === undefined || formParams[key] === '') {
+          if (formParams[key] === undefined) {
             delete formParams[key];
           }
         });

--- a/generator/src/main/resources/line-bot-sdk-nodejs-generator/apiBody/normal.pebble
+++ b/generator/src/main/resources/line-bot-sdk-nodejs-generator/apiBody/normal.pebble
@@ -10,9 +10,14 @@
     {% if op.hasBodyParam %}const params = {{op.bodyParam.paramName}};
     {% elseif op.hasFormParams %}const formParams = {
         {% for param in op.formParams -%}
-            "{{param.paramName}}": {{param.paramName}},
+            "{{param.baseName}}": {{param.paramName}},
         {% endfor %}
         };
+        Object.keys(formParams).forEach((key: keyof typeof formParams) => {
+          if (formParams[key] === undefined || formParams[key] === '') {
+            delete formParams[key];
+          }
+        });
     {% elseif op.hasQueryParams %}const queryParams = {
         {% for param in op.queryParams -%}
             "{{param.paramName}}": {{param.paramName}},

--- a/lib/channel-access-token/api/channelAccessTokenClient.ts
+++ b/lib/channel-access-token/api/channelAccessTokenClient.ts
@@ -96,10 +96,15 @@ export class ChannelAccessTokenClient {
     clientSecret?: string,
   ): Promise<IssueShortLivedChannelAccessTokenResponse> {
     const formParams = {
-      grantType: grantType,
-      clientId: clientId,
-      clientSecret: clientSecret,
+      grant_type: grantType,
+      client_id: clientId,
+      client_secret: clientSecret,
     };
+    Object.keys(formParams).forEach((key: keyof typeof formParams) => {
+      if (formParams[key] === undefined) {
+        delete formParams[key];
+      }
+    });
 
     const res =
       this.httpClient.postForm<IssueShortLivedChannelAccessTokenResponse>(
@@ -122,10 +127,15 @@ export class ChannelAccessTokenClient {
     clientAssertion?: string,
   ): Promise<IssueChannelAccessTokenResponse> {
     const formParams = {
-      grantType: grantType,
-      clientAssertionType: clientAssertionType,
-      clientAssertion: clientAssertion,
+      grant_type: grantType,
+      client_assertion_type: clientAssertionType,
+      client_assertion: clientAssertion,
     };
+    Object.keys(formParams).forEach((key: keyof typeof formParams) => {
+      if (formParams[key] === undefined) {
+        delete formParams[key];
+      }
+    });
 
     const res = this.httpClient.postForm<IssueChannelAccessTokenResponse>(
       "/oauth2/v2.1/token",
@@ -151,12 +161,17 @@ export class ChannelAccessTokenClient {
     clientSecret?: string,
   ): Promise<IssueStatelessChannelAccessTokenResponse> {
     const formParams = {
-      grantType: grantType,
-      clientAssertionType: clientAssertionType,
-      clientAssertion: clientAssertion,
-      clientId: clientId,
-      clientSecret: clientSecret,
+      grant_type: grantType,
+      client_assertion_type: clientAssertionType,
+      client_assertion: clientAssertion,
+      client_id: clientId,
+      client_secret: clientSecret,
     };
+    Object.keys(formParams).forEach((key: keyof typeof formParams) => {
+      if (formParams[key] === undefined) {
+        delete formParams[key];
+      }
+    });
 
     const res =
       this.httpClient.postForm<IssueStatelessChannelAccessTokenResponse>(
@@ -175,8 +190,13 @@ export class ChannelAccessTokenClient {
     accessToken?: string,
   ): Promise<Types.MessageAPIResponseBase> {
     const formParams = {
-      accessToken: accessToken,
+      access_token: accessToken,
     };
+    Object.keys(formParams).forEach((key: keyof typeof formParams) => {
+      if (formParams[key] === undefined) {
+        delete formParams[key];
+      }
+    });
 
     const res = this.httpClient.postForm("/v2/oauth/revoke", formParams);
     return ensureJSON(res);
@@ -195,10 +215,15 @@ export class ChannelAccessTokenClient {
     accessToken?: string,
   ): Promise<Types.MessageAPIResponseBase> {
     const formParams = {
-      clientId: clientId,
-      clientSecret: clientSecret,
-      accessToken: accessToken,
+      client_id: clientId,
+      client_secret: clientSecret,
+      access_token: accessToken,
     };
+    Object.keys(formParams).forEach((key: keyof typeof formParams) => {
+      if (formParams[key] === undefined) {
+        delete formParams[key];
+      }
+    });
 
     const res = this.httpClient.postForm("/oauth2/v2.1/revoke", formParams);
     return ensureJSON(res);
@@ -213,8 +238,13 @@ export class ChannelAccessTokenClient {
     accessToken?: string,
   ): Promise<VerifyChannelAccessTokenResponse> {
     const formParams = {
-      accessToken: accessToken,
+      access_token: accessToken,
     };
+    Object.keys(formParams).forEach((key: keyof typeof formParams) => {
+      if (formParams[key] === undefined) {
+        delete formParams[key];
+      }
+    });
 
     const res = this.httpClient.postForm<VerifyChannelAccessTokenResponse>(
       "/v2/oauth/verify",

--- a/lib/module-attach/api/lineModuleAttachClient.ts
+++ b/lib/module-attach/api/lineModuleAttachClient.ts
@@ -86,17 +86,22 @@ export class LineModuleAttachClient {
     brandType?: string,
   ): Promise<AttachModuleResponse> {
     const formParams = {
-      grantType: grantType,
+      grant_type: grantType,
       code: code,
-      redirectUri: redirectUri,
-      codeVerifier: codeVerifier,
-      clientId: clientId,
-      clientSecret: clientSecret,
+      redirect_uri: redirectUri,
+      code_verifier: codeVerifier,
+      client_id: clientId,
+      client_secret: clientSecret,
       region: region,
-      basicSearchId: basicSearchId,
+      basic_search_id: basicSearchId,
       scope: scope,
-      brandType: brandType,
+      brand_type: brandType,
     };
+    Object.keys(formParams).forEach((key: keyof typeof formParams) => {
+      if (formParams[key] === undefined) {
+        delete formParams[key];
+      }
+    });
 
     const res = this.httpClient.postForm<AttachModuleResponse>(
       "/module/auth/v1/token",

--- a/test/libs-channelAccessToken.spec.ts
+++ b/test/libs-channelAccessToken.spec.ts
@@ -34,7 +34,7 @@ describe("channelAccessToken", () => {
           );
           equal(
             await request.text(),
-            "grantType=test_client_id&clientAssertionType=test_client_secret&clientAssertion=test_grant_type&clientId=test_redirect_uri&clientSecret=test_code",
+            "grant_type=test_client_id&client_id=1234&client_secret=test_code",
           );
 
           return HttpResponse.json({});
@@ -44,9 +44,9 @@ describe("channelAccessToken", () => {
 
     const res = await client.issueStatelessChannelToken(
       "test_client_id",
-      "test_client_secret",
-      "test_grant_type",
-      "test_redirect_uri",
+      undefined,
+      undefined,
+      "1234",
       "test_code",
     );
     deepEqual(res, {});


### PR DESCRIPTION
https://github.com/line/line-bot-sdk-nodejs/pull/597#discussion_r1397648638
As I checked in my local, channel api client's request is rejected. The root cause was that parameter used camel case as form parameter. Snake case is expected according to official document. This change fixes it.