### PR TITLE
Add 'node:' prefix explicitly to import built-in modules

### DIFF
--- a/examples/rich-menu/index.js
+++ b/examples/rich-menu/index.js
@@ -2,7 +2,7 @@
 
 const line = require('@line/bot-sdk');
 const { join } = require("path");
-const { readFileSync } = require("fs");
+const { readFileSync } = require("node:fs");
 
 // create LINE SDK client
 const client = new line.messagingApi.MessagingApiClient({

--- a/examples/rich-menu/index.js
+++ b/examples/rich-menu/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const line = require('@line/bot-sdk');
-const { join } = require("path");
+const { join } = require("node:path");
 const { readFileSync } = require("node:fs");
 
 // create LINE SDK client

--- a/generator/src/main/resources/line-bot-sdk-nodejs-generator/api-single.pebble
+++ b/generator/src/main/resources/line-bot-sdk-nodejs-generator/api-single.pebble
@@ -9,7 +9,7 @@ import { {{import.classname}} } from '{{import.filename}}';
 {% endfor %}
 import * as Types from "../../types";
 import {ensureJSON} from "../../utils";
-import {Readable} from "stream";
+import {Readable} from "node:stream";
 
 import HTTPFetchClient, { convertResponseToReadable } from "../../http-fetch";
 

--- a/generator/src/main/resources/line-bot-sdk-nodejs-generator/api_test.pebble
+++ b/generator/src/main/resources/line-bot-sdk-nodejs-generator/api_test.pebble
@@ -7,7 +7,7 @@ import { {{operations.classname}} } from "../../api";
 import { {{import.classname}} } from '../{{import.filename}}';
 {% endfor %}
 
-import { createServer } from "http";
+import { createServer } from "node:http";
 import { deepEqual, equal, ok } from "node:assert";
 
 const pkg = require("../../../../package.json");

--- a/generator/src/main/resources/line-bot-sdk-nodejs-generator/api_test.pebble
+++ b/generator/src/main/resources/line-bot-sdk-nodejs-generator/api_test.pebble
@@ -8,7 +8,7 @@ import { {{import.classname}} } from '../{{import.filename}}';
 {% endfor %}
 
 import { createServer } from "http";
-import { deepEqual, equal, ok } from "assert";
+import { deepEqual, equal, ok } from "node:assert";
 
 const pkg = require("../../../../package.json");
 

--- a/lib/channel-access-token/api/channelAccessTokenClient.ts
+++ b/lib/channel-access-token/api/channelAccessTokenClient.ts
@@ -20,7 +20,7 @@ import { VerifyChannelAccessTokenResponse } from "../model/verifyChannelAccessTo
 
 import * as Types from "../../types";
 import { ensureJSON } from "../../utils";
-import { Readable } from "stream";
+import { Readable } from "node:stream";
 
 import HTTPFetchClient, { convertResponseToReadable } from "../../http-fetch";
 

--- a/lib/channel-access-token/tests/api/ChannelAccessTokenClientTest.spec.ts
+++ b/lib/channel-access-token/tests/api/ChannelAccessTokenClientTest.spec.ts
@@ -8,7 +8,7 @@ import { IssueStatelessChannelAccessTokenResponse } from "../../model/issueState
 import { VerifyChannelAccessTokenResponse } from "../../model/verifyChannelAccessTokenResponse";
 
 import { createServer } from "http";
-import { deepEqual, equal, ok } from "assert";
+import { deepEqual, equal, ok } from "node:assert";
 
 const pkg = require("../../../../package.json");
 

--- a/lib/channel-access-token/tests/api/ChannelAccessTokenClientTest.spec.ts
+++ b/lib/channel-access-token/tests/api/ChannelAccessTokenClientTest.spec.ts
@@ -7,7 +7,7 @@ import { IssueShortLivedChannelAccessTokenResponse } from "../../model/issueShor
 import { IssueStatelessChannelAccessTokenResponse } from "../../model/issueStatelessChannelAccessTokenResponse";
 import { VerifyChannelAccessTokenResponse } from "../../model/verifyChannelAccessTokenResponse";
 
-import { createServer } from "http";
+import { createServer } from "node:http";
 import { deepEqual, equal, ok } from "node:assert";
 
 const pkg = require("../../../../package.json");

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1,4 +1,4 @@
-import { Readable } from "stream";
+import { Readable } from "node:stream";
 import HTTPClient from "./http-axios";
 import * as Types from "./types";
 import { AxiosRequestConfig, AxiosResponse } from "axios";

--- a/lib/http-axios.ts
+++ b/lib/http-axios.ts
@@ -4,10 +4,10 @@ import axios, {
   AxiosResponse,
   AxiosRequestConfig,
 } from "axios";
-import { Readable } from "stream";
+import { Readable } from "node:stream";
 import { HTTPError, ReadError, RequestError } from "./exceptions";
 import * as fileType from "file-type";
-import * as qs from "querystring";
+import * as qs from "node:querystring";
 
 const pkg = require("../package.json");
 
@@ -45,7 +45,7 @@ export default class HTTPClient {
   public async getStream(url: string, params?: any): Promise<Readable> {
     const res = await this.instance.get(url, {
       params,
-      responseType: "stream",
+      responseType: "node:stream",
     });
     return res.data as Readable;
   }

--- a/lib/http-axios.ts
+++ b/lib/http-axios.ts
@@ -45,7 +45,7 @@ export default class HTTPClient {
   public async getStream(url: string, params?: any): Promise<Readable> {
     const res = await this.instance.get(url, {
       params,
-      responseType: "node:stream",
+      responseType: "stream",
     });
     return res.data as Readable;
   }

--- a/lib/http-fetch.ts
+++ b/lib/http-fetch.ts
@@ -1,6 +1,6 @@
-import { Readable } from "stream";
+import { Readable } from "node:stream";
 import { HTTPFetchError } from "./exceptions";
-import * as qs from "querystring";
+import * as qs from "node:querystring";
 
 const pkg = require("../package.json");
 export interface FetchRequestConfig {

--- a/lib/insight/api/insightClient.ts
+++ b/lib/insight/api/insightClient.ts
@@ -19,7 +19,7 @@ import { GetStatisticsPerUnitResponse } from "../model/getStatisticsPerUnitRespo
 
 import * as Types from "../../types";
 import { ensureJSON } from "../../utils";
-import { Readable } from "stream";
+import { Readable } from "node:stream";
 
 import HTTPFetchClient, { convertResponseToReadable } from "../../http-fetch";
 

--- a/lib/insight/tests/api/InsightClientTest.spec.ts
+++ b/lib/insight/tests/api/InsightClientTest.spec.ts
@@ -6,7 +6,7 @@ import { GetNumberOfFollowersResponse } from "../../model/getNumberOfFollowersRe
 import { GetNumberOfMessageDeliveriesResponse } from "../../model/getNumberOfMessageDeliveriesResponse";
 import { GetStatisticsPerUnitResponse } from "../../model/getStatisticsPerUnitResponse";
 
-import { createServer } from "http";
+import { createServer } from "node:http";
 import { deepEqual, equal, ok } from "node:assert";
 
 const pkg = require("../../../../package.json");

--- a/lib/insight/tests/api/InsightClientTest.spec.ts
+++ b/lib/insight/tests/api/InsightClientTest.spec.ts
@@ -7,7 +7,7 @@ import { GetNumberOfMessageDeliveriesResponse } from "../../model/getNumberOfMes
 import { GetStatisticsPerUnitResponse } from "../../model/getStatisticsPerUnitResponse";
 
 import { createServer } from "http";
-import { deepEqual, equal, ok } from "assert";
+import { deepEqual, equal, ok } from "node:assert";
 
 const pkg = require("../../../../package.json");
 

--- a/lib/liff/api/liffClient.ts
+++ b/lib/liff/api/liffClient.ts
@@ -18,7 +18,7 @@ import { UpdateLiffAppRequest } from "../model/updateLiffAppRequest";
 
 import * as Types from "../../types";
 import { ensureJSON } from "../../utils";
-import { Readable } from "stream";
+import { Readable } from "node:stream";
 
 import HTTPFetchClient, { convertResponseToReadable } from "../../http-fetch";
 

--- a/lib/liff/tests/api/LiffClientTest.spec.ts
+++ b/lib/liff/tests/api/LiffClientTest.spec.ts
@@ -5,7 +5,7 @@ import { AddLiffAppResponse } from "../../model/addLiffAppResponse";
 import { GetAllLiffAppsResponse } from "../../model/getAllLiffAppsResponse";
 import { UpdateLiffAppRequest } from "../../model/updateLiffAppRequest";
 
-import { createServer } from "http";
+import { createServer } from "node:http";
 import { deepEqual, equal, ok } from "node:assert";
 
 const pkg = require("../../../../package.json");

--- a/lib/liff/tests/api/LiffClientTest.spec.ts
+++ b/lib/liff/tests/api/LiffClientTest.spec.ts
@@ -6,7 +6,7 @@ import { GetAllLiffAppsResponse } from "../../model/getAllLiffAppsResponse";
 import { UpdateLiffAppRequest } from "../../model/updateLiffAppRequest";
 
 import { createServer } from "http";
-import { deepEqual, equal, ok } from "assert";
+import { deepEqual, equal, ok } from "node:assert";
 
 const pkg = require("../../../../package.json");
 

--- a/lib/manage-audience/api/manageAudienceBlobClient.ts
+++ b/lib/manage-audience/api/manageAudienceBlobClient.ts
@@ -15,7 +15,7 @@ import { CreateAudienceGroupResponse } from "../model/createAudienceGroupRespons
 
 import * as Types from "../../types";
 import { ensureJSON } from "../../utils";
-import { Readable } from "stream";
+import { Readable } from "node:stream";
 
 import HTTPFetchClient, { convertResponseToReadable } from "../../http-fetch";
 

--- a/lib/manage-audience/api/manageAudienceClient.ts
+++ b/lib/manage-audience/api/manageAudienceClient.ts
@@ -29,7 +29,7 @@ import { UpdateAudienceGroupDescriptionRequest } from "../model/updateAudienceGr
 
 import * as Types from "../../types";
 import { ensureJSON } from "../../utils";
-import { Readable } from "stream";
+import { Readable } from "node:stream";
 
 import HTTPFetchClient, { convertResponseToReadable } from "../../http-fetch";
 

--- a/lib/manage-audience/tests/api/ManageAudienceBlobClientTest.spec.ts
+++ b/lib/manage-audience/tests/api/ManageAudienceBlobClientTest.spec.ts
@@ -2,7 +2,7 @@ import { ManageAudienceBlobClient } from "../../api";
 
 import { CreateAudienceGroupResponse } from "../../model/createAudienceGroupResponse";
 
-import { createServer } from "http";
+import { createServer } from "node:http";
 import { deepEqual, equal, ok } from "node:assert";
 
 const pkg = require("../../../../package.json");

--- a/lib/manage-audience/tests/api/ManageAudienceBlobClientTest.spec.ts
+++ b/lib/manage-audience/tests/api/ManageAudienceBlobClientTest.spec.ts
@@ -3,7 +3,7 @@ import { ManageAudienceBlobClient } from "../../api";
 import { CreateAudienceGroupResponse } from "../../model/createAudienceGroupResponse";
 
 import { createServer } from "http";
-import { deepEqual, equal, ok } from "assert";
+import { deepEqual, equal, ok } from "node:assert";
 
 const pkg = require("../../../../package.json");
 

--- a/lib/manage-audience/tests/api/ManageAudienceClientTest.spec.ts
+++ b/lib/manage-audience/tests/api/ManageAudienceClientTest.spec.ts
@@ -17,7 +17,7 @@ import { UpdateAudienceGroupAuthorityLevelRequest } from "../../model/updateAudi
 import { UpdateAudienceGroupDescriptionRequest } from "../../model/updateAudienceGroupDescriptionRequest";
 
 import { createServer } from "http";
-import { deepEqual, equal, ok } from "assert";
+import { deepEqual, equal, ok } from "node:assert";
 
 const pkg = require("../../../../package.json");
 

--- a/lib/manage-audience/tests/api/ManageAudienceClientTest.spec.ts
+++ b/lib/manage-audience/tests/api/ManageAudienceClientTest.spec.ts
@@ -16,7 +16,7 @@ import { GetAudienceGroupsResponse } from "../../model/getAudienceGroupsResponse
 import { UpdateAudienceGroupAuthorityLevelRequest } from "../../model/updateAudienceGroupAuthorityLevelRequest";
 import { UpdateAudienceGroupDescriptionRequest } from "../../model/updateAudienceGroupDescriptionRequest";
 
-import { createServer } from "http";
+import { createServer } from "node:http";
 import { deepEqual, equal, ok } from "node:assert";
 
 const pkg = require("../../../../package.json");

--- a/lib/messaging-api/api/messagingApiBlobClient.ts
+++ b/lib/messaging-api/api/messagingApiBlobClient.ts
@@ -15,7 +15,7 @@ import { GetMessageContentTranscodingResponse } from "../model/getMessageContent
 
 import * as Types from "../../types";
 import { ensureJSON } from "../../utils";
-import { Readable } from "stream";
+import { Readable } from "node:stream";
 
 import HTTPFetchClient, { convertResponseToReadable } from "../../http-fetch";
 

--- a/lib/messaging-api/api/messagingApiClient.ts
+++ b/lib/messaging-api/api/messagingApiClient.ts
@@ -58,7 +58,7 @@ import { ValidateMessageRequest } from "../model/validateMessageRequest";
 
 import * as Types from "../../types";
 import { ensureJSON } from "../../utils";
-import { Readable } from "stream";
+import { Readable } from "node:stream";
 
 import HTTPFetchClient, { convertResponseToReadable } from "../../http-fetch";
 

--- a/lib/messaging-api/tests/api/MessagingApiBlobClientTest.spec.ts
+++ b/lib/messaging-api/tests/api/MessagingApiBlobClientTest.spec.ts
@@ -3,7 +3,7 @@ import { MessagingApiBlobClient } from "../../api";
 import { GetMessageContentTranscodingResponse } from "../../model/getMessageContentTranscodingResponse";
 
 import { createServer } from "http";
-import { deepEqual, equal, ok } from "assert";
+import { deepEqual, equal, ok } from "node:assert";
 
 const pkg = require("../../../../package.json");
 

--- a/lib/messaging-api/tests/api/MessagingApiBlobClientTest.spec.ts
+++ b/lib/messaging-api/tests/api/MessagingApiBlobClientTest.spec.ts
@@ -2,7 +2,7 @@ import { MessagingApiBlobClient } from "../../api";
 
 import { GetMessageContentTranscodingResponse } from "../../model/getMessageContentTranscodingResponse";
 
-import { createServer } from "http";
+import { createServer } from "node:http";
 import { deepEqual, equal, ok } from "node:assert";
 
 const pkg = require("../../../../package.json");

--- a/lib/messaging-api/tests/api/MessagingApiClientTest.spec.ts
+++ b/lib/messaging-api/tests/api/MessagingApiClientTest.spec.ts
@@ -45,7 +45,7 @@ import { UpdateRichMenuAliasRequest } from "../../model/updateRichMenuAliasReque
 import { UserProfileResponse } from "../../model/userProfileResponse";
 import { ValidateMessageRequest } from "../../model/validateMessageRequest";
 
-import { createServer } from "http";
+import { createServer } from "node:http";
 import { deepEqual, equal, ok } from "node:assert";
 
 const pkg = require("../../../../package.json");

--- a/lib/messaging-api/tests/api/MessagingApiClientTest.spec.ts
+++ b/lib/messaging-api/tests/api/MessagingApiClientTest.spec.ts
@@ -46,7 +46,7 @@ import { UserProfileResponse } from "../../model/userProfileResponse";
 import { ValidateMessageRequest } from "../../model/validateMessageRequest";
 
 import { createServer } from "http";
-import { deepEqual, equal, ok } from "assert";
+import { deepEqual, equal, ok } from "node:assert";
 
 const pkg = require("../../../../package.json");
 

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -1,5 +1,5 @@
 import { raw } from "body-parser";
-import * as http from "http";
+import * as http from "node:http";
 import { JSONParseError, SignatureValidationFailed } from "./exceptions";
 import * as Types from "./types";
 import validateSignature from "./validate-signature";

--- a/lib/module-attach/api/lineModuleAttachClient.ts
+++ b/lib/module-attach/api/lineModuleAttachClient.ts
@@ -15,7 +15,7 @@ import { AttachModuleResponse } from "../model/attachModuleResponse";
 
 import * as Types from "../../types";
 import { ensureJSON } from "../../utils";
-import { Readable } from "stream";
+import { Readable } from "node:stream";
 
 import HTTPFetchClient, { convertResponseToReadable } from "../../http-fetch";
 

--- a/lib/module-attach/tests/api/LineModuleAttachClientTest.spec.ts
+++ b/lib/module-attach/tests/api/LineModuleAttachClientTest.spec.ts
@@ -3,7 +3,7 @@ import { LineModuleAttachClient } from "../../api";
 import { AttachModuleResponse } from "../../model/attachModuleResponse";
 
 import { createServer } from "http";
-import { deepEqual, equal, ok } from "assert";
+import { deepEqual, equal, ok } from "node:assert";
 
 const pkg = require("../../../../package.json");
 

--- a/lib/module-attach/tests/api/LineModuleAttachClientTest.spec.ts
+++ b/lib/module-attach/tests/api/LineModuleAttachClientTest.spec.ts
@@ -2,7 +2,7 @@ import { LineModuleAttachClient } from "../../api";
 
 import { AttachModuleResponse } from "../../model/attachModuleResponse";
 
-import { createServer } from "http";
+import { createServer } from "node:http";
 import { deepEqual, equal, ok } from "node:assert";
 
 const pkg = require("../../../../package.json");

--- a/lib/module/api/lineModuleClient.ts
+++ b/lib/module/api/lineModuleClient.ts
@@ -17,7 +17,7 @@ import { GetModulesResponse } from "../model/getModulesResponse";
 
 import * as Types from "../../types";
 import { ensureJSON } from "../../utils";
-import { Readable } from "stream";
+import { Readable } from "node:stream";
 
 import HTTPFetchClient, { convertResponseToReadable } from "../../http-fetch";
 

--- a/lib/module/tests/api/LineModuleClientTest.spec.ts
+++ b/lib/module/tests/api/LineModuleClientTest.spec.ts
@@ -5,7 +5,7 @@ import { DetachModuleRequest } from "../../model/detachModuleRequest";
 import { GetModulesResponse } from "../../model/getModulesResponse";
 
 import { createServer } from "http";
-import { deepEqual, equal, ok } from "assert";
+import { deepEqual, equal, ok } from "node:assert";
 
 const pkg = require("../../../../package.json");
 

--- a/lib/module/tests/api/LineModuleClientTest.spec.ts
+++ b/lib/module/tests/api/LineModuleClientTest.spec.ts
@@ -4,7 +4,7 @@ import { AcquireChatControlRequest } from "../../model/acquireChatControlRequest
 import { DetachModuleRequest } from "../../model/detachModuleRequest";
 import { GetModulesResponse } from "../../model/getModulesResponse";
 
-import { createServer } from "http";
+import { createServer } from "node:http";
 import { deepEqual, equal, ok } from "node:assert";
 
 const pkg = require("../../../../package.json");

--- a/lib/shop/api/shopClient.ts
+++ b/lib/shop/api/shopClient.ts
@@ -15,7 +15,7 @@ import { MissionStickerRequest } from "../model/missionStickerRequest";
 
 import * as Types from "../../types";
 import { ensureJSON } from "../../utils";
-import { Readable } from "stream";
+import { Readable } from "node:stream";
 
 import HTTPFetchClient, { convertResponseToReadable } from "../../http-fetch";
 

--- a/lib/shop/tests/api/ShopClientTest.spec.ts
+++ b/lib/shop/tests/api/ShopClientTest.spec.ts
@@ -3,7 +3,7 @@ import { ShopClient } from "../../api";
 import { MissionStickerRequest } from "../../model/missionStickerRequest";
 
 import { createServer } from "http";
-import { deepEqual, equal, ok } from "assert";
+import { deepEqual, equal, ok } from "node:assert";
 
 const pkg = require("../../../../package.json");
 

--- a/lib/shop/tests/api/ShopClientTest.spec.ts
+++ b/lib/shop/tests/api/ShopClientTest.spec.ts
@@ -2,7 +2,7 @@ import { ShopClient } from "../../api";
 
 import { MissionStickerRequest } from "../../model/missionStickerRequest";
 
-import { createServer } from "http";
+import { createServer } from "node:http";
 import { deepEqual, equal, ok } from "node:assert";
 
 const pkg = require("../../../../package.json");

--- a/lib/validate-signature.ts
+++ b/lib/validate-signature.ts
@@ -1,4 +1,4 @@
-import { createHmac, timingSafeEqual } from "crypto";
+import { createHmac, timingSafeEqual } from "node:crypto";
 
 function s2b(str: string, encoding: BufferEncoding): Buffer {
   return Buffer.from(str, encoding);

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { join } from "path";
+import { join } from "node:path";
 import { deepEqual, equal, ok, strictEqual } from "assert";
 import { URL } from "url";
 import Client, { OAuth } from "../lib/client";

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { deepEqual, equal, ok, strictEqual } from "assert";
+import { deepEqual, equal, ok, strictEqual } from "node:assert";
 import { URL } from "node:url";
 import Client, { OAuth } from "../lib/client";
 import * as Types from "../lib/types";

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "fs";
+import { readFileSync } from "node:fs";
 import { join } from "path";
 import { deepEqual, equal, ok, strictEqual } from "assert";
 import { URL } from "url";

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { deepEqual, equal, ok, strictEqual } from "assert";
-import { URL } from "url";
+import { URL } from "node:url";
 import Client, { OAuth } from "../lib/client";
 import * as Types from "../lib/types";
 import { getStreamData } from "./helpers/stream";

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -13,7 +13,6 @@ import {
   OAUTH_BASE_PREFIX,
   OAUTH_BASE_PREFIX_V2_1,
 } from "../lib/endpoints";
-import exp = require("constants");
 
 const pkg = require("../package.json");
 

--- a/test/helpers/stream.ts
+++ b/test/helpers/stream.ts
@@ -1,4 +1,4 @@
-import { Readable } from "stream";
+import { Readable } from "node:stream";
 
 export function getStreamData(stream: Readable): Promise<string> {
   return new Promise(resolve => {

--- a/test/helpers/test-server.ts
+++ b/test/helpers/test-server.ts
@@ -1,7 +1,7 @@
 import * as bodyParser from "body-parser";
 import * as express from "express";
 import { Server } from "node:http";
-import { join } from "path";
+import { join } from "node:path";
 import { writeFileSync } from "node:fs";
 import {
   JSONParseError,

--- a/test/helpers/test-server.ts
+++ b/test/helpers/test-server.ts
@@ -1,6 +1,6 @@
 import * as bodyParser from "body-parser";
 import * as express from "express";
-import { Server } from "http";
+import { Server } from "node:http";
 import { join } from "path";
 import { writeFileSync } from "node:fs";
 import {

--- a/test/helpers/test-server.ts
+++ b/test/helpers/test-server.ts
@@ -2,7 +2,7 @@ import * as bodyParser from "body-parser";
 import * as express from "express";
 import { Server } from "http";
 import { join } from "path";
-import { writeFileSync } from "fs";
+import { writeFileSync } from "node:fs";
 import {
   JSONParseError,
   SignatureValidationFailed,

--- a/test/http-axios.spec.ts
+++ b/test/http-axios.spec.ts
@@ -4,9 +4,9 @@ import HTTPClient from "../lib/http-axios";
 import { getStreamData } from "./helpers/stream";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
-import { createReadStream, readFileSync } from "fs";
+import { createReadStream, readFileSync } from "node:fs";
 import { join } from "path";
-import * as fs from "fs";
+import * as fs from "node:fs";
 
 const pkg = require("../package.json");
 const baseURL = "https://line.me";

--- a/test/http-axios.spec.ts
+++ b/test/http-axios.spec.ts
@@ -1,4 +1,4 @@
-import { deepEqual, equal, ok } from "assert";
+import { deepEqual, equal, ok } from "node:assert";
 import { HTTPError } from "../lib/exceptions";
 import HTTPClient from "../lib/http-axios";
 import { getStreamData } from "./helpers/stream";

--- a/test/http-axios.spec.ts
+++ b/test/http-axios.spec.ts
@@ -5,7 +5,7 @@ import { getStreamData } from "./helpers/stream";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import { createReadStream, readFileSync } from "node:fs";
-import { join } from "path";
+import { join } from "node:path";
 import * as fs from "node:fs";
 
 const pkg = require("../package.json");

--- a/test/http-fetch.spec.ts
+++ b/test/http-fetch.spec.ts
@@ -4,7 +4,7 @@ import HTTPFetchClient, { convertResponseToReadable } from "../lib/http-fetch";
 import { getStreamData } from "./helpers/stream";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
-import { join } from "path";
+import { join } from "node:path";
 import * as fs from "node:fs";
 
 const pkg = require("../package.json");

--- a/test/http-fetch.spec.ts
+++ b/test/http-fetch.spec.ts
@@ -1,4 +1,4 @@
-import { deepEqual, equal, ok } from "assert";
+import { deepEqual, equal, ok } from "node:assert";
 import { HTTPFetchError } from "../lib";
 import HTTPFetchClient, { convertResponseToReadable } from "../lib/http-fetch";
 import { getStreamData } from "./helpers/stream";

--- a/test/http-fetch.spec.ts
+++ b/test/http-fetch.spec.ts
@@ -5,7 +5,7 @@ import { getStreamData } from "./helpers/stream";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import { join } from "path";
-import * as fs from "fs";
+import * as fs from "node:fs";
 
 const pkg = require("../package.json");
 const baseURL = "https://line.me";

--- a/test/libs-channelAccessToken.spec.ts
+++ b/test/libs-channelAccessToken.spec.ts
@@ -1,7 +1,7 @@
 import { channelAccessToken } from "../lib";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
-import { deepEqual, equal } from "assert";
+import { deepEqual, equal } from "node:assert";
 
 const pkg = require("../package.json");
 

--- a/test/libs-manageAudience.spec.ts
+++ b/test/libs-manageAudience.spec.ts
@@ -1,7 +1,7 @@
 import { manageAudience } from "../lib";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
-import { deepEqual, equal, match } from "assert";
+import { deepEqual, equal, match } from "node:assert";
 
 const pkg = require("../package.json");
 

--- a/test/libs-messagingApi.spec.ts
+++ b/test/libs-messagingApi.spec.ts
@@ -1,7 +1,7 @@
 import { messagingApi } from "../lib";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
-import { deepEqual, equal } from "assert";
+import { deepEqual, equal } from "node:assert";
 
 const pkg = require("../package.json");
 

--- a/test/libs-shop.spec.ts
+++ b/test/libs-shop.spec.ts
@@ -1,7 +1,7 @@
 import { shop } from "../lib";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
-import { deepEqual, equal } from "assert";
+import { deepEqual, equal } from "node:assert";
 
 const pkg = require("../package.json");
 

--- a/test/middleware.spec.ts
+++ b/test/middleware.spec.ts
@@ -1,6 +1,6 @@
 import { deepEqual, equal, ok } from "assert";
 import { readFileSync } from "node:fs";
-import { join } from "path";
+import { join } from "node:path";
 import { HTTPError } from "../lib/exceptions";
 import HTTPClient from "../lib/http-axios";
 import middleware from "../lib/middleware";

--- a/test/middleware.spec.ts
+++ b/test/middleware.spec.ts
@@ -1,5 +1,5 @@
 import { deepEqual, equal, ok } from "assert";
-import { readFileSync } from "fs";
+import { readFileSync } from "node:fs";
 import { join } from "path";
 import { HTTPError } from "../lib/exceptions";
 import HTTPClient from "../lib/http-axios";

--- a/test/middleware.spec.ts
+++ b/test/middleware.spec.ts
@@ -1,4 +1,4 @@
-import { deepEqual, equal, ok } from "assert";
+import { deepEqual, equal, ok } from "node:assert";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { HTTPError } from "../lib/exceptions";

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -1,6 +1,6 @@
 import { ensureJSON } from "../lib/utils";
 import { JSONParseError } from "../lib/exceptions";
-import { equal, ok } from "assert";
+import { equal, ok } from "node:assert";
 
 describe("utils", () => {
   describe("ensureJSON", () => {

--- a/test/validate-signature.spec.ts
+++ b/test/validate-signature.spec.ts
@@ -1,4 +1,4 @@
-import { ok } from "assert";
+import { ok } from "node:assert";
 import validateSignature from "../lib/validate-signature";
 
 const body = { hello: "world" };


### PR DESCRIPTION
Current Node.js v18 allows us to use `node:` prefix to import built-in modules. line-bot-sdk-nodejs only supports Node.js version >= 18, this won't affect normal line-bot-sdk-nodejs users.


ref: https://github.com/nodejs/node/issues/36098, https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V14.md#2021-09-28-version-14180-fermium-lts-targos
ref: https://nodejs.org/api/esm.html#node-imports

list: https://github.com/sindresorhus/builtin-modules/blob/main/builtin-modules.json