### PR TITLE
Assign reviewers automatically

### DIFF
--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -1,7 +1,7 @@
 name: Assign Reviewers
 on:
   pull_request:
-    types: [opened, ready_for_review]
+#    types: [opened, ready_for_review]
 
 jobs:
   assign_reviewers:

--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -24,6 +24,6 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: pr.number,
-                team_reviewers: ['bot-sdk-general-reviewers'],
+                team_reviewers: ['line/bot-sdk-general-reviewers'],
               });
             }

--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -1,0 +1,29 @@
+name: Assign Reviewers
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  assign_reviewers:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      # Although you could use CodeOwners, we do not want to review Pull Requests created by Renovate or Dependabot.
+      # We do want to review PRs created by other bots (e.g., GitHub Actions) or regular users.
+      # Also, reviewers should only be assigned if the PR is not a draft.
+      - name: Assign reviewers for non-draft PRs that are not from Renovate or Dependabot
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const excludedBotAuthors = ['renovate[bot]', 'dependabot[bot]'];
+
+            if (!excludedBotAuthors.includes(pr.user.login) && !pr.draft) {
+              await github.rest.pulls.requestReviewers({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                team_reviewers: ['line/bot-team/bot-sdk-general-reviewers'],
+              });
+            }

--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -24,6 +24,6 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: pr.number,
-                team_reviewers: ['line/bot-sdk-general-reviewers'],
+                team_reviewers: ['bot-sdk-general-reviewers'],
               });
             }

--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -24,6 +24,6 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: pr.number,
-                team_reviewers: ['line/bot-team/bot-sdk-general-reviewers'],
+                team_reviewers: ['bot-sdk-general-reviewers'],
               });
             }


### PR DESCRIPTION
When we request maintainers to review changes , it's cumbersome to input individual names for each PR. This change defines a workflow to automatically add reviewers for PRs, except those from Renovate or Dependabot.

While it's possible not to add reviewers for bots, I believe that PRs generated by GitHub Actions (to generate code) should be reviewed. Therefore, a blacklist approach is adopted in this workflow.