### PR TITLE
Drop @types/mocha dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ You can freely fork the project, clone the forked repository, and start editing.
 Here are each top-level directory explained:
 
 * `lib`: TypeScript source code. You may modify files under this directory.
-* `test`: Mocha test suites. Please add tests for modification if possible.
+* `test`: Test suites. Please add tests for modification if possible.
 * `examples`: Example projects using this SDK
 * `docs`: [VitePress](https://vitepress.dev/) markdowns for project documentation
 * `tools`: Useful tools

--- a/examples/echo-bot-esm/package-lock.json
+++ b/examples/echo-bot-esm/package-lock.json
@@ -13,34 +13,33 @@
       }
     },
     "../..": {
+      "name": "@line/bot-sdk",
       "version": "1.0.0-test",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/node": "^20.0.0"
+        "@types/node": "^22.0.0"
       },
       "devDependencies": {
-        "@types/express": "4.17.21",
+        "@types/express": "5.0.0",
         "@types/finalhandler": "1.2.3",
-        "@types/mocha": "10.0.6",
-        "@vitest/coverage-v8": "^1.4.0",
-        "express": "4.19.2",
-        "finalhandler": "1.2.0",
-        "husky": "9.0.11",
-        "msw": "2.2.11",
-        "prettier": "3.2.5",
+        "@vitest/coverage-v8": "^2.0.0",
+        "express": "4.21.2",
+        "finalhandler": "1.3.1",
+        "husky": "9.1.7",
+        "msw": "2.7.0",
+        "prettier": "3.4.2",
         "ts-node": "10.9.2",
-        "typedoc": "^0.25.1",
-        "typedoc-plugin-markdown": "^3.16.0",
-        "typescript": "5.4.3",
-        "vite": "^5.2.7",
+        "typedoc": "^0.27.1",
+        "typedoc-plugin-markdown": "^4.3.0",
+        "typescript": "^5.5.4",
         "vitepress": "^1.0.1",
-        "vitest": "^1.4.0"
+        "vitest": "^2.0.0"
       },
       "engines": {
         "node": ">=18"
       },
       "optionalDependencies": {
-        "axios": "^1.0.0"
+        "axios": "^1.7.4"
       }
     },
     "node_modules/@line/bot-sdk": {

--- a/examples/echo-bot-ts-cjs/package-lock.json
+++ b/examples/echo-bot-ts-cjs/package-lock.json
@@ -23,31 +23,29 @@
       "version": "1.0.0-test",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/node": "^20.0.0"
+        "@types/node": "^22.0.0"
       },
       "devDependencies": {
-        "@types/express": "4.17.21",
+        "@types/express": "5.0.0",
         "@types/finalhandler": "1.2.3",
-        "@types/mocha": "10.0.6",
-        "@vitest/coverage-v8": "^1.4.0",
-        "express": "4.19.2",
-        "finalhandler": "1.2.0",
-        "husky": "9.0.11",
-        "msw": "2.3.1",
-        "prettier": "3.3.0",
+        "@vitest/coverage-v8": "^2.0.0",
+        "express": "4.21.2",
+        "finalhandler": "1.3.1",
+        "husky": "9.1.7",
+        "msw": "2.7.0",
+        "prettier": "3.4.2",
         "ts-node": "10.9.2",
-        "typedoc": "^0.25.1",
-        "typedoc-plugin-markdown": "^3.16.0",
-        "typescript": "5.4.5",
-        "vite": "^5.2.7",
+        "typedoc": "^0.27.1",
+        "typedoc-plugin-markdown": "^4.3.0",
+        "typescript": "^5.5.4",
         "vitepress": "^1.0.1",
-        "vitest": "^1.4.0"
+        "vitest": "^2.0.0"
       },
       "engines": {
         "node": ">=18"
       },
       "optionalDependencies": {
-        "axios": "^1.0.0"
+        "axios": "^1.7.4"
       }
     },
     "../../node_modules/@algolia/autocomplete-core": {
@@ -1296,12 +1294,6 @@
       "version": "1.3.2",
       "dev": true,
       "license": "MIT"
-    },
-    "../../node_modules/@types/mocha": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
-      "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
-      "dev": true
     },
     "../../node_modules/@types/mute-stream": {
       "version": "0.0.4",

--- a/examples/echo-bot-ts-esm/package-lock.json
+++ b/examples/echo-bot-ts-esm/package-lock.json
@@ -23,31 +23,29 @@
       "version": "1.0.0-test",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/node": "^20.0.0"
+        "@types/node": "^22.0.0"
       },
       "devDependencies": {
-        "@types/express": "4.17.21",
+        "@types/express": "5.0.0",
         "@types/finalhandler": "1.2.3",
-        "@types/mocha": "10.0.6",
-        "@vitest/coverage-v8": "^1.4.0",
-        "express": "4.19.2",
-        "finalhandler": "1.2.0",
-        "husky": "9.0.11",
-        "msw": "2.2.11",
-        "prettier": "3.2.5",
+        "@vitest/coverage-v8": "^2.0.0",
+        "express": "4.21.2",
+        "finalhandler": "1.3.1",
+        "husky": "9.1.7",
+        "msw": "2.7.0",
+        "prettier": "3.4.2",
         "ts-node": "10.9.2",
-        "typedoc": "^0.25.1",
-        "typedoc-plugin-markdown": "^3.16.0",
-        "typescript": "5.4.3",
-        "vite": "^5.2.7",
+        "typedoc": "^0.27.1",
+        "typedoc-plugin-markdown": "^4.3.0",
+        "typescript": "^5.5.4",
         "vitepress": "^1.0.1",
-        "vitest": "^1.4.0"
+        "vitest": "^2.0.0"
       },
       "engines": {
         "node": ">=18"
       },
       "optionalDependencies": {
-        "axios": "^1.0.0"
+        "axios": "^1.7.4"
       }
     },
     "node_modules/@isaacs/cliui": {

--- a/examples/echo-bot/package-lock.json
+++ b/examples/echo-bot/package-lock.json
@@ -17,31 +17,29 @@
       "version": "1.0.0-test",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/node": "^20.0.0"
+        "@types/node": "^22.0.0"
       },
       "devDependencies": {
-        "@types/express": "4.17.21",
+        "@types/express": "5.0.0",
         "@types/finalhandler": "1.2.3",
-        "@types/mocha": "10.0.6",
-        "@vitest/coverage-v8": "^1.4.0",
-        "express": "4.19.2",
-        "finalhandler": "1.2.0",
-        "husky": "9.0.11",
-        "msw": "2.3.1",
-        "prettier": "3.3.0",
+        "@vitest/coverage-v8": "^2.0.0",
+        "express": "4.21.2",
+        "finalhandler": "1.3.1",
+        "husky": "9.1.7",
+        "msw": "2.7.0",
+        "prettier": "3.4.2",
         "ts-node": "10.9.2",
-        "typedoc": "^0.25.1",
-        "typedoc-plugin-markdown": "^3.16.0",
-        "typescript": "5.4.5",
-        "vite": "^5.2.7",
+        "typedoc": "^0.27.1",
+        "typedoc-plugin-markdown": "^4.3.0",
+        "typescript": "^5.5.4",
         "vitepress": "^1.0.1",
-        "vitest": "^1.4.0"
+        "vitest": "^2.0.0"
       },
       "engines": {
         "node": ">=18"
       },
       "optionalDependencies": {
-        "axios": "^1.0.0"
+        "axios": "^1.7.4"
       }
     },
     "node_modules/@line/bot-sdk": {

--- a/examples/kitchensink/package-lock.json
+++ b/examples/kitchensink/package-lock.json
@@ -18,31 +18,29 @@
       "version": "1.0.0-test",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/node": "^20.0.0"
+        "@types/node": "^22.0.0"
       },
       "devDependencies": {
-        "@types/express": "4.17.21",
+        "@types/express": "5.0.0",
         "@types/finalhandler": "1.2.3",
-        "@types/mocha": "10.0.6",
-        "@vitest/coverage-v8": "^1.4.0",
-        "express": "4.19.2",
-        "finalhandler": "1.2.0",
-        "husky": "9.0.11",
-        "msw": "2.3.1",
-        "prettier": "3.3.0",
+        "@vitest/coverage-v8": "^2.0.0",
+        "express": "4.21.2",
+        "finalhandler": "1.3.1",
+        "husky": "9.1.7",
+        "msw": "2.7.0",
+        "prettier": "3.4.2",
         "ts-node": "10.9.2",
-        "typedoc": "^0.25.1",
-        "typedoc-plugin-markdown": "^3.16.0",
-        "typescript": "5.4.5",
-        "vite": "^5.2.7",
+        "typedoc": "^0.27.1",
+        "typedoc-plugin-markdown": "^4.3.0",
+        "typescript": "^5.5.4",
         "vitepress": "^1.0.1",
-        "vitest": "^1.4.0"
+        "vitest": "^2.0.0"
       },
       "engines": {
         "node": ">=18"
       },
       "optionalDependencies": {
-        "axios": "^1.0.0"
+        "axios": "^1.7.4"
       }
     },
     "../../node_modules/@algolia/autocomplete-core": {
@@ -1302,12 +1300,6 @@
       "version": "1.3.2",
       "dev": true,
       "license": "MIT"
-    },
-    "../../node_modules/@types/mocha": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
-      "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
-      "dev": true
     },
     "../../node_modules/@types/mute-stream": {
       "version": "0.0.4",

--- a/examples/rich-menu/package-lock.json
+++ b/examples/rich-menu/package-lock.json
@@ -16,31 +16,29 @@
       "version": "1.0.0-test",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/node": "^20.0.0"
+        "@types/node": "^22.0.0"
       },
       "devDependencies": {
-        "@types/express": "4.17.21",
+        "@types/express": "5.0.0",
         "@types/finalhandler": "1.2.3",
-        "@types/mocha": "10.0.6",
-        "@vitest/coverage-v8": "^1.4.0",
-        "express": "4.19.2",
-        "finalhandler": "1.2.0",
-        "husky": "9.0.11",
-        "msw": "2.3.1",
-        "prettier": "3.3.0",
+        "@vitest/coverage-v8": "^2.0.0",
+        "express": "4.21.2",
+        "finalhandler": "1.3.1",
+        "husky": "9.1.7",
+        "msw": "2.7.0",
+        "prettier": "3.4.2",
         "ts-node": "10.9.2",
-        "typedoc": "^0.25.1",
-        "typedoc-plugin-markdown": "^3.16.0",
-        "typescript": "5.4.5",
-        "vite": "^5.2.7",
+        "typedoc": "^0.27.1",
+        "typedoc-plugin-markdown": "^4.3.0",
+        "typescript": "^5.5.4",
         "vitepress": "^1.0.1",
-        "vitest": "^1.4.0"
+        "vitest": "^2.0.0"
       },
       "engines": {
         "node": ">=18"
       },
       "optionalDependencies": {
-        "axios": "^1.0.0"
+        "axios": "^1.7.4"
       }
     },
     "../../node_modules/@algolia/autocomplete-core": {
@@ -1300,12 +1298,6 @@
       "version": "1.3.2",
       "dev": true,
       "license": "MIT"
-    },
-    "../../node_modules/@types/mocha": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
-      "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
-      "dev": true
     },
     "../../node_modules/@types/mute-stream": {
       "version": "0.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
       "devDependencies": {
         "@types/express": "5.0.0",
         "@types/finalhandler": "1.2.3",
-        "@types/mocha": "10.0.10",
         "@vitest/coverage-v8": "^2.0.0",
         "express": "4.21.2",
         "finalhandler": "1.3.1",
@@ -1695,13 +1694,6 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
       "dev": true
-    },
-    "node_modules/@types/mocha": {
-      "version": "10.0.10",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
-      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.10.2",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
   "devDependencies": {
     "@types/express": "5.0.0",
     "@types/finalhandler": "1.2.3",
-    "@types/mocha": "10.0.10",
     "@vitest/coverage-v8": "^2.0.0",
     "express": "4.21.2",
     "finalhandler": "1.3.1",


### PR DESCRIPTION
We haven't used mocha, so `@types/mocha` dependency is not necessary for now.
(follow-up for https://github.com/line/line-bot-sdk-nodejs/pull/793)