### PR TITLE
PR must fail when generated code is not committed

### DIFF
--- a/.github/workflows/update-code.yml
+++ b/.github/workflows/update-code.yml
@@ -2,6 +2,7 @@ name: Generate OpenAPI based code
 
 on:
   workflow_dispatch:
+  pull_request:
   push:
     branches:
       - master
@@ -33,13 +34,19 @@ jobs:
         run: npm ci
 
       # Generate codes
-      - run: |
-          python3 generate-code.py
+      - name: Generate code
+        run: python3 generate-code.py
       - run: |
           diff=$(git --no-pager diff --name-only)
           echo "DIFF_IS_EMPTY=$([[ -z "$diff" ]] && echo 'true' || echo 'false')" >> $GITHUB_ENV
           echo "CURRENT_DATETIME=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
-      - if: ${{ env.DIFF_IS_EMPTY != 'true' }}
+      ## Run if diff exists and pull request, and make CI status failure
+      - if: ${{ github.event_name == 'pull_request' && env.DIFF_IS_EMPTY != 'true' }}
+        run: |
+          echo "There are changes in the generated codes. Please run 'generate-code.py' and commit the changes." >&2
+          exit 1
+      ## Run if diff exists and event is not pull request, and make PR
+      - if: ${{ github.event_name != 'pull_request' && env.DIFF_IS_EMPTY != 'true' }}
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com

--- a/lib/shop/api/apis.ts
+++ b/lib/shop/api/apis.ts
@@ -1,1 +1,2 @@
 export { ShopClient } from "./shopClient.js";
+const shopClient = new ShopClient();

--- a/lib/shop/api/apis.ts
+++ b/lib/shop/api/apis.ts
@@ -1,2 +1,1 @@
 export { ShopClient } from "./shopClient.js";
-const shopClient = new ShopClient();


### PR DESCRIPTION
When some code are changed by modifying code generator or templates, forgetting to commit the expected changes can lead to mistakes. I want to enforce that the PR author commits the generated code, by causing the CI to fail if the generated code is not committed. This PR achieves that.