### PR TITLE
Allow renovate PR to have un committed changes

### DIFF
--- a/.github/workflows/update-code.yml
+++ b/.github/workflows/update-code.yml
@@ -40,8 +40,8 @@ jobs:
           diff=$(git --no-pager diff --name-only)
           echo "DIFF_IS_EMPTY=$([[ -z "$diff" ]] && echo 'true' || echo 'false')" >> $GITHUB_ENV
           echo "CURRENT_DATETIME=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
-      ## Run if diff exists and pull request, and make CI status failure
-      - if: ${{ github.event_name == 'pull_request' && env.DIFF_IS_EMPTY != 'true' }}
+      ## Run if diff exists and pull request, and make CI status failure (but allow renovate bot)
+      - if: ${{ github.event_name == 'pull_request' && env.DIFF_IS_EMPTY != 'true' && github.actor != 'renovate[bot]' }}
         run: |
           echo "There are changes in the generated codes. Please run 'generate-code.py' and commit the changes." >&2
           exit 1


### PR DESCRIPTION
I've found CI always fails when renovate updates git submodule...
If there is un-committed changes by renovate PR(= new code will be generated by openapi generator), I think we can allow this. Finally github actions open PR after the PR by renovate is merged.

Another way is to make renovate to run script to generate code again, but the cost is a little bit high.(https://docs.renovatebot.com/configuration-options/#postupgradetasks) 
The situation won't get bad even when we merge this change, so let me merge this change.