### PR TITLE
feat: add http-xior

### DIFF
--- a/lib/http-xior.ts
+++ b/lib/http-xior.ts
@@ -1,0 +1,183 @@
+import axios, {
+  xior as AxiosInstance,
+  XiorError as AxiosError,
+  XiorResponse as AxiosResponse,
+  XiorRequestConfig as AxiosRequestConfig,
+} from "xior";
+import { Readable } from "stream";
+import { HTTPError, ReadError } from "./exceptions";
+import * as fileType from "file-type";
+import * as qs from "querystring";
+import { convertResponseToReadable } from "./http-fetch";
+
+const pkg = require("../package.json");
+
+interface httpClientConfig extends Partial<AxiosRequestConfig> {
+  baseURL?: string;
+  defaultHeaders?: any;
+  responseParser?: <T>(res: AxiosResponse) => T;
+}
+
+export default class HTTPClient {
+  private instance: AxiosInstance;
+  private readonly config: httpClientConfig;
+
+  constructor(config: httpClientConfig = {}) {
+    this.config = config;
+    const { baseURL, defaultHeaders } = config;
+    this.instance = axios.create({
+      baseURL,
+      headers: Object.assign({}, defaultHeaders, {
+        "User-Agent": `${pkg.name}/${pkg.version}`,
+      }),
+    });
+
+    this.instance.interceptors.response.use(
+      res => res,
+      err => Promise.reject(this.wrapError(err)),
+    );
+  }
+
+  public async get<T>(url: string, params?: any): Promise<T> {
+    const res = await this.instance.get(url, { params });
+    return res.data;
+  }
+
+  public async getStream(url: string, params?: any): Promise<Readable> {
+    const { response } = await this.instance.get(url, {
+      params,
+      responseType: "stream",
+    });
+    const stream = convertResponseToReadable(response);
+    return stream;
+  }
+
+  public async post<T>(
+    url: string,
+    body?: any,
+    config?: Partial<AxiosRequestConfig>,
+  ): Promise<T> {
+    const res = await this.instance.post(url, body, {
+      headers: {
+        "Content-Type": "application/json",
+        ...(config && config.headers),
+      },
+      ...config,
+    });
+
+    return this.responseParse(res);
+  }
+
+  private responseParse(res: AxiosResponse) {
+    const { responseParser } = this.config;
+    if (responseParser) return responseParser(res);
+    else return res.data;
+  }
+
+  public async put<T>(
+    url: string,
+    body?: any,
+    config?: Partial<AxiosRequestConfig>,
+  ): Promise<T> {
+    const res = await this.instance.put<T>(url, body, {
+      headers: {
+        "Content-Type": "application/json",
+        ...(config && config.headers),
+      },
+      ...config,
+    });
+
+    return this.responseParse(res);
+  }
+
+  public async postForm<T>(url: string, body?: any): Promise<T> {
+    const res = await this.instance.post(url, qs.stringify(body), {
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    });
+
+    return res.data;
+  }
+
+  public async postFormMultipart<T>(url: string, form: FormData): Promise<T> {
+    const res = await this.instance.post<T>(url, form);
+    return res.data;
+  }
+
+  public async putFormMultipart<T>(
+    url: string,
+    form: FormData,
+    config?: Partial<AxiosRequestConfig>,
+  ): Promise<T> {
+    const res = await this.instance.put<T>(url, form, config);
+    return res.data;
+  }
+
+  public async toBuffer(data: Buffer | Readable) {
+    if (Buffer.isBuffer(data)) {
+      return data;
+    } else if (data instanceof Readable) {
+      return await new Promise<Buffer>((resolve, reject) => {
+        const buffers: Buffer[] = [];
+        let size = 0;
+        data.on("data", (chunk: Buffer) => {
+          buffers.push(chunk);
+          size += chunk.length;
+        });
+        data.on("end", () => resolve(Buffer.concat(buffers, size)));
+        data.on("error", reject);
+      });
+    } else {
+      throw new Error("invalid data type for binary data");
+    }
+  }
+
+  public async postBinary<T>(
+    url: string,
+    data: Buffer | Readable,
+    contentType?: string,
+  ): Promise<T> {
+    const buffer = await this.toBuffer(data);
+
+    const res = await this.instance.post(url, buffer, {
+      headers: {
+        "Content-Type": contentType || (await fileType.fromBuffer(buffer)).mime,
+        "Content-Length": buffer.length,
+      },
+    });
+
+    return res.data;
+  }
+
+  public async postBinaryContent<T>(url: string, body: Blob): Promise<T> {
+    const res = await this.instance.post(url, body, {
+      headers: {
+        "Content-Type": body.type,
+        "Content-Length": body.size,
+      },
+    });
+
+    return res.data;
+  }
+
+  public async delete<T>(url: string, params?: any): Promise<T> {
+    const res = await this.instance.delete(url, { params });
+    return res.data;
+  }
+
+  private wrapError(err: AxiosError): Error {
+    if (err.response) {
+      return new HTTPError(
+        err.message,
+        err.response.status,
+        err.response.statusText,
+        err,
+      );
+    } else if (err.request) {
+      // unknown, but from axios
+      return new ReadError(err);
+    }
+
+    // otherwise, just rethrow
+    return err;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,8 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "axios": "^1.0.0"
+        "axios": "^1.0.0",
+        "xior": "^0.1.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -6870,6 +6871,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/tiny-lru": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-11.2.5.tgz",
+      "integrity": "sha512-JpqM0K33lG6iQGKiigcwuURAKZlq6rHXfrgeL4/I8/REoyJTGU+tEMszvT/oTRVHG2OiylhGDjqPp1jWMlr3bw==",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -6920,6 +6930,15 @@
       "resolved": "https://registry.npmjs.org/ts-debounce/-/ts-debounce-4.0.0.tgz",
       "integrity": "sha512-+1iDGY6NmOGidq7i7xZGA4cm8DAa6fqdYcvO5Z6yBevH++Bdo9Qt/mN0TzHUgcCcKv1gmh9+W5dHqz8pMWbCbg==",
       "dev": true
+    },
+    "node_modules/ts-deepmerge": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-7.0.0.tgz",
+      "integrity": "sha512-WZ/iAJrKDhdINv1WG6KZIGHrZDar6VfhftG1QJFpVbOYZMYJLJOvZOo1amictRXVdBXZIgBHKswMTXzElngprA==",
+      "optional": true,
+      "engines": {
+        "node": ">=14.13.1"
+      }
     },
     "node_modules/ts-node": {
       "version": "10.9.2",
@@ -7496,6 +7515,16 @@
         "is-typedarray": "^1.0.0",
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "node_modules/xior": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/xior/-/xior-0.1.1.tgz",
+      "integrity": "sha512-GZwWfZ7DoZpNMsUCRaKJKAPgBcfLx8/IJM9NOlFJVF87PPRHHjLhhblWOOOxyLPgC3NJkT+fFHzxYlQlGbCbhw==",
+      "optional": true,
+      "dependencies": {
+        "tiny-lru": "^11.2.5",
+        "ts-deepmerge": "^7.0.0"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "file-type": "^16.5.4"
   },
   "optionalDependencies": {
-    "axios": "^1.0.0"
+    "axios": "^1.0.0",
+    "xior": "^0.1.1"
   },
   "devDependencies": {
     "@types/express": "4.17.21",

--- a/test/http-xior.spec.ts
+++ b/test/http-xior.spec.ts
@@ -1,0 +1,298 @@
+import { deepEqual, equal, ok } from "assert";
+import { HTTPError } from "../lib/exceptions";
+import HTTPClient from "../lib/http-xior";
+import { getStreamData } from "./helpers/stream";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { createReadStream, readFileSync } from "fs";
+import { join } from "path";
+import * as fs from "fs";
+
+const pkg = require("../package.json");
+const baseURL = "https://line.me";
+describe("http(xior)", () => {
+  const httpClient = new HTTPClient({
+    baseURL,
+    defaultHeaders: {
+      "test-header-key": "Test-Header-Value",
+    },
+  });
+
+  const server = setupServer();
+  before(() => {
+    server.listen();
+  });
+  after(() => {
+    server.close();
+  });
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  const interceptionOption: Record<string, string> = {
+    "test-header-key": "Test-Header-Value",
+    "User-Agent": `${pkg.name}/${pkg.version}`,
+  };
+
+  class MSWResult {
+    private _done: boolean;
+
+    constructor() {
+      this._done = false;
+    }
+
+    public done() {
+      this._done = true;
+    }
+
+    public isDone() {
+      return this._done;
+    }
+  }
+
+  const mockGet = (path: string, expectedQuery?: Record<string, string>) => {
+    const result = new MSWResult();
+    server.use(
+      http.get(baseURL + path, ({ request }) => {
+        for (const key in interceptionOption) {
+          equal(request.headers.get(key), interceptionOption[key]);
+        }
+
+        if (expectedQuery) {
+          const url = new URL(request.url);
+          const queryParams = url.searchParams;
+          for (const key in expectedQuery) {
+            equal(queryParams.get(key), expectedQuery[key]);
+          }
+        }
+
+        result.done();
+
+        return HttpResponse.json({});
+      }),
+    );
+    return result;
+  };
+
+  const mockPost = (path: string, expectedBody?: object) => {
+    const result = new MSWResult();
+    server.use(
+      http.post(baseURL + path, async ({ request, params, cookies }) => {
+        for (const key in interceptionOption) {
+          equal(request.headers.get(key), interceptionOption[key]);
+        }
+
+        if (expectedBody) {
+          const dat = await request.json();
+          ok(dat);
+          deepEqual(dat, expectedBody);
+        }
+
+        result.done();
+
+        return HttpResponse.json({});
+      }),
+    );
+    return result;
+  };
+
+  const mockDelete = (path: string, expectedQuery?: Record<string, string>) => {
+    const result = new MSWResult();
+    server.use(
+      http.delete(baseURL + path, ({ request }) => {
+        for (const key in interceptionOption) {
+          equal(request.headers.get(key), interceptionOption[key]);
+        }
+
+        if (expectedQuery) {
+          const url = new URL(request.url);
+          const queryParams = url.searchParams;
+          for (const key in expectedQuery) {
+            equal(queryParams.get(key), expectedQuery[key]);
+          }
+        }
+
+        result.done();
+
+        return HttpResponse.json({});
+      }),
+    );
+    return result;
+  };
+
+  it("get", async () => {
+    const scope = mockGet("/get");
+    const res = await httpClient.get<any>(`/get`);
+    equal(scope.isDone(), true);
+    deepEqual(res, {});
+  });
+
+  it("get with query", async () => {
+    const scope = mockGet("/get", { x: "10" });
+    const res = await httpClient.get<any>(`/get`, { x: 10 });
+    equal(scope.isDone(), true);
+    deepEqual(res, {});
+  });
+
+  it("post without body", async () => {
+    const scope = mockPost("/post");
+    const res = await httpClient.post<any>(`/post`);
+    equal(scope.isDone(), true);
+
+    deepEqual(res, {});
+  });
+
+  it("post with body", async () => {
+    const testBody = {
+      id: 12345,
+      message: "hello, body!",
+    };
+
+    const scope = mockPost("/post/body", testBody);
+    const res = await httpClient.post<any>(`/post/body`, testBody);
+    equal(scope.isDone(), true);
+
+    deepEqual(res, {});
+  });
+
+  it("getStream", async () => {
+    const scope = new MSWResult();
+    server.use(
+      http.get(baseURL + "/stream.txt", ({}) => {
+        scope.done();
+
+        const stream = new ReadableStream({
+          start(controller) {
+            const content = fs.readFileSync(
+              join(__dirname, "./helpers/stream.txt"),
+            );
+            // Encode the string chunks using "TextEncoder".
+            controller.enqueue(content);
+            controller.close();
+          },
+        });
+
+        // Send the mocked response immediately.
+        return new HttpResponse(stream, {
+          headers: {
+            "Content-Type": "text/plain",
+          },
+        });
+      }),
+    );
+
+    const stream = await httpClient.getStream(`/stream.txt`);
+    const data = await getStreamData(stream);
+
+    equal(scope.isDone(), true);
+    equal(data, "hello, stream!\n");
+  });
+
+  it("delete", async () => {
+    const scope = mockDelete("/delete");
+    await httpClient.delete(`/delete`);
+    equal(scope.isDone(), true);
+  });
+
+  it("delete with query", async () => {
+    const scope = mockDelete("/delete", { x: "10" });
+    await httpClient.delete(`/delete`, { x: 10 });
+    equal(scope.isDone(), true);
+  });
+
+  const mockPostBinary = (
+    buffer: Buffer,
+    reqheaders: Record<string, string>,
+  ) => {
+    const result = new MSWResult();
+    server.use(
+      http.post(
+        baseURL + "/post/binary",
+        async ({ request, params, cookies }) => {
+          for (const key in interceptionOption) {
+            equal(request.headers.get(key), interceptionOption[key]);
+          }
+          for (const key in reqheaders) {
+            equal(request.headers.get(key), reqheaders[key]);
+          }
+          equal(request.headers.get("content-length"), buffer.length + "");
+
+          result.done();
+
+          return HttpResponse.json({});
+        },
+      ),
+    );
+    return result;
+  };
+
+  it("postBinary", async () => {
+    const filepath = join(__dirname, "/helpers/line-icon.png");
+    const buffer = readFileSync(filepath);
+    const scope = mockPostBinary(buffer, {
+      "content-type": "image/png",
+    });
+
+    await httpClient.postBinary(`/post/binary`, buffer);
+    equal(scope.isDone(), true);
+  });
+
+  it("postBinary with specific content type", async () => {
+    const filepath = join(__dirname, "/helpers/line-icon.png");
+    const buffer = readFileSync(filepath);
+    const scope = mockPostBinary(buffer, {
+      "content-type": "image/jpeg",
+    });
+
+    await httpClient.postBinary(`/post/binary`, buffer, "image/jpeg");
+    equal(scope.isDone(), true);
+  });
+
+  it("postBinary with stream", async () => {
+    const filepath = join(__dirname, "/helpers/line-icon.png");
+    const stream = createReadStream(filepath);
+    const buffer = readFileSync(filepath);
+    const scope = mockPostBinary(buffer, {
+      "content-type": "image/png",
+    });
+
+    await httpClient.postBinary(`/post/binary`, stream);
+    equal(scope.isDone(), true);
+  });
+
+  it("fail with 404", async () => {
+    const scope = new MSWResult();
+    server.use(
+      http.get(baseURL + "/404", async ({ request, params, cookies }) => {
+        scope.done();
+        equal(request.headers.get("user-agent"), `${pkg.name}/${pkg.version}`);
+        return HttpResponse.json(404, { status: 404 });
+      }),
+    );
+
+    try {
+      await httpClient.get(`/404`);
+      ok(false);
+    } catch (err) {
+      ok(err instanceof HTTPError);
+      equal(scope.isDone(), true);
+      equal(err.statusCode, 404);
+    }
+  });
+
+  it("will generate default params", async () => {
+    const scope = new MSWResult();
+    server.use(
+      http.get(baseURL + "/get", async ({ request }) => {
+        scope.done();
+        equal(request.headers.get("user-agent"), `${pkg.name}/${pkg.version}`);
+        return HttpResponse.json({});
+      }),
+    );
+
+    const httpClient = new HTTPClient();
+    const res = await httpClient.get<any>(`${baseURL}/get`);
+    equal(scope.isDone(), true);
+    deepEqual(res, {});
+  });
+});


### PR DESCRIPTION
xior is a similar axios library(not 100%), but based on fetch, and lightweight.

The only change compared to `http-axios` are: `import alias`, `getStream` and `error handle`, not much change :)

https://github.com/line/line-bot-sdk-nodejs/pull/737/files#diff-fe8f317fd21c10d835aa5660c095fa0f1d90702d1f4dfb69936f81b5c0eac1ceR1

https://github.com/line/line-bot-sdk-nodejs/pull/737/files#diff-fe8f317fd21c10d835aa5660c095fa0f1d90702d1f4dfb69936f81b5c0eac1ceR46

https://github.com/line/line-bot-sdk-nodejs/pull/737/files#diff-fe8f317fd21c10d835aa5660c095fa0f1d90702d1f4dfb69936f81b5c0eac1ceR167

