### PR TITLE
Stop using doc branch to use github pages

### DIFF
--- a/.github/workflows/deploy-doc.yml
+++ b/.github/workflows/deploy-doc.yml
@@ -1,0 +1,50 @@
+name: Deploy static content to Pages on release
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build API Docs
+        run: export NODE_OPTIONS=--openssl-legacy-provider; npm run apidocs
+      - name: Build Docs
+        run: export NODE_OPTIONS=--openssl-legacy-provider; npm run docs:build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/.vitepress/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: [build]
+    runs-on: ubuntu-latest
+    name: Deploy
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,37 +26,5 @@ jobs:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   deploy-docs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js 18
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18
-      - name: Install Dependency
-        run: npm ci
-      - name: Config Internal Git
-        run: |
-          git config --global user.email "action@github.com"
-          git config --global user.name "GitHub Action"
-      - name: Clone Doc History
-        uses: actions/checkout@v4
-        with:
-          ref: 'gh-pages'
-          path: 'doc-dist'
-      - name: Clean Doc Directory
-        run: |
-          cd doc-dist
-          ls | grep -v '.git' | xargs rm -r
-          cd ../
-      - name: Build API Docs
-        run: export NODE_OPTIONS=--openssl-legacy-provider; npm run apidocs
-      - name: Build Docs
-        run: export NODE_OPTIONS=--openssl-legacy-provider; npm run docs:build
-      - name: Copy & Deploy
-        run: |
-          cp -r docs/.vitepress/dist/* doc-dist/
-          cd doc-dist
-          git add -A
-          git commit -m 'Deploy docs'
-          git push
+    needs: [release-package]
+      use: ./.github/workflows/deploy-doc.yml


### PR DESCRIPTION
`gh-pages` branch for documentation is no longer necessary. By using GitHub Actions, you can utilize GitHub Pages directly.

This change supports that. Additionally, this change has made sure not to update the documentation until the upload to npm is complete. This is to prevent confusion among users if the documentation is updated but package is not updated.

TODO: Modify settings in https://github.com/line/line-bot-sdk-nodejs/settings/pages after this change is merged

ref: https://vitepress.dev/guide/deploy#github-pages

Resolve #521 