### PR TITLE
Do not publish tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,11 @@
   },
   "sideEffects": false,
   "files": [
-    "dist"
+    "dist",
+    "lib",
+    "!lib/**/tests",
+    "!dist/*/tests",
+    "!dist/cjs/*/tests"
   ],
   "scripts": {
     "pretest": "npm run format && npm run build",


### PR DESCRIPTION
We don't have to publish test files at all.

ref: https://www.npmjs.com/package/@line/bot-sdk/v/9.0.4?activeTab=code (dist > messaging-api > tests)