### PR TITLE
Do not override base url

### DIFF
--- a/generator/src/main/resources/line-bot-sdk-nodejs-generator/api-single.pebble
+++ b/generator/src/main/resources/line-bot-sdk-nodejs-generator/api-single.pebble
@@ -30,16 +30,14 @@ export class {{operations.classname}} {
     private httpClient: HTTPFetchClient;
 
     constructor(config: httpClientConfig) {
-        if (!config.baseURL) {
-            config.baseURL = '{{endpoint(operations.classname)}}';
-        }
+        const baseURL = config.baseURL || '{{endpoint(operations.classname)}}';
         this.httpClient = new HTTPFetchClient({
             defaultHeaders: {
                 {% if authMethods != null -%}
                 Authorization: "Bearer " + config.channelAccessToken,
                 {% endif -%}
             },
-            baseURL: config.baseURL,
+            baseURL: baseURL,
         });
     }
 

--- a/lib/channel-access-token/api/channelAccessTokenClient.ts
+++ b/lib/channel-access-token/api/channelAccessTokenClient.ts
@@ -39,12 +39,10 @@ export class ChannelAccessTokenClient {
   private httpClient: HTTPFetchClient;
 
   constructor(config: httpClientConfig) {
-    if (!config.baseURL) {
-      config.baseURL = "https://api.line.me";
-    }
+    const baseURL = config.baseURL || "https://api.line.me";
     this.httpClient = new HTTPFetchClient({
       defaultHeaders: {},
-      baseURL: config.baseURL,
+      baseURL: baseURL,
     });
   }
 

--- a/lib/insight/api/insightClient.ts
+++ b/lib/insight/api/insightClient.ts
@@ -39,14 +39,12 @@ export class InsightClient {
   private httpClient: HTTPFetchClient;
 
   constructor(config: httpClientConfig) {
-    if (!config.baseURL) {
-      config.baseURL = "https://api.line.me";
-    }
+    const baseURL = config.baseURL || "https://api.line.me";
     this.httpClient = new HTTPFetchClient({
       defaultHeaders: {
         Authorization: "Bearer " + config.channelAccessToken,
       },
-      baseURL: config.baseURL,
+      baseURL: baseURL,
     });
   }
 

--- a/lib/liff/api/liffClient.ts
+++ b/lib/liff/api/liffClient.ts
@@ -38,14 +38,12 @@ export class LiffClient {
   private httpClient: HTTPFetchClient;
 
   constructor(config: httpClientConfig) {
-    if (!config.baseURL) {
-      config.baseURL = "https://api.line.me";
-    }
+    const baseURL = config.baseURL || "https://api.line.me";
     this.httpClient = new HTTPFetchClient({
       defaultHeaders: {
         Authorization: "Bearer " + config.channelAccessToken,
       },
-      baseURL: config.baseURL,
+      baseURL: baseURL,
     });
   }
 

--- a/lib/manage-audience/api/manageAudienceBlobClient.ts
+++ b/lib/manage-audience/api/manageAudienceBlobClient.ts
@@ -35,14 +35,12 @@ export class ManageAudienceBlobClient {
   private httpClient: HTTPFetchClient;
 
   constructor(config: httpClientConfig) {
-    if (!config.baseURL) {
-      config.baseURL = "https://api-data.line.me";
-    }
+    const baseURL = config.baseURL || "https://api-data.line.me";
     this.httpClient = new HTTPFetchClient({
       defaultHeaders: {
         Authorization: "Bearer " + config.channelAccessToken,
       },
-      baseURL: config.baseURL,
+      baseURL: baseURL,
     });
   }
 

--- a/lib/manage-audience/api/manageAudienceClient.ts
+++ b/lib/manage-audience/api/manageAudienceClient.ts
@@ -49,14 +49,12 @@ export class ManageAudienceClient {
   private httpClient: HTTPFetchClient;
 
   constructor(config: httpClientConfig) {
-    if (!config.baseURL) {
-      config.baseURL = "https://api.line.me";
-    }
+    const baseURL = config.baseURL || "https://api.line.me";
     this.httpClient = new HTTPFetchClient({
       defaultHeaders: {
         Authorization: "Bearer " + config.channelAccessToken,
       },
-      baseURL: config.baseURL,
+      baseURL: baseURL,
     });
   }
 

--- a/lib/messaging-api/api/messagingApiBlobClient.ts
+++ b/lib/messaging-api/api/messagingApiBlobClient.ts
@@ -35,14 +35,12 @@ export class MessagingApiBlobClient {
   private httpClient: HTTPFetchClient;
 
   constructor(config: httpClientConfig) {
-    if (!config.baseURL) {
-      config.baseURL = "https://api-data.line.me";
-    }
+    const baseURL = config.baseURL || "https://api-data.line.me";
     this.httpClient = new HTTPFetchClient({
       defaultHeaders: {
         Authorization: "Bearer " + config.channelAccessToken,
       },
-      baseURL: config.baseURL,
+      baseURL: baseURL,
     });
   }
 

--- a/lib/messaging-api/api/messagingApiClient.ts
+++ b/lib/messaging-api/api/messagingApiClient.ts
@@ -81,14 +81,12 @@ export class MessagingApiClient {
   private httpClient: HTTPFetchClient;
 
   constructor(config: httpClientConfig) {
-    if (!config.baseURL) {
-      config.baseURL = "https://api.line.me";
-    }
+    const baseURL = config.baseURL || "https://api.line.me";
     this.httpClient = new HTTPFetchClient({
       defaultHeaders: {
         Authorization: "Bearer " + config.channelAccessToken,
       },
-      baseURL: config.baseURL,
+      baseURL: baseURL,
     });
   }
 

--- a/lib/module-attach/api/lineModuleAttachClient.ts
+++ b/lib/module-attach/api/lineModuleAttachClient.ts
@@ -35,14 +35,12 @@ export class LineModuleAttachClient {
   private httpClient: HTTPFetchClient;
 
   constructor(config: httpClientConfig) {
-    if (!config.baseURL) {
-      config.baseURL = "https://manager.line.biz";
-    }
+    const baseURL = config.baseURL || "https://manager.line.biz";
     this.httpClient = new HTTPFetchClient({
       defaultHeaders: {
         Authorization: "Bearer " + config.channelAccessToken,
       },
-      baseURL: config.baseURL,
+      baseURL: baseURL,
     });
   }
 

--- a/lib/module/api/lineModuleClient.ts
+++ b/lib/module/api/lineModuleClient.ts
@@ -37,14 +37,12 @@ export class LineModuleClient {
   private httpClient: HTTPFetchClient;
 
   constructor(config: httpClientConfig) {
-    if (!config.baseURL) {
-      config.baseURL = "https://api.line.me";
-    }
+    const baseURL = config.baseURL || "https://api.line.me";
     this.httpClient = new HTTPFetchClient({
       defaultHeaders: {
         Authorization: "Bearer " + config.channelAccessToken,
       },
-      baseURL: config.baseURL,
+      baseURL: baseURL,
     });
   }
 

--- a/lib/shop/api/shopClient.ts
+++ b/lib/shop/api/shopClient.ts
@@ -35,14 +35,12 @@ export class ShopClient {
   private httpClient: HTTPFetchClient;
 
   constructor(config: httpClientConfig) {
-    if (!config.baseURL) {
-      config.baseURL = "https://api.line.me";
-    }
+    const baseURL = config.baseURL || "https://api.line.me";
     this.httpClient = new HTTPFetchClient({
       defaultHeaders: {
         Authorization: "Bearer " + config.channelAccessToken,
       },
-      baseURL: config.baseURL,
+      baseURL: baseURL,
     });
   }
 

--- a/test/libs-messagingApi.spec.ts
+++ b/test/libs-messagingApi.spec.ts
@@ -194,4 +194,16 @@ describe("messagingApi", () => {
       next: "yANU9IA..",
     });
   });
+
+  it("config is not overrided", async () => {
+    const config = {
+      channelAccessToken: "token-token",
+      baseURL: undefined,
+    };
+    const client = new messagingApi.MessagingApiClient(config);
+    equal(config.baseURL, undefined);
+
+    const blobClient = new messagingApi.MessagingApiBlobClient(config);
+    equal(config.baseURL, undefined);
+  });
 });


### PR DESCRIPTION
## Changes
The constructor of line-bot-sdk-nodejs client modifies the given config, which should ideally behave immutably. Reusing the config as is can lead to unexpected behavior(see below sample `#2`). This change ensures that the config is not unintentionally overwritten.

## How to reproduce this

(normal)
```ts
// #1 (it works, but `config`'s baseURL is updated expectedly)
const config = {
  channelAccessToken: "token-token",
};
const blobClient = new messagingApi.MessagingApiBlobClient(config);
// config.baseURL -> https://api-data.line.me (Unexpected, but it works)
```

(this issue)
Executing the following code does not set `api.line-data.me`. A workaround is to clone the config, but this is not convenient and debugging can be troublesome.

```ts
// #2 (blob doesn't work, because the first unexpected update blocks blob client uses expected baseURL)
const config = {
  channelAccessToken: "token-token",
};
const client = new messagingApi.MessagingApiClient(config);
// config.baseURL -> https://api.line.me
const blobClient = new messagingApi.MessagingApiBlobClient(config);
// config.baseURL -> https://api.line.me, not https://api-data.line.me (Unexpected, and it won't work)
```