### PR TITLE
Remove unknown types from model generator

### DIFF
--- a/examples/echo-bot-ts-cjs/index.ts
+++ b/examples/echo-bot-ts-cjs/index.ts
@@ -27,22 +27,24 @@ const client = new messagingApi.MessagingApiClient(clientConfig);
 // Create a new Express application.
 const app: Application = express();
 
-const isTextEvent = (event: any): event is webhook.MessageEvent & { message: webhook.TextMessageContent } => {
-  return event.type === 'message' && event.message && event.message.type === 'text';
-};
-
 // Function handler to receive the text.
 const textEventHandler = async (event: webhook.Event): Promise<MessageAPIResponseBase | undefined> => {
   // Process all variables here.
-  if (!isTextEvent(event)) {
+
+  // Check if for a text message
+  if (event.type !== 'message' || event.message.type !== 'text') {
     return;
   }
 
   // Process all message related variables here.
+
+  // Check if message is repliable
+  if (!event.replyToken) return;
+  
   // Create a new message.
   // Reply to the user.
   await client.replyMessage({
-    replyToken: event.replyToken as string,
+    replyToken:event.replyToken,
     messages: [{
       type: 'text',
       text: event.message.text,

--- a/examples/echo-bot-ts-esm/index.ts
+++ b/examples/echo-bot-ts-esm/index.ts
@@ -27,22 +27,25 @@ const client = new messagingApi.MessagingApiClient(clientConfig);
 // Create a new Express application.
 const app: Application = express();
 
-const isTextEvent = (event: any): event is webhook.MessageEvent & { message: webhook.TextMessageContent } => {
-  return event.type === 'message' && event.message && event.message.type === 'text';
-};
 
 // Function handler to receive the text.
 const textEventHandler = async (event: webhook.Event): Promise<MessageAPIResponseBase | undefined> => {
   // Process all variables here.
-  if (!isTextEvent(event)) {
+
+  // Check if for a text message
+  if (event.type !== 'message' || event.message.type !== 'text') {
     return;
   }
 
   // Process all message related variables here.
+
+  // Check if message is repliable
+  if (!event.replyToken) return;
+  
   // Create a new message.
   // Reply to the user.
   await client.replyMessage({
-    replyToken: event.replyToken as string,
+    replyToken:event.replyToken,
     messages: [{
       type: 'text',
       text: event.message.text,

--- a/generator/src/main/resources/line-bot-sdk-nodejs-generator/model.pebble
+++ b/generator/src/main/resources/line-bot-sdk-nodejs-generator/model.pebble
@@ -15,12 +15,8 @@ export type {{classname}} =
         {%- for model in model.model.discriminator.mappedModels %}
         | {{model.modelName}} // {{model.mappingName}}
         {%- endfor %}
-        | Unknown{{classname}}
 ;
 
-export type Unknown{{classname}} = {{classname}}Base & {
-    [key: string]: unknown;
-};
     {% endif -%}
 
     {% if model.model.description != null %}

--- a/lib/messaging-api/model/action.ts
+++ b/lib/messaging-api/model/action.ts
@@ -29,12 +29,7 @@ export type Action =
   | MessageAction // message
   | PostbackAction // postback
   | RichMenuSwitchAction // richmenuswitch
-  | URIAction // uri
-  | UnknownAction;
-
-export type UnknownAction = ActionBase & {
-  [key: string]: unknown;
-};
+  | URIAction; // uri
 
 /**
  * Action

--- a/lib/messaging-api/model/demographicFilter.ts
+++ b/lib/messaging-api/model/demographicFilter.ts
@@ -23,12 +23,7 @@ export type DemographicFilter =
   | AreaDemographicFilter // area
   | GenderDemographicFilter // gender
   | OperatorDemographicFilter // operator
-  | SubscriptionPeriodDemographicFilter // subscriptionPeriod
-  | UnknownDemographicFilter;
-
-export type UnknownDemographicFilter = DemographicFilterBase & {
-  [key: string]: unknown;
-};
+  | SubscriptionPeriodDemographicFilter; // subscriptionPeriod
 
 /**
  * Demographic filter

--- a/lib/messaging-api/model/flexBoxBackground.ts
+++ b/lib/messaging-api/model/flexBoxBackground.ts
@@ -12,13 +12,7 @@
 
 import { FlexBoxLinearGradient } from "./models.js";
 
-export type FlexBoxBackground =
-  | FlexBoxLinearGradient // linearGradient
-  | UnknownFlexBoxBackground;
-
-export type UnknownFlexBoxBackground = FlexBoxBackgroundBase & {
-  [key: string]: unknown;
-};
+export type FlexBoxBackground = FlexBoxLinearGradient; // linearGradient
 
 export type FlexBoxBackgroundBase = {
   /**

--- a/lib/messaging-api/model/flexComponent.ts
+++ b/lib/messaging-api/model/flexComponent.ts
@@ -29,12 +29,7 @@ export type FlexComponent =
   | FlexSeparator // separator
   | FlexSpan // span
   | FlexText // text
-  | FlexVideo // video
-  | UnknownFlexComponent;
-
-export type UnknownFlexComponent = FlexComponentBase & {
-  [key: string]: unknown;
-};
+  | FlexVideo; // video
 
 export type FlexComponentBase = {
   /**

--- a/lib/messaging-api/model/flexContainer.ts
+++ b/lib/messaging-api/model/flexContainer.ts
@@ -15,12 +15,7 @@ import { FlexCarousel } from "./models.js";
 
 export type FlexContainer =
   | FlexBubble // bubble
-  | FlexCarousel // carousel
-  | UnknownFlexContainer;
-
-export type UnknownFlexContainer = FlexContainerBase & {
-  [key: string]: unknown;
-};
+  | FlexCarousel; // carousel
 
 export type FlexContainerBase = {
   /**

--- a/lib/messaging-api/model/imagemapAction.ts
+++ b/lib/messaging-api/model/imagemapAction.ts
@@ -19,12 +19,7 @@ import { URIImagemapAction } from "./models.js";
 export type ImagemapAction =
   | ClipboardImagemapAction // clipboard
   | MessageImagemapAction // message
-  | URIImagemapAction // uri
-  | UnknownImagemapAction;
-
-export type UnknownImagemapAction = ImagemapActionBase & {
-  [key: string]: unknown;
-};
+  | URIImagemapAction; // uri
 
 export type ImagemapActionBase = {
   /**

--- a/lib/messaging-api/model/message.ts
+++ b/lib/messaging-api/model/message.ts
@@ -32,12 +32,7 @@ export type Message =
   | StickerMessage // sticker
   | TemplateMessage // template
   | TextMessage // text
-  | VideoMessage // video
-  | UnknownMessage;
-
-export type UnknownMessage = MessageBase & {
-  [key: string]: unknown;
-};
+  | VideoMessage; // video
 
 export type MessageBase = {
   /**

--- a/lib/messaging-api/model/recipient.ts
+++ b/lib/messaging-api/model/recipient.ts
@@ -17,12 +17,7 @@ import { RedeliveryRecipient } from "./models.js";
 export type Recipient =
   | AudienceRecipient // audience
   | OperatorRecipient // operator
-  | RedeliveryRecipient // redelivery
-  | UnknownRecipient;
-
-export type UnknownRecipient = RecipientBase & {
-  [key: string]: unknown;
-};
+  | RedeliveryRecipient; // redelivery
 
 /**
  * Recipient

--- a/lib/messaging-api/model/richMenuBatchOperation.ts
+++ b/lib/messaging-api/model/richMenuBatchOperation.ts
@@ -17,12 +17,7 @@ import { RichMenuBatchUnlinkAllOperation } from "./models.js";
 export type RichMenuBatchOperation =
   | RichMenuBatchLinkOperation // link
   | RichMenuBatchUnlinkOperation // unlink
-  | RichMenuBatchUnlinkAllOperation // unlinkAll
-  | UnknownRichMenuBatchOperation;
-
-export type UnknownRichMenuBatchOperation = RichMenuBatchOperationBase & {
-  [key: string]: unknown;
-};
+  | RichMenuBatchUnlinkAllOperation; // unlinkAll
 
 /**
  * Rich menu operation object represents the batch operation to the rich menu linked to the user.

--- a/lib/messaging-api/model/template.ts
+++ b/lib/messaging-api/model/template.ts
@@ -19,12 +19,7 @@ export type Template =
   | ButtonsTemplate // buttons
   | CarouselTemplate // carousel
   | ConfirmTemplate // confirm
-  | ImageCarouselTemplate // image_carousel
-  | UnknownTemplate;
-
-export type UnknownTemplate = TemplateBase & {
-  [key: string]: unknown;
-};
+  | ImageCarouselTemplate; // image_carousel
 
 export type TemplateBase = {
   /**

--- a/lib/webhook/model/event.ts
+++ b/lib/webhook/model/event.ts
@@ -53,12 +53,7 @@ export type Event =
   | ThingsEvent // things
   | UnfollowEvent // unfollow
   | UnsendEvent // unsend
-  | VideoPlayCompleteEvent // videoPlayComplete
-  | UnknownEvent;
-
-export type UnknownEvent = EventBase & {
-  [key: string]: unknown;
-};
+  | VideoPlayCompleteEvent; // videoPlayComplete
 
 /**
  * Webhook event

--- a/lib/webhook/model/mentionee.ts
+++ b/lib/webhook/model/mentionee.ts
@@ -15,12 +15,7 @@ import { UserMentionee } from "./models.js";
 
 export type Mentionee =
   | AllMentionee // all
-  | UserMentionee // user
-  | UnknownMentionee;
-
-export type UnknownMentionee = MentioneeBase & {
-  [key: string]: unknown;
-};
+  | UserMentionee; // user
 
 export type MentioneeBase = {
   /**

--- a/lib/webhook/model/messageContent.ts
+++ b/lib/webhook/model/messageContent.ts
@@ -25,12 +25,7 @@ export type MessageContent =
   | LocationMessageContent // location
   | StickerMessageContent // sticker
   | TextMessageContent // text
-  | VideoMessageContent // video
-  | UnknownMessageContent;
-
-export type UnknownMessageContent = MessageContentBase & {
-  [key: string]: unknown;
-};
+  | VideoMessageContent; // video
 
 export type MessageContentBase = {
   /**

--- a/lib/webhook/model/moduleContent.ts
+++ b/lib/webhook/model/moduleContent.ts
@@ -15,12 +15,7 @@ import { DetachedModuleContent } from "./models.js";
 
 export type ModuleContent =
   | AttachedModuleContent // attached
-  | DetachedModuleContent // detached
-  | UnknownModuleContent;
-
-export type UnknownModuleContent = ModuleContentBase & {
-  [key: string]: unknown;
-};
+  | DetachedModuleContent; // detached
 
 export type ModuleContentBase = {
   /**

--- a/lib/webhook/model/source.ts
+++ b/lib/webhook/model/source.ts
@@ -17,12 +17,7 @@ import { UserSource } from "./models.js";
 export type Source =
   | GroupSource // group
   | RoomSource // room
-  | UserSource // user
-  | UnknownSource;
-
-export type UnknownSource = SourceBase & {
-  [key: string]: unknown;
-};
+  | UserSource; // user
 
 /**
  * the source of the event.

--- a/lib/webhook/model/thingsContent.ts
+++ b/lib/webhook/model/thingsContent.ts
@@ -17,12 +17,7 @@ import { UnlinkThingsContent } from "./models.js";
 export type ThingsContent =
   | LinkThingsContent // link
   | ScenarioResultThingsContent // scenarioResult
-  | UnlinkThingsContent // unlink
-  | UnknownThingsContent;
-
-export type UnknownThingsContent = ThingsContentBase & {
-  [key: string]: unknown;
-};
+  | UnlinkThingsContent; // unlink
 
 export type ThingsContentBase = {
   /**


### PR DESCRIPTION
This PR removes the unknown model types generated from OpenAPI model generator.
This ensures strict type safety and a better developer experience while using the generated clients.

Closes : #831 