### PR TITLE
Improve a way to update package version on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,7 @@ jobs:
         else
           VERSION=${{ github.event.release.tag_name }}
         fi
-        VERSION=${VERSION#v}
-        sed -i "s/__LINE_BOT_SDK_NODEJS_VERSION__/$VERSION/g" package.json
-        sed -i "s/__LINE_BOT_SDK_NODEJS_VERSION__/$VERSION/g" package-lock.json
-        sed -i "s/__LINE_BOT_SDK_NODEJS_VERSION__/$VERSION/g" lib/version.ts
+        node ./scripts/update-version.js $VERSION
     - run: npm run release
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_2 }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,8 @@ jobs:
         else
           VERSION=${{ github.event.release.tag_name }}
         fi
-        node ./scripts/update-version.js $VERSION
+        VERSION=${VERSION#v}
+        node ./scripts/update-version.mjs $VERSION
     - run: npm run release
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_2 }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,8 @@ jobs:
         npm install
         npm run build
         cd -
+    - name: try to update next version
+      run: node ./scripts/update-version.mjs "3.3.0"
     - name: publint
       run: npx publint
     - name: validate package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,8 +60,6 @@ jobs:
         npm install
         npm run build
         cd -
-    - name: try to update next version
-      run: node ./scripts/update-version.mjs "3.3.0"
     - name: publint
       run: npx publint
     - name: validate package

--- a/examples/echo-bot-esm/package-lock.json
+++ b/examples/echo-bot-esm/package-lock.json
@@ -13,7 +13,7 @@
       }
     },
     "../..": {
-      "version": "__LINE_BOT_SDK_NODEJS_VERSION__",
+      "version": "1.0.0-test",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^20.0.0"

--- a/examples/echo-bot-ts-cjs/package-lock.json
+++ b/examples/echo-bot-ts-cjs/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../..": {
       "name": "@line/bot-sdk",
-      "version": "__LINE_BOT_SDK_NODEJS_VERSION__",
+      "version": "1.0.0-test",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^20.0.0"

--- a/examples/echo-bot-ts-esm/package-lock.json
+++ b/examples/echo-bot-ts-esm/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../..": {
       "name": "@line/bot-sdk",
-      "version": "__LINE_BOT_SDK_NODEJS_VERSION__",
+      "version": "1.0.0-test",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^20.0.0"

--- a/examples/echo-bot/package-lock.json
+++ b/examples/echo-bot/package-lock.json
@@ -14,7 +14,7 @@
     },
     "../..": {
       "name": "@line/bot-sdk",
-      "version": "__LINE_BOT_SDK_NODEJS_VERSION__",
+      "version": "1.0.0-test",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^20.0.0"

--- a/examples/kitchensink/package-lock.json
+++ b/examples/kitchensink/package-lock.json
@@ -15,7 +15,7 @@
     },
     "../..": {
       "name": "@line/bot-sdk",
-      "version": "__LINE_BOT_SDK_NODEJS_VERSION__",
+      "version": "1.0.0-test",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^20.0.0"

--- a/examples/rich-menu/package-lock.json
+++ b/examples/rich-menu/package-lock.json
@@ -13,7 +13,7 @@
     },
     "../..": {
       "name": "@line/bot-sdk",
-      "version": "__LINE_BOT_SDK_NODEJS_VERSION__",
+      "version": "1.0.0-test",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^20.0.0"

--- a/generator/src/main/resources/line-bot-sdk-nodejs-generator/api_test.pebble
+++ b/generator/src/main/resources/line-bot-sdk-nodejs-generator/api_test.pebble
@@ -122,7 +122,7 @@ function parseForm(
     {% endif -%}
       equal(
         req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
+        "@line/bot-sdk/1.0.0-test",
       );
       {% if op.isMultipart %}
       ok(

--- a/lib/channel-access-token/tests/api/ChannelAccessTokenClientTest.spec.ts
+++ b/lib/channel-access-token/tests/api/ChannelAccessTokenClientTest.spec.ts
@@ -94,10 +94,7 @@ describe("ChannelAccessTokenClient", () => {
         ),
       );
 
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -160,10 +157,7 @@ describe("ChannelAccessTokenClient", () => {
         ),
       );
 
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -210,10 +204,7 @@ describe("ChannelAccessTokenClient", () => {
           .replace("{clientSecret}", "DUMMY"), // string
       );
 
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -263,10 +254,7 @@ describe("ChannelAccessTokenClient", () => {
           .replace("{clientSecret}", "DUMMY"), // string
       );
 
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -316,10 +304,7 @@ describe("ChannelAccessTokenClient", () => {
           .replace("{clientAssertion}", "DUMMY"), // string
       );
 
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -369,10 +354,7 @@ describe("ChannelAccessTokenClient", () => {
           .replace("{clientAssertion}", "DUMMY"), // string
       );
 
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -424,10 +406,7 @@ describe("ChannelAccessTokenClient", () => {
           .replace("{clientSecret}", "DUMMY"), // string
       );
 
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -485,10 +464,7 @@ describe("ChannelAccessTokenClient", () => {
           .replace("{clientSecret}", "DUMMY"), // string
       );
 
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -541,10 +517,7 @@ describe("ChannelAccessTokenClient", () => {
         "/v2/oauth/revoke".replace("{accessToken}", "DUMMY"), // string
       );
 
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -585,10 +558,7 @@ describe("ChannelAccessTokenClient", () => {
         "/v2/oauth/revoke".replace("{accessToken}", "DUMMY"), // string
       );
 
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -632,10 +602,7 @@ describe("ChannelAccessTokenClient", () => {
           .replace("{accessToken}", "DUMMY"), // string
       );
 
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -685,10 +652,7 @@ describe("ChannelAccessTokenClient", () => {
           .replace("{accessToken}", "DUMMY"), // string
       );
 
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -735,10 +699,7 @@ describe("ChannelAccessTokenClient", () => {
         "/v2/oauth/verify".replace("{accessToken}", "DUMMY"), // string
       );
 
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -779,10 +740,7 @@ describe("ChannelAccessTokenClient", () => {
         "/v2/oauth/verify".replace("{accessToken}", "DUMMY"), // string
       );
 
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -833,10 +791,7 @@ describe("ChannelAccessTokenClient", () => {
         ),
       );
 
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -887,10 +842,7 @@ describe("ChannelAccessTokenClient", () => {
         ),
       );
 
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));

--- a/lib/insight/tests/api/InsightClientTest.spec.ts
+++ b/lib/insight/tests/api/InsightClientTest.spec.ts
@@ -72,10 +72,7 @@ describe("InsightClient", () => {
       equal(reqUrl.pathname, "/v2/bot/insight/demographic");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -112,10 +109,7 @@ describe("InsightClient", () => {
       equal(reqUrl.pathname, "/v2/bot/insight/demographic");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -165,10 +159,7 @@ describe("InsightClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -221,10 +212,7 @@ describe("InsightClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -277,10 +265,7 @@ describe("InsightClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -333,10 +318,7 @@ describe("InsightClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -389,10 +371,7 @@ describe("InsightClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -445,10 +424,7 @@ describe("InsightClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -518,10 +494,7 @@ describe("InsightClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -597,10 +570,7 @@ describe("InsightClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));

--- a/lib/liff/tests/api/LiffClientTest.spec.ts
+++ b/lib/liff/tests/api/LiffClientTest.spec.ts
@@ -71,10 +71,7 @@ describe("LiffClient", () => {
       equal(reqUrl.pathname, "/liff/v1/apps");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -114,10 +111,7 @@ describe("LiffClient", () => {
       equal(reqUrl.pathname, "/liff/v1/apps");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -160,10 +154,7 @@ describe("LiffClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -206,10 +197,7 @@ describe("LiffClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -249,10 +237,7 @@ describe("LiffClient", () => {
       equal(reqUrl.pathname, "/liff/v1/apps");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -289,10 +274,7 @@ describe("LiffClient", () => {
       equal(reqUrl.pathname, "/liff/v1/apps");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -332,10 +314,7 @@ describe("LiffClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -381,10 +360,7 @@ describe("LiffClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));

--- a/lib/manage-audience/tests/api/ManageAudienceBlobClientTest.spec.ts
+++ b/lib/manage-audience/tests/api/ManageAudienceBlobClientTest.spec.ts
@@ -73,10 +73,7 @@ describe("ManageAudienceBlobClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       ok(
         req.headers["content-type"].startsWith(
@@ -174,10 +171,7 @@ describe("ManageAudienceBlobClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       ok(
         req.headers["content-type"].startsWith(
@@ -275,10 +269,7 @@ describe("ManageAudienceBlobClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       ok(
         req.headers["content-type"].startsWith(
@@ -386,10 +377,7 @@ describe("ManageAudienceBlobClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       ok(
         req.headers["content-type"].startsWith(

--- a/lib/manage-audience/tests/api/ManageAudienceClientTest.spec.ts
+++ b/lib/manage-audience/tests/api/ManageAudienceClientTest.spec.ts
@@ -88,10 +88,7 @@ describe("ManageAudienceClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -137,10 +134,7 @@ describe("ManageAudienceClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -180,10 +174,7 @@ describe("ManageAudienceClient", () => {
       equal(reqUrl.pathname, "/v2/bot/audienceGroup/upload");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -223,10 +214,7 @@ describe("ManageAudienceClient", () => {
       equal(reqUrl.pathname, "/v2/bot/audienceGroup/upload");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -266,10 +254,7 @@ describe("ManageAudienceClient", () => {
       equal(reqUrl.pathname, "/v2/bot/audienceGroup/upload");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -309,10 +294,7 @@ describe("ManageAudienceClient", () => {
       equal(reqUrl.pathname, "/v2/bot/audienceGroup/upload");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -352,10 +334,7 @@ describe("ManageAudienceClient", () => {
       equal(reqUrl.pathname, "/v2/bot/audienceGroup/click");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -395,10 +374,7 @@ describe("ManageAudienceClient", () => {
       equal(reqUrl.pathname, "/v2/bot/audienceGroup/click");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -438,10 +414,7 @@ describe("ManageAudienceClient", () => {
       equal(reqUrl.pathname, "/v2/bot/audienceGroup/imp");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -481,10 +454,7 @@ describe("ManageAudienceClient", () => {
       equal(reqUrl.pathname, "/v2/bot/audienceGroup/imp");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -530,10 +500,7 @@ describe("ManageAudienceClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -579,10 +546,7 @@ describe("ManageAudienceClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -628,10 +592,7 @@ describe("ManageAudienceClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -677,10 +638,7 @@ describe("ManageAudienceClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -720,10 +678,7 @@ describe("ManageAudienceClient", () => {
       equal(reqUrl.pathname, "/v2/bot/audienceGroup/authorityLevel");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -760,10 +715,7 @@ describe("ManageAudienceClient", () => {
       equal(reqUrl.pathname, "/v2/bot/audienceGroup/authorityLevel");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -851,10 +803,7 @@ describe("ManageAudienceClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -960,10 +909,7 @@ describe("ManageAudienceClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -1018,10 +964,7 @@ describe("ManageAudienceClient", () => {
       equal(reqUrl.pathname, "/v2/bot/audienceGroup/authorityLevel");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -1061,10 +1004,7 @@ describe("ManageAudienceClient", () => {
       equal(reqUrl.pathname, "/v2/bot/audienceGroup/authorityLevel");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -1110,10 +1050,7 @@ describe("ManageAudienceClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -1162,10 +1099,7 @@ describe("ManageAudienceClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));

--- a/lib/messaging-api/tests/api/MessagingApiBlobClientTest.spec.ts
+++ b/lib/messaging-api/tests/api/MessagingApiBlobClientTest.spec.ts
@@ -71,10 +71,7 @@ describe("MessagingApiBlobClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -117,10 +114,7 @@ describe("MessagingApiBlobClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -166,10 +160,7 @@ describe("MessagingApiBlobClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -215,10 +206,7 @@ describe("MessagingApiBlobClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -264,10 +252,7 @@ describe("MessagingApiBlobClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -314,10 +299,7 @@ describe("MessagingApiBlobClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -363,10 +345,7 @@ describe("MessagingApiBlobClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -412,10 +391,7 @@ describe("MessagingApiBlobClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -461,10 +437,7 @@ describe("MessagingApiBlobClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -513,10 +486,7 @@ describe("MessagingApiBlobClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));

--- a/lib/messaging-api/tests/api/MessagingApiClientTest.spec.ts
+++ b/lib/messaging-api/tests/api/MessagingApiClientTest.spec.ts
@@ -114,10 +114,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/bot/ad/multicast/phone");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -157,10 +154,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/bot/ad/multicast/phone");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -203,10 +197,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -252,10 +243,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -298,10 +286,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/user/all/richmenu");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -338,10 +323,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/user/all/richmenu");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -378,10 +360,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/richmenu");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -421,10 +400,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/richmenu");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -464,10 +440,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/richmenu/alias");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -507,10 +480,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/richmenu/alias");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -553,10 +523,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -599,10 +566,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -648,10 +612,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -697,10 +658,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -753,10 +711,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -809,10 +764,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -874,10 +826,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -942,10 +891,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -988,10 +934,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/message/aggregation/info");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -1028,10 +971,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/message/aggregation/info");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -1068,10 +1008,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/info");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -1108,10 +1045,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/info");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -1148,10 +1082,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/user/all/richmenu");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -1188,10 +1119,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/user/all/richmenu");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -1250,10 +1178,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -1318,10 +1243,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -1367,10 +1289,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -1413,10 +1332,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -1461,10 +1377,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -1512,10 +1425,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -1573,10 +1483,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -1634,10 +1541,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -1683,10 +1587,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -1729,10 +1630,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -1772,10 +1670,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/membership/list");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -1812,10 +1707,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/membership/list");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -1855,10 +1747,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -1901,10 +1790,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -1944,10 +1830,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/message/quota");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -1984,10 +1867,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/message/quota");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -2024,10 +1904,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/message/quota/consumption");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -2064,10 +1941,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/message/quota/consumption");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -2117,10 +1991,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -2173,10 +2044,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -2229,10 +2097,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -2285,10 +2150,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -2341,10 +2203,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -2397,10 +2256,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -2453,10 +2309,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -2509,10 +2362,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -2565,10 +2415,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -2621,10 +2468,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -2677,10 +2521,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -2733,10 +2574,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -2779,10 +2617,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -2825,10 +2660,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -2871,10 +2703,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -2917,10 +2746,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -2966,10 +2792,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -3015,10 +2838,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -3058,10 +2878,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/richmenu/alias/list");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -3098,10 +2915,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/richmenu/alias/list");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -3151,10 +2965,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -3207,10 +3018,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -3253,10 +3061,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -3299,10 +3104,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -3342,10 +3144,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/richmenu/list");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -3382,10 +3181,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/richmenu/list");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -3425,10 +3221,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -3471,10 +3264,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -3519,10 +3309,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -3570,10 +3357,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -3631,10 +3415,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -3692,10 +3473,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -3738,10 +3516,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/channel/webhook/endpoint");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -3778,10 +3553,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/channel/webhook/endpoint");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -3821,10 +3593,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -3867,10 +3636,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -3913,10 +3679,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -3959,10 +3722,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -4005,10 +3765,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -4051,10 +3808,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -4099,10 +3853,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -4150,10 +3901,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -4196,10 +3944,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/richmenu/bulk/link");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -4239,10 +3984,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/richmenu/bulk/link");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -4282,10 +4024,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/message/markAsRead");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -4325,10 +4064,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/message/markAsRead");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -4371,10 +4107,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -4420,10 +4153,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -4469,10 +4199,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -4518,10 +4245,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -4567,10 +4291,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -4616,10 +4337,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -4665,10 +4383,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -4714,10 +4429,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -4760,10 +4472,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/message/reply");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -4803,10 +4512,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/message/reply");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -4846,10 +4552,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/richmenu/batch");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -4889,10 +4592,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/richmenu/batch");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -4938,10 +4638,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -4987,10 +4684,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -5030,10 +4724,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/channel/webhook/endpoint");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -5073,10 +4764,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/channel/webhook/endpoint");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -5116,10 +4804,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/chat/loading/start");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -5159,10 +4844,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/chat/loading/start");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -5202,10 +4884,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/channel/webhook/test");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -5245,10 +4924,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/channel/webhook/test");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -5291,10 +4967,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -5337,10 +5010,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -5380,10 +5050,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/richmenu/bulk/unlink");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -5423,10 +5090,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/richmenu/bulk/unlink");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -5472,10 +5136,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -5524,10 +5185,7 @@ describe("MessagingApiClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -5570,10 +5228,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/message/validate/broadcast");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -5613,10 +5268,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/message/validate/broadcast");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -5656,10 +5308,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/message/validate/multicast");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -5699,10 +5348,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/message/validate/multicast");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -5742,10 +5388,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/message/validate/narrowcast");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -5785,10 +5428,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/message/validate/narrowcast");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -5828,10 +5468,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/message/validate/push");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -5871,10 +5508,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/message/validate/push");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -5914,10 +5548,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/message/validate/reply");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -5957,10 +5588,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/message/validate/reply");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -6000,10 +5628,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/richmenu/validate/batch");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -6043,10 +5668,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/richmenu/validate/batch");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -6086,10 +5708,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/richmenu/validate");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -6129,10 +5748,7 @@ describe("MessagingApiClient", () => {
       equal(reqUrl.pathname, "/v2/bot/richmenu/validate");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));

--- a/lib/module-attach/tests/api/LineModuleAttachClientTest.spec.ts
+++ b/lib/module-attach/tests/api/LineModuleAttachClientTest.spec.ts
@@ -81,10 +81,7 @@ describe("LineModuleAttachClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -164,10 +161,7 @@ describe("LineModuleAttachClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));

--- a/lib/module/tests/api/LineModuleClientTest.spec.ts
+++ b/lib/module/tests/api/LineModuleClientTest.spec.ts
@@ -73,10 +73,7 @@ describe("LineModuleClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -122,10 +119,7 @@ describe("LineModuleClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -168,10 +162,7 @@ describe("LineModuleClient", () => {
       equal(reqUrl.pathname, "/v2/bot/channel/detach");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -211,10 +202,7 @@ describe("LineModuleClient", () => {
       equal(reqUrl.pathname, "/v2/bot/channel/detach");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -276,10 +264,7 @@ describe("LineModuleClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -344,10 +329,7 @@ describe("LineModuleClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -393,10 +375,7 @@ describe("LineModuleClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -439,10 +418,7 @@ describe("LineModuleClient", () => {
       );
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));

--- a/lib/shop/tests/api/ShopClientTest.spec.ts
+++ b/lib/shop/tests/api/ShopClientTest.spec.ts
@@ -68,10 +68,7 @@ describe("ShopClient", () => {
       equal(reqUrl.pathname, "/shop/v3/mission");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));
@@ -111,10 +108,7 @@ describe("ShopClient", () => {
       equal(reqUrl.pathname, "/shop/v3/mission");
 
       equal(req.headers["authorization"], `Bearer ${channel_access_token}`);
-      equal(
-        req.headers["user-agent"],
-        "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-      );
+      equal(req.headers["user-agent"], "@line/bot-sdk/1.0.0-test");
 
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({}));

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -1,2 +1,2 @@
-const LINE_BOT_SDK_VERSION = "__LINE_BOT_SDK_NODEJS_VERSION__";
+const LINE_BOT_SDK_VERSION = "1.0.0-test";
 export const USER_AGENT = `@line/bot-sdk/${LINE_BOT_SDK_VERSION}`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@line/bot-sdk",
-  "version": "__LINE_BOT_SDK_NODEJS_VERSION__",
+  "version": "1.0.0-test",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@line/bot-sdk",
-      "version": "__LINE_BOT_SDK_NODEJS_VERSION__",
+      "version": "1.0.0-test",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^22.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@line/bot-sdk",
-  "version": "__LINE_BOT_SDK_NODEJS_VERSION__",
+  "version": "1.0.0-test",
   "description": "Node.js SDK for LINE Messaging API",
   "type": "module",
   "engines": {

--- a/scripts/update-version.mjs
+++ b/scripts/update-version.mjs
@@ -1,0 +1,100 @@
+import fs from 'fs/promises';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+async function updateVersion(newVersion) {
+  // FIles having version number
+  const files = {
+    packageJson: './package.json',
+    packageLockJson: './package-lock.json',
+    versionTs: './lib/version.ts',
+  };
+
+  // package.json
+  const packageJsonData = JSON.parse(await fs.readFile(files.packageJson, 'utf8'));
+  packageJsonData.version = newVersion;
+  await fs.writeFile(files.packageJson, JSON.stringify(packageJsonData, null, 2) + '\n');
+
+  // package-lock.json
+  const packageLockJsonData = JSON.parse(await fs.readFile(files.packageLockJson, 'utf8'));
+  packageLockJsonData.version = newVersion;
+  if (packageLockJsonData.packages && packageLockJsonData.packages[""]) {
+    packageLockJsonData.packages[""].version = newVersion;
+  }
+  await fs.writeFile(files.packageLockJson, JSON.stringify(packageLockJsonData, null, 2) + '\n');
+
+  // lib/version.ts
+  const versionTsData = await fs.readFile(files.versionTs, 'utf8');
+  const updatedVersionTsData = versionTsData.replace(
+    /const LINE_BOT_SDK_VERSION = ".*?";/,
+    `const LINE_BOT_SDK_VERSION = "${newVersion}";`
+  );
+  await fs.writeFile(files.versionTs, updatedVersionTsData);
+
+  console.log(`Version updated to ${newVersion} in all files.`);
+}
+
+async function verifyVersion(expectedVersion) {
+  // package.json
+  const packageJsonData = JSON.parse(await fs.readFile('./package.json', 'utf8'));
+  if (packageJsonData.version !== expectedVersion) {
+    throw new Error(`package.json version mismatch: expected ${expectedVersion}, found ${packageJsonData.version}`);
+  }
+
+  // package-lock.json
+  const packageLockJsonData = JSON.parse(await fs.readFile('./package-lock.json', 'utf8'));
+  if (packageLockJsonData.version !== expectedVersion) {
+    throw new Error(`package-lock.json version mismatch: expected ${expectedVersion}, found ${packageLockJsonData.version}`);
+  }
+  if (packageLockJsonData.packages && packageLockJsonData.packages[""] && packageLockJsonData.packages[""].version !== expectedVersion) {
+    throw new Error(`package-lock.json root package version mismatch: expected ${expectedVersion}, found ${packageLockJsonData.packages[""].version}`);
+  }
+
+  // lib/version.ts
+  const versionTsData = await fs.readFile('./lib/version.ts', 'utf8');
+  if (!versionTsData.includes(`const LINE_BOT_SDK_VERSION = "${expectedVersion}";`)) {
+    throw new Error(`lib/version.ts version mismatch: expected ${expectedVersion}`);
+  }
+
+  console.log(`All files have the correct version: ${expectedVersion}`);
+}
+
+async function verifyGitDiff() {
+  try {
+    const { stdout: numstatOutput } = await execAsync('git diff --numstat');
+    const { addedLines, deletedLines } = numstatOutput.trim().split('\n').reduce((acc, line) => {
+      const [added, deleted] = line.split('\t').map(Number);
+      acc.addedLines += added;
+      acc.deletedLines += deleted;
+      return acc;
+    }, { addedLines: 0, deletedLines: 0 });
+
+    if (addedLines !== 4 || deletedLines !== 4) {
+      throw new Error(`Unexpected number of changed lines: expected 4 added and 4 deleted, found ${addedLines} added and ${deletedLines} deleted`);
+    }
+
+    console.log('Git diff verification passed: 4 lines added and 4 lines deleted.');
+
+    // Display the diff with context and color
+    const { stdout: diffOutput } = await execAsync('git diff -U5 --color=always');
+    console.log('Git diff with context and color:\n', diffOutput);
+
+  } catch (error) {
+    console.error('Error during git diff verification:', error.message);
+    process.exit(1);
+  }
+}
+
+// Main process
+const args = process.argv.slice(2);
+if (args.length !== 1) {
+  console.error('Usage: node update-version.mjs <new-version>');
+  process.exit(1);
+}
+
+const newVersion = args[0];
+await updateVersion(newVersion);
+await verifyVersion(newVersion);
+await verifyGitDiff();

--- a/scripts/update-version.mjs
+++ b/scripts/update-version.mjs
@@ -64,6 +64,7 @@ async function verifyVersion(expectedVersion) {
 async function verifyGitDiff() {
   try {
     const { stdout: numstatOutput } = await execAsync('git diff --numstat');
+    console.log('Git diff --numstat output:\n', numstatOutput);
     const { addedLines, deletedLines } = numstatOutput.trim().split('\n').reduce((acc, line) => {
       const [added, deleted] = line.split('\t').map(Number);
       acc.addedLines += added;

--- a/scripts/update-version.mjs
+++ b/scripts/update-version.mjs
@@ -64,7 +64,6 @@ async function verifyVersion(expectedVersion) {
 async function verifyGitDiff() {
   try {
     const { stdout: numstatOutput } = await execAsync('git diff --numstat');
-    console.log('Git diff --numstat output:\n', numstatOutput);
     const { addedLines, deletedLines } = numstatOutput.trim().split('\n').reduce((acc, line) => {
       const [added, deleted] = line.split('\t').map(Number);
       acc.addedLines += added;

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -97,7 +97,7 @@ describe("client", () => {
 
   const interceptionOption: Record<string, string> = {
     authorization: `Bearer ${channelAccessToken}`,
-    "User-Agent": "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
+    "User-Agent": "@line/bot-sdk/1.0.0-test",
   };
 
   const mockGet = (
@@ -1357,7 +1357,7 @@ describe("oauth", () => {
 
   const interceptionOption: Record<string, string> = {
     "content-type": "application/x-www-form-urlencoded",
-    "User-Agent": "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
+    "User-Agent": "@line/bot-sdk/1.0.0-test",
   };
   it("issueAccessToken", async () => {
     const client_id = "test_client_id";

--- a/test/http-axios.spec.ts
+++ b/test/http-axios.spec.ts
@@ -32,7 +32,7 @@ describe("http", () => {
 
   const interceptionOption: Record<string, string> = {
     "test-header-key": "Test-Header-Value",
-    "User-Agent": "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
+    "User-Agent": "@line/bot-sdk/1.0.0-test",
   };
 
   class MSWResult {
@@ -266,10 +266,7 @@ describe("http", () => {
     server.use(
       http.get(baseURL + "/404", async ({ request, params, cookies }) => {
         scope.done();
-        equal(
-          request.headers.get("user-agent"),
-          "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-        );
+        equal(request.headers.get("user-agent"), "@line/bot-sdk/1.0.0-test");
         return HttpResponse.json(404, { status: 404 });
       }),
     );
@@ -289,10 +286,7 @@ describe("http", () => {
     server.use(
       http.get(baseURL + "/get", async ({ request }) => {
         scope.done();
-        equal(
-          request.headers.get("user-agent"),
-          "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-        );
+        equal(request.headers.get("user-agent"), "@line/bot-sdk/1.0.0-test");
         return HttpResponse.json({});
       }),
     );

--- a/test/http-fetch.spec.ts
+++ b/test/http-fetch.spec.ts
@@ -34,7 +34,7 @@ describe("http(fetch)", () => {
 
   const interceptionOption: Record<string, string> = {
     "test-header-key": "Test-Header-Value",
-    "User-Agent": "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
+    "User-Agent": "@line/bot-sdk/1.0.0-test",
   };
 
   class MSWResult {
@@ -209,10 +209,7 @@ describe("http(fetch)", () => {
     server.use(
       http.get(baseURL + "/404", async ({ request, params, cookies }) => {
         scope.done();
-        equal(
-          request.headers.get("user-agent"),
-          "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-        );
+        equal(request.headers.get("user-agent"), "@line/bot-sdk/1.0.0-test");
         return HttpResponse.json({ reason: "not found" }, { status: 404 });
       }),
     );
@@ -234,10 +231,7 @@ describe("http(fetch)", () => {
     server.use(
       http.get(baseURL + "/get", async ({ request }) => {
         scope.done();
-        equal(
-          request.headers.get("user-agent"),
-          "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-        );
+        equal(request.headers.get("user-agent"), "@line/bot-sdk/1.0.0-test");
         return HttpResponse.json({});
       }),
     );

--- a/test/libs-channelAccessToken.spec.ts
+++ b/test/libs-channelAccessToken.spec.ts
@@ -24,10 +24,7 @@ describe("channelAccessToken", () => {
       http.post(
         "https://api.line.me/oauth2/v3/token",
         async ({ request, params, cookies }) => {
-          equal(
-            request.headers.get("User-Agent"),
-            "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-          );
+          equal(request.headers.get("User-Agent"), "@line/bot-sdk/1.0.0-test");
           equal(
             request.headers.get("content-type"),
             "application/x-www-form-urlencoded",

--- a/test/libs-manageAudience.spec.ts
+++ b/test/libs-manageAudience.spec.ts
@@ -39,10 +39,7 @@ describe("manageAudience", () => {
             request.headers.get("Authorization"),
             `Bearer test_channel_access_token`,
           );
-          equal(
-            request.headers.get("User-Agent"),
-            "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-          );
+          equal(request.headers.get("User-Agent"), "@line/bot-sdk/1.0.0-test");
           match(
             request.headers.get("content-type")!!,
             /^multipart\/form-data; boundary=.*$/,

--- a/test/libs-messagingApi.spec.ts
+++ b/test/libs-messagingApi.spec.ts
@@ -39,10 +39,7 @@ describe("messagingApi", () => {
             request.headers.get("Authorization"),
             `Bearer test_channel_access_token`,
           );
-          equal(
-            request.headers.get("User-Agent"),
-            "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-          );
+          equal(request.headers.get("User-Agent"), "@line/bot-sdk/1.0.0-test");
           equal(request.headers.get("content-type"), "image/jpeg");
           equal(await request.text(), "GREAT_JPEG");
 
@@ -71,10 +68,7 @@ describe("messagingApi", () => {
             request.headers.get("Authorization"),
             "Bearer test_channel_access_token",
           );
-          equal(
-            request.headers.get("User-Agent"),
-            "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-          );
+          equal(request.headers.get("User-Agent"), "@line/bot-sdk/1.0.0-test");
           equal(request.headers.get("content-type"), "application/json");
           equal(request.headers.get("x-line-retry-key"), "KEYKEYKEYKEY");
           return HttpResponse.json({});
@@ -102,10 +96,7 @@ describe("messagingApi", () => {
             request.headers.get("Authorization"),
             "Bearer test_channel_access_token",
           );
-          equal(
-            request.headers.get("User-Agent"),
-            "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-          );
+          equal(request.headers.get("User-Agent"), "@line/bot-sdk/1.0.0-test");
           equal(request.headers.get("content-type"), "application/json");
           equal(request.headers.get("x-line-retry-key"), undefined);
           return HttpResponse.json({});
@@ -133,10 +124,7 @@ describe("messagingApi", () => {
             request.headers.get("Authorization"),
             "Bearer test_channel_access_token",
           );
-          equal(
-            request.headers.get("User-Agent"),
-            "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-          );
+          equal(request.headers.get("User-Agent"), "@line/bot-sdk/1.0.0-test");
 
           const url = new URL(request.url);
           const searchParams = url.searchParams;
@@ -170,10 +158,7 @@ describe("messagingApi", () => {
             request.headers.get("Authorization"),
             "Bearer test_channel_access_token",
           );
-          equal(
-            request.headers.get("User-Agent"),
-            "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-          );
+          equal(request.headers.get("User-Agent"), "@line/bot-sdk/1.0.0-test");
 
           const url = new URL(request.url);
           const searchParams = url.searchParams;

--- a/test/libs-shop.spec.ts
+++ b/test/libs-shop.spec.ts
@@ -32,10 +32,7 @@ describe("shop", () => {
             request.headers.get("Authorization"),
             "Bearer test_channel_access_token",
           );
-          equal(
-            request.headers.get("User-Agent"),
-            "@line/bot-sdk/__LINE_BOT_SDK_NODEJS_VERSION__",
-          );
+          equal(request.headers.get("User-Agent"), "@line/bot-sdk/1.0.0-test");
           return HttpResponse.json({});
         },
       ),


### PR DESCRIPTION
The string `__LINE_BOT_SDK_NODEJS_VERSION__` is used in several files to make it easier to replace with the new version at the time of release. However, this string is inappropriate as a version, so it needs to be replaced when testing locally... This is cumbersome for us, so this PR addresses that issue.

At the time of release, the files that need to be updated will be directly modified anyway. `./scripts/update-version.mjs` will handle this. Since 4 lines across 3 files need to be changed, the CI will fail if this condition is not met. Reviewers can verify that the version is changed locally, but it's up to them whether to do so.