### PR TITLE
Open issue when release failed

### DIFF
--- a/.github/workflows/deploy-doc.yml
+++ b/.github/workflows/deploy-doc.yml
@@ -37,6 +37,24 @@ jobs:
         with:
           path: docs/.vitepress/dist
 
+      - name: Create GitHub Issue on Failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issueTitle = `build-page job failed`;
+            const issueBody = `The build-page job failed. Please check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details.`;
+            const assignees = [context.actor];
+
+            await github.rest.issues.create({
+              owner,
+              repo,
+              title: issueTitle,
+              body: issueBody,
+              assignees
+            });
+
   deploy:
     environment:
       name: github-pages
@@ -48,3 +66,21 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+      - name: Create GitHub Issue on Failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issueTitle = `deploy-page job failed`;
+            const issueBody = `The deploy-page job failed. Please check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details.`;
+            const assignees = [context.actor];
+
+            await github.rest.issues.create({
+              owner,
+              repo,
+              title: issueTitle,
+              body: issueBody,
+              assignees
+            });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,30 @@ jobs:
           VERSION=${{ github.event.release.tag_name }}
         fi
         VERSION=${VERSION#v}
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
         node ./scripts/update-version.mjs $VERSION
     - run: npm run release
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_2 }}
+
+    - name: Create GitHub Issue on Failure
+      if: failure()
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const { owner, repo } = context.repo;
+          const version = process.env.VERSION;
+          const issueTitle = `Release job for ${version} failed`;
+          const issueBody = `The release job failed. Please check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details.`;
+          const assignees = [context.actor];
+
+          await github.rest.issues.create({
+            owner,
+            repo,
+            title: issueTitle,
+            body: issueBody,
+            assignees
+          });
 
   deploy-docs:
     needs: [release-package]


### PR DESCRIPTION
When release job fails, we may not realize the issue. Let's open issue to notify us the release job failed.

I've tested this change and it opened an issue like this.
- title contains the release(d) version
- actor is assigned
- description contains failed job url
![image](https://github.com/user-attachments/assets/d2f0464d-2d0f-413a-b0df-da7966289e7e)
