### PR TITLE
Replace undici's multipart/form-data parser with custom implementation in tests

### DIFF
--- a/generator/src/main/resources/line-bot-sdk-nodejs-generator/api_test.pebble
+++ b/generator/src/main/resources/line-bot-sdk-nodejs-generator/api_test.pebble
@@ -12,9 +12,56 @@ import { deepEqual, equal, ok } from "node:assert";
 
 import { describe, it } from "vitest";
 
-import { parseForm } from "../../../../test/helpers/parse-form";
-
 const channel_access_token = "test_channel_access_token";
+
+// This is not a perfect multipart/form-data parser,
+// but it works for the purpose of this test.
+function parseForm(
+  arrayBuffer: ArrayBuffer,
+): Record<string, string | Blob> {
+  const uint8Array = new Uint8Array(arrayBuffer);
+  const text = new TextDecoder().decode(uint8Array);
+
+  const boundary = text.match(/^--[^\r\n]+/)![0];
+
+  // split to parts, and drop first and last empty parts
+  const parts = text.split(new RegExp(boundary + "(?:\\r\\n|--)")).slice(1, -1);
+
+  const result: Record<string, string | Blob> = {};
+
+  for (const part of parts) {
+    const headerEnd = part.indexOf("\r\n\r\n");
+    if (headerEnd === -1) continue;
+
+    const headers = part.slice(0, headerEnd);
+    const content = part.slice(headerEnd + 4);
+
+    const nameMatch = headers.match(/name="([^"]+)"/);
+    const fileNameMatch = headers.match(/filename="([^"]+)"/);
+
+    if (nameMatch) {
+      const name = nameMatch[1];
+
+      if (fileNameMatch) {
+        // it's a file
+        const contentTypeMatch = headers.match(/Content-Type:\s*(\S+)/i);
+        const contentType = contentTypeMatch
+          ? contentTypeMatch[1]
+          : "application/octet-stream";
+
+        result[name] = new Blob([content.replace(/\r\n$/, "")], {
+          type: contentType,
+        });
+      } else {
+        // basic field
+        const value = content.trim();
+        result[name] = value;
+      }
+    }
+  }
+
+  return result;
+}
 
 {% macro paramDummyValue(param) %}
 {# @pebvariable name="param" type="org.openapitools.codegen.CodegenParameter" #}

--- a/generator/src/main/resources/line-bot-sdk-nodejs-generator/api_test.pebble
+++ b/generator/src/main/resources/line-bot-sdk-nodejs-generator/api_test.pebble
@@ -12,6 +12,8 @@ import { deepEqual, equal, ok } from "node:assert";
 
 import { describe, it } from "vitest";
 
+import { parseForm } from "../../../../test/helpers/parse-form";
+
 const channel_access_token = "test_channel_access_token";
 
 {% macro paramDummyValue(param) %}
@@ -82,8 +84,33 @@ const channel_access_token = "test_channel_access_token";
       );
       {% endif %}
 
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({}));
+      {% if op.hasFormParams and op.isMultipart %}
+        let data: Buffer[] = [];
+
+        req.on('data', chunk => {
+          data.push(chunk);
+        });
+
+        req.on('end', () => {
+          // Combine the data chunks into a single Buffer
+          const buffer = Buffer.concat(data);
+
+          // Convert Buffer to ArrayBuffer
+          const arrayBuffer = buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
+
+          // Form parameters
+          const formData = parseForm(arrayBuffer);
+          {% for param in op.formParams -%}
+          equal(formData["{{param.paramName}}"], String({{ paramDummyValue(param) }}));
+          {% endfor %}
+
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({}));
+        });
+      {% else %}
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({}));
+      {% endif %}
     });
     await new Promise((resolve) => {
       server.listen(0);

--- a/lib/channel-access-token/tests/api/ChannelAccessTokenClientTest.spec.ts
+++ b/lib/channel-access-token/tests/api/ChannelAccessTokenClientTest.spec.ts
@@ -12,9 +12,56 @@ import { deepEqual, equal, ok } from "node:assert";
 
 import { describe, it } from "vitest";
 
-import { parseForm } from "../../../../test/helpers/parse-form";
-
 const channel_access_token = "test_channel_access_token";
+
+// This is not a perfect multipart/form-data parser,
+// but it works for the purpose of this test.
+export function parseForm(
+  arrayBuffer: ArrayBuffer,
+): Record<string, string | Blob> {
+  const uint8Array = new Uint8Array(arrayBuffer);
+  const text = new TextDecoder().decode(uint8Array);
+
+  const boundary = text.match(/^--[^\r\n]+/)![0];
+
+  // split to parts, and drop first and last empty parts
+  const parts = text.split(new RegExp(boundary + "(?:\\r\\n|--)")).slice(1, -1);
+
+  const result: Record<string, string | Blob> = {};
+
+  for (const part of parts) {
+    const headerEnd = part.indexOf("\r\n\r\n");
+    if (headerEnd === -1) continue;
+
+    const headers = part.slice(0, headerEnd);
+    const content = part.slice(headerEnd + 4);
+
+    const nameMatch = headers.match(/name="([^"]+)"/);
+    const fileNameMatch = headers.match(/filename="([^"]+)"/);
+
+    if (nameMatch) {
+      const name = nameMatch[1];
+
+      if (fileNameMatch) {
+        // it's a file
+        const contentTypeMatch = headers.match(/Content-Type:\s*(\S+)/i);
+        const contentType = contentTypeMatch
+          ? contentTypeMatch[1]
+          : "application/octet-stream";
+
+        result[name] = new Blob([content.replace(/\r\n$/, "")], {
+          type: contentType,
+        });
+      } else {
+        // basic field
+        const value = content.trim();
+        result[name] = value;
+      }
+    }
+  }
+
+  return result;
+}
 
 describe("ChannelAccessTokenClient", () => {
   it("getsAllValidChannelAccessTokenKeyIdsWithHttpInfo", async () => {

--- a/lib/channel-access-token/tests/api/ChannelAccessTokenClientTest.spec.ts
+++ b/lib/channel-access-token/tests/api/ChannelAccessTokenClientTest.spec.ts
@@ -12,6 +12,8 @@ import { deepEqual, equal, ok } from "node:assert";
 
 import { describe, it } from "vitest";
 
+import { parseForm } from "../../../../test/helpers/parse-form";
+
 const channel_access_token = "test_channel_access_token";
 
 describe("ChannelAccessTokenClient", () => {

--- a/lib/insight/tests/api/InsightClientTest.spec.ts
+++ b/lib/insight/tests/api/InsightClientTest.spec.ts
@@ -11,9 +11,56 @@ import { deepEqual, equal, ok } from "node:assert";
 
 import { describe, it } from "vitest";
 
-import { parseForm } from "../../../../test/helpers/parse-form";
-
 const channel_access_token = "test_channel_access_token";
+
+// This is not a perfect multipart/form-data parser,
+// but it works for the purpose of this test.
+export function parseForm(
+  arrayBuffer: ArrayBuffer,
+): Record<string, string | Blob> {
+  const uint8Array = new Uint8Array(arrayBuffer);
+  const text = new TextDecoder().decode(uint8Array);
+
+  const boundary = text.match(/^--[^\r\n]+/)![0];
+
+  // split to parts, and drop first and last empty parts
+  const parts = text.split(new RegExp(boundary + "(?:\\r\\n|--)")).slice(1, -1);
+
+  const result: Record<string, string | Blob> = {};
+
+  for (const part of parts) {
+    const headerEnd = part.indexOf("\r\n\r\n");
+    if (headerEnd === -1) continue;
+
+    const headers = part.slice(0, headerEnd);
+    const content = part.slice(headerEnd + 4);
+
+    const nameMatch = headers.match(/name="([^"]+)"/);
+    const fileNameMatch = headers.match(/filename="([^"]+)"/);
+
+    if (nameMatch) {
+      const name = nameMatch[1];
+
+      if (fileNameMatch) {
+        // it's a file
+        const contentTypeMatch = headers.match(/Content-Type:\s*(\S+)/i);
+        const contentType = contentTypeMatch
+          ? contentTypeMatch[1]
+          : "application/octet-stream";
+
+        result[name] = new Blob([content.replace(/\r\n$/, "")], {
+          type: contentType,
+        });
+      } else {
+        // basic field
+        const value = content.trim();
+        result[name] = value;
+      }
+    }
+  }
+
+  return result;
+}
 
 describe("InsightClient", () => {
   it("getFriendsDemographicsWithHttpInfo", async () => {

--- a/lib/insight/tests/api/InsightClientTest.spec.ts
+++ b/lib/insight/tests/api/InsightClientTest.spec.ts
@@ -11,6 +11,8 @@ import { deepEqual, equal, ok } from "node:assert";
 
 import { describe, it } from "vitest";
 
+import { parseForm } from "../../../../test/helpers/parse-form";
+
 const channel_access_token = "test_channel_access_token";
 
 describe("InsightClient", () => {

--- a/lib/liff/tests/api/LiffClientTest.spec.ts
+++ b/lib/liff/tests/api/LiffClientTest.spec.ts
@@ -10,6 +10,8 @@ import { deepEqual, equal, ok } from "node:assert";
 
 import { describe, it } from "vitest";
 
+import { parseForm } from "../../../../test/helpers/parse-form";
+
 const channel_access_token = "test_channel_access_token";
 
 describe("LiffClient", () => {

--- a/lib/liff/tests/api/LiffClientTest.spec.ts
+++ b/lib/liff/tests/api/LiffClientTest.spec.ts
@@ -10,9 +10,56 @@ import { deepEqual, equal, ok } from "node:assert";
 
 import { describe, it } from "vitest";
 
-import { parseForm } from "../../../../test/helpers/parse-form";
-
 const channel_access_token = "test_channel_access_token";
+
+// This is not a perfect multipart/form-data parser,
+// but it works for the purpose of this test.
+export function parseForm(
+  arrayBuffer: ArrayBuffer,
+): Record<string, string | Blob> {
+  const uint8Array = new Uint8Array(arrayBuffer);
+  const text = new TextDecoder().decode(uint8Array);
+
+  const boundary = text.match(/^--[^\r\n]+/)![0];
+
+  // split to parts, and drop first and last empty parts
+  const parts = text.split(new RegExp(boundary + "(?:\\r\\n|--)")).slice(1, -1);
+
+  const result: Record<string, string | Blob> = {};
+
+  for (const part of parts) {
+    const headerEnd = part.indexOf("\r\n\r\n");
+    if (headerEnd === -1) continue;
+
+    const headers = part.slice(0, headerEnd);
+    const content = part.slice(headerEnd + 4);
+
+    const nameMatch = headers.match(/name="([^"]+)"/);
+    const fileNameMatch = headers.match(/filename="([^"]+)"/);
+
+    if (nameMatch) {
+      const name = nameMatch[1];
+
+      if (fileNameMatch) {
+        // it's a file
+        const contentTypeMatch = headers.match(/Content-Type:\s*(\S+)/i);
+        const contentType = contentTypeMatch
+          ? contentTypeMatch[1]
+          : "application/octet-stream";
+
+        result[name] = new Blob([content.replace(/\r\n$/, "")], {
+          type: contentType,
+        });
+      } else {
+        // basic field
+        const value = content.trim();
+        result[name] = value;
+      }
+    }
+  }
+
+  return result;
+}
 
 describe("LiffClient", () => {
   it("addLIFFAppWithHttpInfo", async () => {

--- a/lib/manage-audience/tests/api/ManageAudienceBlobClientTest.spec.ts
+++ b/lib/manage-audience/tests/api/ManageAudienceBlobClientTest.spec.ts
@@ -7,9 +7,56 @@ import { deepEqual, equal, ok } from "node:assert";
 
 import { describe, it } from "vitest";
 
-import { parseForm } from "../../../../test/helpers/parse-form";
-
 const channel_access_token = "test_channel_access_token";
+
+// This is not a perfect multipart/form-data parser,
+// but it works for the purpose of this test.
+export function parseForm(
+  arrayBuffer: ArrayBuffer,
+): Record<string, string | Blob> {
+  const uint8Array = new Uint8Array(arrayBuffer);
+  const text = new TextDecoder().decode(uint8Array);
+
+  const boundary = text.match(/^--[^\r\n]+/)![0];
+
+  // split to parts, and drop first and last empty parts
+  const parts = text.split(new RegExp(boundary + "(?:\\r\\n|--)")).slice(1, -1);
+
+  const result: Record<string, string | Blob> = {};
+
+  for (const part of parts) {
+    const headerEnd = part.indexOf("\r\n\r\n");
+    if (headerEnd === -1) continue;
+
+    const headers = part.slice(0, headerEnd);
+    const content = part.slice(headerEnd + 4);
+
+    const nameMatch = headers.match(/name="([^"]+)"/);
+    const fileNameMatch = headers.match(/filename="([^"]+)"/);
+
+    if (nameMatch) {
+      const name = nameMatch[1];
+
+      if (fileNameMatch) {
+        // it's a file
+        const contentTypeMatch = headers.match(/Content-Type:\s*(\S+)/i);
+        const contentType = contentTypeMatch
+          ? contentTypeMatch[1]
+          : "application/octet-stream";
+
+        result[name] = new Blob([content.replace(/\r\n$/, "")], {
+          type: contentType,
+        });
+      } else {
+        // basic field
+        const value = content.trim();
+        result[name] = value;
+      }
+    }
+  }
+
+  return result;
+}
 
 describe("ManageAudienceBlobClient", () => {
   it("addUserIdsToAudienceWithHttpInfo", async () => {

--- a/lib/manage-audience/tests/api/ManageAudienceBlobClientTest.spec.ts
+++ b/lib/manage-audience/tests/api/ManageAudienceBlobClientTest.spec.ts
@@ -7,6 +7,8 @@ import { deepEqual, equal, ok } from "node:assert";
 
 import { describe, it } from "vitest";
 
+import { parseForm } from "../../../../test/helpers/parse-form";
+
 const channel_access_token = "test_channel_access_token";
 
 describe("ManageAudienceBlobClient", () => {
@@ -37,8 +39,49 @@ describe("ManageAudienceBlobClient", () => {
         ),
       );
 
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({}));
+      let data: Buffer[] = [];
+
+      req.on("data", chunk => {
+        data.push(chunk);
+      });
+
+      req.on("end", () => {
+        // Combine the data chunks into a single Buffer
+        const buffer = Buffer.concat(data);
+
+        // Convert Buffer to ArrayBuffer
+        const arrayBuffer = buffer.buffer.slice(
+          buffer.byteOffset,
+          buffer.byteOffset + buffer.byteLength,
+        );
+
+        // Form parameters
+        const formData = parseForm(arrayBuffer);
+        equal(
+          formData["audienceGroupId"],
+          String(
+            // audienceGroupId: number
+            0, // paramName=audienceGroupId(number or int or long)
+          ),
+        );
+        equal(
+          formData["uploadDescription"],
+          String(
+            // uploadDescription: string
+            "DUMMY", // uploadDescription(string)
+          ),
+        );
+        equal(
+          formData["file"],
+          String(
+            // file: Blob
+            new Blob([]), // paramName=file
+          ),
+        );
+
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({}));
+      });
     });
     await new Promise(resolve => {
       server.listen(0);
@@ -97,8 +140,49 @@ describe("ManageAudienceBlobClient", () => {
         ),
       );
 
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({}));
+      let data: Buffer[] = [];
+
+      req.on("data", chunk => {
+        data.push(chunk);
+      });
+
+      req.on("end", () => {
+        // Combine the data chunks into a single Buffer
+        const buffer = Buffer.concat(data);
+
+        // Convert Buffer to ArrayBuffer
+        const arrayBuffer = buffer.buffer.slice(
+          buffer.byteOffset,
+          buffer.byteOffset + buffer.byteLength,
+        );
+
+        // Form parameters
+        const formData = parseForm(arrayBuffer);
+        equal(
+          formData["audienceGroupId"],
+          String(
+            // audienceGroupId: number
+            0, // paramName=audienceGroupId(number or int or long)
+          ),
+        );
+        equal(
+          formData["uploadDescription"],
+          String(
+            // uploadDescription: string
+            "DUMMY", // uploadDescription(string)
+          ),
+        );
+        equal(
+          formData["file"],
+          String(
+            // file: Blob
+            new Blob([]), // paramName=file
+          ),
+        );
+
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({}));
+      });
     });
     await new Promise(resolve => {
       server.listen(0);
@@ -157,8 +241,56 @@ describe("ManageAudienceBlobClient", () => {
         ),
       );
 
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({}));
+      let data: Buffer[] = [];
+
+      req.on("data", chunk => {
+        data.push(chunk);
+      });
+
+      req.on("end", () => {
+        // Combine the data chunks into a single Buffer
+        const buffer = Buffer.concat(data);
+
+        // Convert Buffer to ArrayBuffer
+        const arrayBuffer = buffer.buffer.slice(
+          buffer.byteOffset,
+          buffer.byteOffset + buffer.byteLength,
+        );
+
+        // Form parameters
+        const formData = parseForm(arrayBuffer);
+        equal(
+          formData["description"],
+          String(
+            // description: string
+            "DUMMY", // description(string)
+          ),
+        );
+        equal(
+          formData["isIfaAudience"],
+          String(
+            // isIfaAudience: boolean
+            true, // paramName=isIfaAudience
+          ),
+        );
+        equal(
+          formData["uploadDescription"],
+          String(
+            // uploadDescription: string
+            "DUMMY", // uploadDescription(string)
+          ),
+        );
+        equal(
+          formData["file"],
+          String(
+            // file: Blob
+            new Blob([]), // paramName=file
+          ),
+        );
+
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({}));
+      });
     });
     await new Promise(resolve => {
       server.listen(0);
@@ -220,8 +352,56 @@ describe("ManageAudienceBlobClient", () => {
         ),
       );
 
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({}));
+      let data: Buffer[] = [];
+
+      req.on("data", chunk => {
+        data.push(chunk);
+      });
+
+      req.on("end", () => {
+        // Combine the data chunks into a single Buffer
+        const buffer = Buffer.concat(data);
+
+        // Convert Buffer to ArrayBuffer
+        const arrayBuffer = buffer.buffer.slice(
+          buffer.byteOffset,
+          buffer.byteOffset + buffer.byteLength,
+        );
+
+        // Form parameters
+        const formData = parseForm(arrayBuffer);
+        equal(
+          formData["description"],
+          String(
+            // description: string
+            "DUMMY", // description(string)
+          ),
+        );
+        equal(
+          formData["isIfaAudience"],
+          String(
+            // isIfaAudience: boolean
+            true, // paramName=isIfaAudience
+          ),
+        );
+        equal(
+          formData["uploadDescription"],
+          String(
+            // uploadDescription: string
+            "DUMMY", // uploadDescription(string)
+          ),
+        );
+        equal(
+          formData["file"],
+          String(
+            // file: Blob
+            new Blob([]), // paramName=file
+          ),
+        );
+
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({}));
+      });
     });
     await new Promise(resolve => {
       server.listen(0);

--- a/lib/manage-audience/tests/api/ManageAudienceClientTest.spec.ts
+++ b/lib/manage-audience/tests/api/ManageAudienceClientTest.spec.ts
@@ -21,9 +21,56 @@ import { deepEqual, equal, ok } from "node:assert";
 
 import { describe, it } from "vitest";
 
-import { parseForm } from "../../../../test/helpers/parse-form";
-
 const channel_access_token = "test_channel_access_token";
+
+// This is not a perfect multipart/form-data parser,
+// but it works for the purpose of this test.
+export function parseForm(
+  arrayBuffer: ArrayBuffer,
+): Record<string, string | Blob> {
+  const uint8Array = new Uint8Array(arrayBuffer);
+  const text = new TextDecoder().decode(uint8Array);
+
+  const boundary = text.match(/^--[^\r\n]+/)![0];
+
+  // split to parts, and drop first and last empty parts
+  const parts = text.split(new RegExp(boundary + "(?:\\r\\n|--)")).slice(1, -1);
+
+  const result: Record<string, string | Blob> = {};
+
+  for (const part of parts) {
+    const headerEnd = part.indexOf("\r\n\r\n");
+    if (headerEnd === -1) continue;
+
+    const headers = part.slice(0, headerEnd);
+    const content = part.slice(headerEnd + 4);
+
+    const nameMatch = headers.match(/name="([^"]+)"/);
+    const fileNameMatch = headers.match(/filename="([^"]+)"/);
+
+    if (nameMatch) {
+      const name = nameMatch[1];
+
+      if (fileNameMatch) {
+        // it's a file
+        const contentTypeMatch = headers.match(/Content-Type:\s*(\S+)/i);
+        const contentType = contentTypeMatch
+          ? contentTypeMatch[1]
+          : "application/octet-stream";
+
+        result[name] = new Blob([content.replace(/\r\n$/, "")], {
+          type: contentType,
+        });
+      } else {
+        // basic field
+        const value = content.trim();
+        result[name] = value;
+      }
+    }
+  }
+
+  return result;
+}
 
 describe("ManageAudienceClient", () => {
   it("activateAudienceGroupWithHttpInfo", async () => {

--- a/lib/manage-audience/tests/api/ManageAudienceClientTest.spec.ts
+++ b/lib/manage-audience/tests/api/ManageAudienceClientTest.spec.ts
@@ -21,6 +21,8 @@ import { deepEqual, equal, ok } from "node:assert";
 
 import { describe, it } from "vitest";
 
+import { parseForm } from "../../../../test/helpers/parse-form";
+
 const channel_access_token = "test_channel_access_token";
 
 describe("ManageAudienceClient", () => {

--- a/lib/messaging-api/tests/api/MessagingApiBlobClientTest.spec.ts
+++ b/lib/messaging-api/tests/api/MessagingApiBlobClientTest.spec.ts
@@ -7,9 +7,56 @@ import { deepEqual, equal, ok } from "node:assert";
 
 import { describe, it } from "vitest";
 
-import { parseForm } from "../../../../test/helpers/parse-form";
-
 const channel_access_token = "test_channel_access_token";
+
+// This is not a perfect multipart/form-data parser,
+// but it works for the purpose of this test.
+export function parseForm(
+  arrayBuffer: ArrayBuffer,
+): Record<string, string | Blob> {
+  const uint8Array = new Uint8Array(arrayBuffer);
+  const text = new TextDecoder().decode(uint8Array);
+
+  const boundary = text.match(/^--[^\r\n]+/)![0];
+
+  // split to parts, and drop first and last empty parts
+  const parts = text.split(new RegExp(boundary + "(?:\\r\\n|--)")).slice(1, -1);
+
+  const result: Record<string, string | Blob> = {};
+
+  for (const part of parts) {
+    const headerEnd = part.indexOf("\r\n\r\n");
+    if (headerEnd === -1) continue;
+
+    const headers = part.slice(0, headerEnd);
+    const content = part.slice(headerEnd + 4);
+
+    const nameMatch = headers.match(/name="([^"]+)"/);
+    const fileNameMatch = headers.match(/filename="([^"]+)"/);
+
+    if (nameMatch) {
+      const name = nameMatch[1];
+
+      if (fileNameMatch) {
+        // it's a file
+        const contentTypeMatch = headers.match(/Content-Type:\s*(\S+)/i);
+        const contentType = contentTypeMatch
+          ? contentTypeMatch[1]
+          : "application/octet-stream";
+
+        result[name] = new Blob([content.replace(/\r\n$/, "")], {
+          type: contentType,
+        });
+      } else {
+        // basic field
+        const value = content.trim();
+        result[name] = value;
+      }
+    }
+  }
+
+  return result;
+}
 
 describe("MessagingApiBlobClient", () => {
   it("getMessageContentWithHttpInfo", async () => {

--- a/lib/messaging-api/tests/api/MessagingApiBlobClientTest.spec.ts
+++ b/lib/messaging-api/tests/api/MessagingApiBlobClientTest.spec.ts
@@ -7,6 +7,8 @@ import { deepEqual, equal, ok } from "node:assert";
 
 import { describe, it } from "vitest";
 
+import { parseForm } from "../../../../test/helpers/parse-form";
+
 const channel_access_token = "test_channel_access_token";
 
 describe("MessagingApiBlobClient", () => {

--- a/lib/messaging-api/tests/api/MessagingApiClientTest.spec.ts
+++ b/lib/messaging-api/tests/api/MessagingApiClientTest.spec.ts
@@ -53,6 +53,8 @@ import { deepEqual, equal, ok } from "node:assert";
 
 import { describe, it } from "vitest";
 
+import { parseForm } from "../../../../test/helpers/parse-form";
+
 const channel_access_token = "test_channel_access_token";
 
 describe("MessagingApiClient", () => {

--- a/lib/messaging-api/tests/api/MessagingApiClientTest.spec.ts
+++ b/lib/messaging-api/tests/api/MessagingApiClientTest.spec.ts
@@ -53,9 +53,56 @@ import { deepEqual, equal, ok } from "node:assert";
 
 import { describe, it } from "vitest";
 
-import { parseForm } from "../../../../test/helpers/parse-form";
-
 const channel_access_token = "test_channel_access_token";
+
+// This is not a perfect multipart/form-data parser,
+// but it works for the purpose of this test.
+export function parseForm(
+  arrayBuffer: ArrayBuffer,
+): Record<string, string | Blob> {
+  const uint8Array = new Uint8Array(arrayBuffer);
+  const text = new TextDecoder().decode(uint8Array);
+
+  const boundary = text.match(/^--[^\r\n]+/)![0];
+
+  // split to parts, and drop first and last empty parts
+  const parts = text.split(new RegExp(boundary + "(?:\\r\\n|--)")).slice(1, -1);
+
+  const result: Record<string, string | Blob> = {};
+
+  for (const part of parts) {
+    const headerEnd = part.indexOf("\r\n\r\n");
+    if (headerEnd === -1) continue;
+
+    const headers = part.slice(0, headerEnd);
+    const content = part.slice(headerEnd + 4);
+
+    const nameMatch = headers.match(/name="([^"]+)"/);
+    const fileNameMatch = headers.match(/filename="([^"]+)"/);
+
+    if (nameMatch) {
+      const name = nameMatch[1];
+
+      if (fileNameMatch) {
+        // it's a file
+        const contentTypeMatch = headers.match(/Content-Type:\s*(\S+)/i);
+        const contentType = contentTypeMatch
+          ? contentTypeMatch[1]
+          : "application/octet-stream";
+
+        result[name] = new Blob([content.replace(/\r\n$/, "")], {
+          type: contentType,
+        });
+      } else {
+        // basic field
+        const value = content.trim();
+        result[name] = value;
+      }
+    }
+  }
+
+  return result;
+}
 
 describe("MessagingApiClient", () => {
   it("audienceMatchWithHttpInfo", async () => {

--- a/lib/module-attach/tests/api/LineModuleAttachClientTest.spec.ts
+++ b/lib/module-attach/tests/api/LineModuleAttachClientTest.spec.ts
@@ -7,9 +7,56 @@ import { deepEqual, equal, ok } from "node:assert";
 
 import { describe, it } from "vitest";
 
-import { parseForm } from "../../../../test/helpers/parse-form";
-
 const channel_access_token = "test_channel_access_token";
+
+// This is not a perfect multipart/form-data parser,
+// but it works for the purpose of this test.
+export function parseForm(
+  arrayBuffer: ArrayBuffer,
+): Record<string, string | Blob> {
+  const uint8Array = new Uint8Array(arrayBuffer);
+  const text = new TextDecoder().decode(uint8Array);
+
+  const boundary = text.match(/^--[^\r\n]+/)![0];
+
+  // split to parts, and drop first and last empty parts
+  const parts = text.split(new RegExp(boundary + "(?:\\r\\n|--)")).slice(1, -1);
+
+  const result: Record<string, string | Blob> = {};
+
+  for (const part of parts) {
+    const headerEnd = part.indexOf("\r\n\r\n");
+    if (headerEnd === -1) continue;
+
+    const headers = part.slice(0, headerEnd);
+    const content = part.slice(headerEnd + 4);
+
+    const nameMatch = headers.match(/name="([^"]+)"/);
+    const fileNameMatch = headers.match(/filename="([^"]+)"/);
+
+    if (nameMatch) {
+      const name = nameMatch[1];
+
+      if (fileNameMatch) {
+        // it's a file
+        const contentTypeMatch = headers.match(/Content-Type:\s*(\S+)/i);
+        const contentType = contentTypeMatch
+          ? contentTypeMatch[1]
+          : "application/octet-stream";
+
+        result[name] = new Blob([content.replace(/\r\n$/, "")], {
+          type: contentType,
+        });
+      } else {
+        // basic field
+        const value = content.trim();
+        result[name] = value;
+      }
+    }
+  }
+
+  return result;
+}
 
 describe("LineModuleAttachClient", () => {
   it("attachModuleWithHttpInfo", async () => {

--- a/lib/module-attach/tests/api/LineModuleAttachClientTest.spec.ts
+++ b/lib/module-attach/tests/api/LineModuleAttachClientTest.spec.ts
@@ -7,6 +7,8 @@ import { deepEqual, equal, ok } from "node:assert";
 
 import { describe, it } from "vitest";
 
+import { parseForm } from "../../../../test/helpers/parse-form";
+
 const channel_access_token = "test_channel_access_token";
 
 describe("LineModuleAttachClient", () => {

--- a/lib/module/tests/api/LineModuleClientTest.spec.ts
+++ b/lib/module/tests/api/LineModuleClientTest.spec.ts
@@ -9,6 +9,8 @@ import { deepEqual, equal, ok } from "node:assert";
 
 import { describe, it } from "vitest";
 
+import { parseForm } from "../../../../test/helpers/parse-form";
+
 const channel_access_token = "test_channel_access_token";
 
 describe("LineModuleClient", () => {

--- a/lib/module/tests/api/LineModuleClientTest.spec.ts
+++ b/lib/module/tests/api/LineModuleClientTest.spec.ts
@@ -9,9 +9,56 @@ import { deepEqual, equal, ok } from "node:assert";
 
 import { describe, it } from "vitest";
 
-import { parseForm } from "../../../../test/helpers/parse-form";
-
 const channel_access_token = "test_channel_access_token";
+
+// This is not a perfect multipart/form-data parser,
+// but it works for the purpose of this test.
+export function parseForm(
+  arrayBuffer: ArrayBuffer,
+): Record<string, string | Blob> {
+  const uint8Array = new Uint8Array(arrayBuffer);
+  const text = new TextDecoder().decode(uint8Array);
+
+  const boundary = text.match(/^--[^\r\n]+/)![0];
+
+  // split to parts, and drop first and last empty parts
+  const parts = text.split(new RegExp(boundary + "(?:\\r\\n|--)")).slice(1, -1);
+
+  const result: Record<string, string | Blob> = {};
+
+  for (const part of parts) {
+    const headerEnd = part.indexOf("\r\n\r\n");
+    if (headerEnd === -1) continue;
+
+    const headers = part.slice(0, headerEnd);
+    const content = part.slice(headerEnd + 4);
+
+    const nameMatch = headers.match(/name="([^"]+)"/);
+    const fileNameMatch = headers.match(/filename="([^"]+)"/);
+
+    if (nameMatch) {
+      const name = nameMatch[1];
+
+      if (fileNameMatch) {
+        // it's a file
+        const contentTypeMatch = headers.match(/Content-Type:\s*(\S+)/i);
+        const contentType = contentTypeMatch
+          ? contentTypeMatch[1]
+          : "application/octet-stream";
+
+        result[name] = new Blob([content.replace(/\r\n$/, "")], {
+          type: contentType,
+        });
+      } else {
+        // basic field
+        const value = content.trim();
+        result[name] = value;
+      }
+    }
+  }
+
+  return result;
+}
 
 describe("LineModuleClient", () => {
   it("acquireChatControlWithHttpInfo", async () => {

--- a/lib/shop/tests/api/ShopClientTest.spec.ts
+++ b/lib/shop/tests/api/ShopClientTest.spec.ts
@@ -7,6 +7,8 @@ import { deepEqual, equal, ok } from "node:assert";
 
 import { describe, it } from "vitest";
 
+import { parseForm } from "../../../../test/helpers/parse-form";
+
 const channel_access_token = "test_channel_access_token";
 
 describe("ShopClient", () => {

--- a/lib/shop/tests/api/ShopClientTest.spec.ts
+++ b/lib/shop/tests/api/ShopClientTest.spec.ts
@@ -7,9 +7,56 @@ import { deepEqual, equal, ok } from "node:assert";
 
 import { describe, it } from "vitest";
 
-import { parseForm } from "../../../../test/helpers/parse-form";
-
 const channel_access_token = "test_channel_access_token";
+
+// This is not a perfect multipart/form-data parser,
+// but it works for the purpose of this test.
+export function parseForm(
+  arrayBuffer: ArrayBuffer,
+): Record<string, string | Blob> {
+  const uint8Array = new Uint8Array(arrayBuffer);
+  const text = new TextDecoder().decode(uint8Array);
+
+  const boundary = text.match(/^--[^\r\n]+/)![0];
+
+  // split to parts, and drop first and last empty parts
+  const parts = text.split(new RegExp(boundary + "(?:\\r\\n|--)")).slice(1, -1);
+
+  const result: Record<string, string | Blob> = {};
+
+  for (const part of parts) {
+    const headerEnd = part.indexOf("\r\n\r\n");
+    if (headerEnd === -1) continue;
+
+    const headers = part.slice(0, headerEnd);
+    const content = part.slice(headerEnd + 4);
+
+    const nameMatch = headers.match(/name="([^"]+)"/);
+    const fileNameMatch = headers.match(/filename="([^"]+)"/);
+
+    if (nameMatch) {
+      const name = nameMatch[1];
+
+      if (fileNameMatch) {
+        // it's a file
+        const contentTypeMatch = headers.match(/Content-Type:\s*(\S+)/i);
+        const contentType = contentTypeMatch
+          ? contentTypeMatch[1]
+          : "application/octet-stream";
+
+        result[name] = new Blob([content.replace(/\r\n$/, "")], {
+          type: contentType,
+        });
+      } else {
+        // basic field
+        const value = content.trim();
+        result[name] = value;
+      }
+    }
+  }
+
+  return result;
+}
 
 describe("ShopClient", () => {
   it("missionStickerV3WithHttpInfo", async () => {

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -23,6 +23,84 @@ const client = new Client({
   channelAccessToken,
 });
 
+// This is not a perfect multipart/form-data parser,
+// but it works for the purpose of this test.
+async function parseForm(blob: Blob) {
+  const arrayBuffer = await blob.arrayBuffer();
+  const uint8Array = new Uint8Array(arrayBuffer);
+  const text = new TextDecoder().decode(uint8Array);
+
+  /*
+--axios-1.7.2-boundary-gO2LZK1gY4J9v9AfRI29XEHgu
+Content-Disposition: form-data; name="audienceGroupId"
+
+4389303728991
+--axios-1.7.2-boundary-gO2LZK1gY4J9v9AfRI29XEHgu
+Content-Disposition: form-data; name="uploadDescription"
+
+fileName
+--axios-1.7.2-boundary-gO2LZK1gY4J9v9AfRI29XEHgu
+Content-Disposition: form-data; name="file"; filename="blob"
+Content-Type: application/octet-stream
+
+PNG BINARY DATA
+--axios-1.7.2-boundary-gO2LZK1gY4J9v9AfRI29XEHgu--
+   */
+
+  const boundary = text.match(/^--[^\r\n]+/)![0];
+
+  /*
+[
+  'Content-Disposition: form-data; name="audienceGroupId"\r\n\r\n4389303728991\r\n',
+  'Content-Disposition: form-data; name="uploadDescription"\r\n\r\nfileName\r\n',
+  'Content-Disposition: form-data; name="file"; filename="blob"\r\n' +
+    'Content-Type: application/octet-stream\r\n' +
+    '\r\n' +
+    'HELLO\n' +
+    '\r\n' +
+    '--axios-1.7.2-boundary-HytTvC4rGiQmNGiM6aC23i1GT--\r\n' +
+    '\r\n'
+]
+   */
+  // split to parts, and drop first and last empty parts
+  const parts = text.split(new RegExp(boundary + "(?:\\r\\n|--)")).slice(1, -1);
+
+  const result: Record<string, string | Blob> = {};
+
+  for (const part of parts) {
+    const headerEnd = part.indexOf("\r\n\r\n");
+    if (headerEnd === -1) continue;
+
+    const headers = part.slice(0, headerEnd);
+    const content = part.slice(headerEnd + 4);
+
+    const nameMatch = headers.match(/name="([^"]+)"/);
+    const fileNameMatch = headers.match(/filename="([^"]+)"/);
+
+    if (nameMatch) {
+      const name = nameMatch[1];
+
+      if (fileNameMatch) {
+        // it's a file
+        const contentTypeMatch = headers.match(/Content-Type:\s*(\S+)/i);
+        const contentType = contentTypeMatch
+          ? contentTypeMatch[1]
+          : "application/octet-stream";
+
+        result[name] = new Blob([content.replace(/\r\n$/, "")], {
+          type: contentType,
+        });
+      } else {
+        // basic field
+        const value = content.trim();
+        result[name] = value;
+      }
+    }
+  }
+
+  return result;
+}
+
 class MSWResult {
   private _done: boolean;
 
@@ -228,6 +306,34 @@ describe("client", () => {
     );
     return result;
   };
+
+  it("test parseForm", async () => {
+    const result = await parseForm(
+      new Blob([
+        "--axios-1.7.2-boundary-gO2LZK1gY4J9v9AfRI29XEHgu\r\n" +
+          'Content-Disposition: form-data; name="audienceGroupId"\r\n' +
+          "\r\n" +
+          "4389303728991\r\n" +
+          "--axios-1.7.2-boundary-gO2LZK1gY4J9v9AfRI29XEHgu\r\n" +
+          'Content-Disposition: form-data; name="uploadDescription"\r\n' +
+          "\r\n" +
+          "fileName\r\n" +
+          "--axios-1.7.2-boundary-gO2LZK1gY4J9v9AfRI29XEHgu\r\n" +
+          'Content-Disposition: form-data; name="file"; filename="blob"\r\n' +
+          "Content-Type: application/octet-stream\r\n" +
+          "\r\n" +
+          "PNG BINARY DATA\r\n" +
+          "--axios-1.7.2-boundary-gO2LZK1gY4J9v9AfRI29XEHgu--\r\n\r\n",
+      ]),
+    );
+    deepEqual(result, {
+      audienceGroupId: "4389303728991",
+      uploadDescription: "fileName",
+      file: new Blob(["PNG BINARY DATA"], {
+        type: "application/octet-stream",
+      }),
+    });
+  });
 
   it("reply", async () => {
     const scope = mockPost(MESSAGING_API_PREFIX, `/message/reply`, {
@@ -1016,18 +1122,16 @@ describe("client", () => {
               .startsWith(`multipart/form-data; boundary=`),
           );
 
-          const formData = await request.formData();
-          equal(formData.get("description"), requestBody.description);
+          const blob = await request.blob();
+          const formData = await parseForm(blob);
+          equal(formData["description"], requestBody.description);
           equal(
-            formData.get("isIfaAudience"),
+            formData["isIfaAudience"],
             requestBody.isIfaAudience.toString(),
           );
+          equal(formData["uploadDescription"], requestBody.uploadDescription);
           equal(
-            formData.get("uploadDescription"),
-            requestBody.uploadDescription,
-          );
-          equal(
-            Buffer.from(await (formData.get("file") as Blob).arrayBuffer()),
+            Buffer.from(await (formData["file"] as Blob).arrayBuffer()),
             requestBody.file.toString(),
           );
 
@@ -1085,14 +1189,14 @@ describe("client", () => {
               .get("content-type")
               .startsWith(`multipart/form-data; boundary=`),
           );
-          const formData = await request.formData();
-          equal(formData.get("audienceGroupId"), requestBody.audienceGroupId);
+          const blob = await request.blob();
+          const formData = await parseForm(blob);
+          equal(formData["audienceGroupId"], requestBody.audienceGroupId);
+          equal(formData["uploadDescription"], requestBody.uploadDescription);
           equal(
-            formData.get("uploadDescription"),
-            requestBody.uploadDescription,
-          );
-          equal(
-            Buffer.from(await (formData.get("file") as Blob).arrayBuffer()),
+            Buffer.from(
+              await (formData["file"] as Blob).arrayBuffer(),
+            ).toString(),
             requestBody.file.toString(),
           );
           scope.done();

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -16,90 +16,13 @@ import {
 } from "../lib/endpoints.js";
 
 import { describe, it, beforeAll, afterAll, afterEach } from "vitest";
+import { parseForm } from "./helpers/parse-form";
 
 const channelAccessToken = "test_channel_access_token";
 
 const client = new Client({
   channelAccessToken,
 });
-
-// This is not a perfect multipart/form-data parser,
-// but it works for the purpose of this test.
-async function parseForm(blob: Blob) {
-  const arrayBuffer = await blob.arrayBuffer();
-  const uint8Array = new Uint8Array(arrayBuffer);
-  const text = new TextDecoder().decode(uint8Array);
-
-  /*
---axios-1.7.2-boundary-gO2LZK1gY4J9v9AfRI29XEHgu
-Content-Disposition: form-data; name="audienceGroupId"
-
-4389303728991
---axios-1.7.2-boundary-gO2LZK1gY4J9v9AfRI29XEHgu
-Content-Disposition: form-data; name="uploadDescription"
-
-fileName
---axios-1.7.2-boundary-gO2LZK1gY4J9v9AfRI29XEHgu
-Content-Disposition: form-data; name="file"; filename="blob"
-Content-Type: application/octet-stream
-
-PNG BINARY DATA
---axios-1.7.2-boundary-gO2LZK1gY4J9v9AfRI29XEHgu--
-   */
-
-  const boundary = text.match(/^--[^\r\n]+/)![0];
-
-  /*
-[
-  'Content-Disposition: form-data; name="audienceGroupId"\r\n\r\n4389303728991\r\n',
-  'Content-Disposition: form-data; name="uploadDescription"\r\n\r\nfileName\r\n',
-  'Content-Disposition: form-data; name="file"; filename="blob"\r\n' +
-    'Content-Type: application/octet-stream\r\n' +
-    '\r\n' +
-    'HELLO\n' +
-    '\r\n' +
-    '--axios-1.7.2-boundary-HytTvC4rGiQmNGiM6aC23i1GT--\r\n' +
-    '\r\n'
-]
-   */
-  // split to parts, and drop first and last empty parts
-  const parts = text.split(new RegExp(boundary + "(?:\\r\\n|--)")).slice(1, -1);
-
-  const result: Record<string, string | Blob> = {};
-
-  for (const part of parts) {
-    const headerEnd = part.indexOf("\r\n\r\n");
-    if (headerEnd === -1) continue;
-
-    const headers = part.slice(0, headerEnd);
-    const content = part.slice(headerEnd + 4);
-
-    const nameMatch = headers.match(/name="([^"]+)"/);
-    const fileNameMatch = headers.match(/filename="([^"]+)"/);
-
-    if (nameMatch) {
-      const name = nameMatch[1];
-
-      if (fileNameMatch) {
-        // it's a file
-        const contentTypeMatch = headers.match(/Content-Type:\s*(\S+)/i);
-        const contentType = contentTypeMatch
-          ? contentTypeMatch[1]
-          : "application/octet-stream";
-
-        result[name] = new Blob([content.replace(/\r\n$/, "")], {
-          type: contentType,
-        });
-      } else {
-        // basic field
-        const value = content.trim();
-        result[name] = value;
-      }
-    }
-  }
-
-  return result;
-}
 
 class MSWResult {
   private _done: boolean;
@@ -306,34 +229,6 @@ describe("client", () => {
     );
     return result;
   };
-
-  it("test parseForm", async () => {
-    const result = await parseForm(
-      new Blob([
-        "--axios-1.7.2-boundary-gO2LZK1gY4J9v9AfRI29XEHgu\r\n" +
-          'Content-Disposition: form-data; name="audienceGroupId"\r\n' +
-          "\r\n" +
-          "4389303728991\r\n" +
-          "--axios-1.7.2-boundary-gO2LZK1gY4J9v9AfRI29XEHgu\r\n" +
-          'Content-Disposition: form-data; name="uploadDescription"\r\n' +
-          "\r\n" +
-          "fileName\r\n" +
-          "--axios-1.7.2-boundary-gO2LZK1gY4J9v9AfRI29XEHgu\r\n" +
-          'Content-Disposition: form-data; name="file"; filename="blob"\r\n' +
-          "Content-Type: application/octet-stream\r\n" +
-          "\r\n" +
-          "PNG BINARY DATA\r\n" +
-          "--axios-1.7.2-boundary-gO2LZK1gY4J9v9AfRI29XEHgu--\r\n\r\n",
-      ]),
-    );
-    deepEqual(result, {
-      audienceGroupId: "4389303728991",
-      uploadDescription: "fileName",
-      file: new Blob(["PNG BINARY DATA"], {
-        type: "application/octet-stream",
-      }),
-    });
-  });
 
   it("reply", async () => {
     const scope = mockPost(MESSAGING_API_PREFIX, `/message/reply`, {
@@ -1123,7 +1018,8 @@ describe("client", () => {
           );
 
           const blob = await request.blob();
-          const formData = await parseForm(blob);
+          const arrayBuffer = await blob.arrayBuffer();
+          const formData = parseForm(arrayBuffer);
           equal(formData["description"], requestBody.description);
           equal(
             formData["isIfaAudience"],
@@ -1190,7 +1086,8 @@ describe("client", () => {
               .startsWith(`multipart/form-data; boundary=`),
           );
           const blob = await request.blob();
-          const formData = await parseForm(blob);
+          const arrayBuffer = await blob.arrayBuffer();
+          const formData = parseForm(arrayBuffer);
           equal(formData["audienceGroupId"], requestBody.audienceGroupId);
           equal(formData["uploadDescription"], requestBody.uploadDescription);
           equal(

--- a/test/helpers/parse-form.spec.ts
+++ b/test/helpers/parse-form.spec.ts
@@ -1,0 +1,31 @@
+import { it } from "vitest";
+import { parseForm } from "./parse-form";
+import { deepEqual } from "node:assert";
+
+it("test parseForm", async () => {
+  const blob = new Blob([
+    "--axios-1.7.2-boundary-gO2LZK1gY4J9v9AfRI29XEHgu\r\n" +
+      'Content-Disposition: form-data; name="audienceGroupId"\r\n' +
+      "\r\n" +
+      "4389303728991\r\n" +
+      "--axios-1.7.2-boundary-gO2LZK1gY4J9v9AfRI29XEHgu\r\n" +
+      'Content-Disposition: form-data; name="uploadDescription"\r\n' +
+      "\r\n" +
+      "fileName\r\n" +
+      "--axios-1.7.2-boundary-gO2LZK1gY4J9v9AfRI29XEHgu\r\n" +
+      'Content-Disposition: form-data; name="file"; filename="blob"\r\n' +
+      "Content-Type: application/octet-stream\r\n" +
+      "\r\n" +
+      "PNG BINARY DATA\r\n" +
+      "--axios-1.7.2-boundary-gO2LZK1gY4J9v9AfRI29XEHgu--\r\n\r\n",
+  ]);
+  const arrayBuffer = await blob.arrayBuffer();
+  const result = parseForm(arrayBuffer);
+  deepEqual(result, {
+    audienceGroupId: "4389303728991",
+    uploadDescription: "fileName",
+    file: new Blob(["PNG BINARY DATA"], {
+      type: "application/octet-stream",
+    }),
+  });
+});

--- a/test/helpers/parse-form.ts
+++ b/test/helpers/parse-form.ts
@@ -1,0 +1,78 @@
+// This is not a perfect multipart/form-data parser,
+// but it works for the purpose of this test.
+export function parseForm(
+  arrayBuffer: ArrayBuffer,
+): Record<string, string | Blob> {
+  const uint8Array = new Uint8Array(arrayBuffer);
+  const text = new TextDecoder().decode(uint8Array);
+
+  /*
+--axios-1.7.2-boundary-gO2LZK1gY4J9v9AfRI29XEHgu
+Content-Disposition: form-data; name="audienceGroupId"
+
+4389303728991
+--axios-1.7.2-boundary-gO2LZK1gY4J9v9AfRI29XEHgu
+Content-Disposition: form-data; name="uploadDescription"
+
+fileName
+--axios-1.7.2-boundary-gO2LZK1gY4J9v9AfRI29XEHgu
+Content-Disposition: form-data; name="file"; filename="blob"
+Content-Type: application/octet-stream
+
+PNG BINARY DATA
+--axios-1.7.2-boundary-gO2LZK1gY4J9v9AfRI29XEHgu--
+   */
+
+  const boundary = text.match(/^--[^\r\n]+/)![0];
+
+  /*
+[
+  'Content-Disposition: form-data; name="audienceGroupId"\r\n\r\n4389303728991\r\n',
+  'Content-Disposition: form-data; name="uploadDescription"\r\n\r\nfileName\r\n',
+  'Content-Disposition: form-data; name="file"; filename="blob"\r\n' +
+    'Content-Type: application/octet-stream\r\n' +
+    '\r\n' +
+    'HELLO\n' +
+    '\r\n' +
+    '--axios-1.7.2-boundary-HytTvC4rGiQmNGiM6aC23i1GT--\r\n' +
+    '\r\n'
+]
+   */
+  // split to parts, and drop first and last empty parts
+  const parts = text.split(new RegExp(boundary + "(?:\\r\\n|--)")).slice(1, -1);
+
+  const result: Record<string, string | Blob> = {};
+
+  for (const part of parts) {
+    const headerEnd = part.indexOf("\r\n\r\n");
+    if (headerEnd === -1) continue;
+
+    const headers = part.slice(0, headerEnd);
+    const content = part.slice(headerEnd + 4);
+
+    const nameMatch = headers.match(/name="([^"]+)"/);
+    const fileNameMatch = headers.match(/filename="([^"]+)"/);
+
+    if (nameMatch) {
+      const name = nameMatch[1];
+
+      if (fileNameMatch) {
+        // it's a file
+        const contentTypeMatch = headers.match(/Content-Type:\s*(\S+)/i);
+        const contentType = contentTypeMatch
+          ? contentTypeMatch[1]
+          : "application/octet-stream";
+
+        result[name] = new Blob([content.replace(/\r\n$/, "")], {
+          type: contentType,
+        });
+      } else {
+        // basic field
+        const value = content.trim();
+        result[name] = value;
+      }
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
Undici's multipart/form-data parser cannot handle Axios' multipart/form-data requests correctly. For example, see this failure: https://github.com/line/line-bot-sdk-nodejs/actions/runs/9362094041/job/25770215937.

The root cause of this issue is unclear, but it exists in the legacy client code, which we plan to deprecate by the end of this year. 

As a temporary workaround, we are replacing undici's parser with our own implementation to ensure the tests pass.

Changes:
- Added a custom multipart/form-data parser function in `test/client.spec.ts`.
- Updated tests to use the custom parser instead of undici's.
