### PR TITLE
Renovate should update package-lock.json in examples automatically when toplevel dependencies are updated

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,20 @@
     {
       "matchPackagePatterns": ["^line-openapi$"],
       "labels": ["dependency upgrade", "line-openapi-update"]
+    },
+    {
+      "matchPaths": [
+        "examples/*"
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "npm install"
+        ],
+        "fileFilters": [
+          "package.json",
+          "package-lock.json"
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
There are no issues with running the example, but if someone is concerned about diffs occurring in package-lock.json when running npm install in the projects under examples, we can let Renovate handle updating the lockfile for the examples when it updates the top-level package.json.