### PR TITLE
Modify doc index (basic usage -> TypeScript)

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -44,7 +44,7 @@ export default {
             items: [
                 {text: 'Webhook', link: '/guide/webhook.html'},
                 {text: 'Client', link: '/guide/client.html'},
-                {text: 'Basic Usage', link: '/guide/typescript.html'},
+                {text: 'TypeScript', link: '/guide/typescript.html'},
             ],
           },
           {


### PR DESCRIPTION
There are 2 `Basic Usage` in docs, but one is for TypeScript. This change modifies it.
![image](https://github.com/user-attachments/assets/4a4fc52b-8f12-4563-be49-8cede89b4fb3)
