### PR TITLE
Bye node:querystring

### DIFF
--- a/lib/http-axios.ts
+++ b/lib/http-axios.ts
@@ -7,7 +7,6 @@ import axios, {
 import { Readable } from "node:stream";
 import { HTTPError, ReadError, RequestError } from "./exceptions";
 import * as fileType from "file-type";
-import * as qs from "node:querystring";
 
 const pkg = require("../package.json");
 
@@ -89,7 +88,13 @@ export default class HTTPClient {
   }
 
   public async postForm<T>(url: string, body?: any): Promise<T> {
-    const res = await this.instance.post(url, qs.stringify(body), {
+    const params = new URLSearchParams();
+    for (const key in body) {
+      if (body.hasOwnProperty(key)) {
+        params.append(key, body[key]);
+      }
+    }
+    const res = await this.instance.post(url, params.toString(), {
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
     });
 

--- a/lib/http-fetch.ts
+++ b/lib/http-fetch.ts
@@ -1,6 +1,5 @@
 import { Readable } from "node:stream";
 import { HTTPFetchError } from "./exceptions";
-import * as qs from "node:querystring";
 
 const pkg = require("../package.json");
 export interface FetchRequestConfig {
@@ -41,7 +40,13 @@ export default class HTTPFetchClient {
   public async get<T>(url: string, params?: any): Promise<Response> {
     const requestUrl = new URL(url, this.baseURL);
     if (params) {
-      requestUrl.search = qs.stringify(params);
+      const searchParams = new URLSearchParams();
+      for (const key in params) {
+        if (params.hasOwnProperty(key)) {
+          searchParams.append(key, params[key]);
+        }
+      }
+      requestUrl.search = searchParams.toString();
     }
     const response = await fetch(requestUrl, {
       headers: this.defaultHeaders,
@@ -90,13 +95,19 @@ export default class HTTPFetchClient {
 
   public async postForm(url: string, body?: any): Promise<Response> {
     const requestUrl = new URL(url, this.baseURL);
+    const params = new URLSearchParams();
+    for (const key in body) {
+      if (body.hasOwnProperty(key)) {
+        params.append(key, body[key]);
+      }
+    }
     const response = await fetch(requestUrl, {
       method: "POST",
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
         ...this.defaultHeaders,
       },
-      body: qs.stringify(body),
+      body: params.toString(),
     });
     await this.checkResponseStatus(response);
     return response;

--- a/test/libs-messagingApi.spec.ts
+++ b/test/libs-messagingApi.spec.ts
@@ -120,4 +120,41 @@ describe("messagingApi", () => {
     equal(requestCount, 1);
     deepEqual(res, {});
   });
+
+  it("get followers", async () => {
+    let requestCount = 0;
+    server.use(
+      http.get(
+        "https://api.line.me/v2/bot/followers/ids",
+        async ({ request, params, cookies }) => {
+          requestCount++;
+
+          equal(
+            request.headers.get("Authorization"),
+            "Bearer test_channel_access_token",
+          );
+          equal(
+            request.headers.get("User-Agent"),
+            `${pkg.name}/${pkg.version}`,
+          );
+
+          const url = new URL(request.url);
+          const searchParams = url.searchParams;
+          equal(searchParams.get("start"), "xBQU2IB");
+          equal(searchParams.get("limit"), "100");
+
+          return HttpResponse.json({
+            userIds: ["UAAAAAAAAAAAAAA"],
+            next: "yANU9IA..",
+          });
+        },
+      ),
+    );
+
+    const res = await client.getFollowers("xBQU2IB", 100);
+    deepEqual(res, {
+      userIds: ["UAAAAAAAAAAAAAA"],
+      next: "yANU9IA..",
+    });
+  });
 });


### PR DESCRIPTION
now we don't have to use `node:querystring` because the usage is very simple.
 
Resolve #748 