### PR TITLE
Use node:buffer explicitly

### DIFF
--- a/lib/http-fetch.ts
+++ b/lib/http-fetch.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { Readable } from "node:stream";
 import { HTTPFetchError } from "./exceptions.js";
 import { USER_AGENT } from "./version.js";

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -1,4 +1,5 @@
 import * as http from "node:http";
+import { Buffer } from "node:buffer";
 import { JSONParseError, SignatureValidationFailed } from "./exceptions.js";
 import * as Types from "./types.js";
 import validateSignature from "./validate-signature.js";

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { JSONParseError } from "./exceptions.js";
 
 export function toArray<T>(maybeArr: T | T[]): T[] {

--- a/lib/validate-signature.ts
+++ b/lib/validate-signature.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { createHmac, timingSafeEqual } from "node:crypto";
 
 function s2b(str: string, encoding: BufferEncoding): Buffer {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "types": "./dist/cjs/index.d.ts",
         "default": "./dist/cjs/index.js"
       },
-       "default": "./dist/cjs/index.js"
+      "default": "./dist/cjs/index.js"
     },
     "./package.json": "./package.json"
   },
@@ -47,7 +47,6 @@
     "docs:preview": "vitepress preview docs",
     "docs:deploy": "./scripts/deploy-docs.sh",
     "apidocs": "typedoc --excludePrivate --plugin typedoc-plugin-markdown --out docs/apidocs lib/index.ts",
-    "generate-changelog": "ts-node ./scripts/generate-changelog.ts",
     "release": "npm run build && npm publish --access public"
   },
   "repository": {

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { Buffer } from "node:buffer";
 import { join } from "node:path";
 import { deepEqual, equal, ok, strictEqual } from "node:assert";
 import { URL } from "node:url";

--- a/test/helpers/test-server.ts
+++ b/test/helpers/test-server.ts
@@ -1,4 +1,5 @@
 import * as bodyParser from "body-parser";
+import { Buffer } from "node:buffer";
 import express from "express";
 import { Server } from "node:http";
 import { join } from "node:path";


### PR DESCRIPTION
While it works without explicit [`node:buffer`](https://github.com/nodejs/node/blob/main/doc/api/buffer.md) in a Node.js environment, it won't work in environments compatible with Node.js. There's no downside to explicitly using `node:buffer`. This change supports that.