### PR TITLE
Bye ts-node

### DIFF
--- a/examples/echo-bot-esm/package-lock.json
+++ b/examples/echo-bot-esm/package-lock.json
@@ -28,7 +28,6 @@
         "husky": "9.1.7",
         "msw": "2.7.0",
         "prettier": "3.4.2",
-        "ts-node": "10.9.2",
         "typedoc": "^0.27.1",
         "typedoc-plugin-markdown": "^4.3.0",
         "typescript": "^5.5.4",

--- a/examples/echo-bot-ts-cjs/package-lock.json
+++ b/examples/echo-bot-ts-cjs/package-lock.json
@@ -34,7 +34,6 @@
         "husky": "9.1.7",
         "msw": "2.7.0",
         "prettier": "3.4.2",
-        "ts-node": "10.9.2",
         "typedoc": "^0.27.1",
         "typedoc-plugin-markdown": "^4.3.0",
         "typescript": "^5.5.4",
@@ -339,17 +338,6 @@
       "dev": true,
       "dependencies": {
         "statuses": "^2.0.1"
-      }
-    },
-    "../../node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "../../node_modules/@docsearch/css": {
@@ -891,15 +879,6 @@
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
       "dev": true
     },
-    "../../node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
     "../../node_modules/@mswjs/cookies": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
@@ -1185,26 +1164,6 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true
-    },
-    "../../node_modules/@tsconfig/node10": {
-      "version": "1.0.9",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../node_modules/@tsconfig/node16": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
     },
     "../../node_modules/@types/body-parser": {
       "version": "1.19.2",
@@ -1950,11 +1909,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "../../node_modules/arg": {
-      "version": "4.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "../../node_modules/array-flatten": {
       "version": "1.1.1",
       "dev": true,
@@ -2251,11 +2205,6 @@
     },
     "../../node_modules/cookie-signature": {
       "version": "1.0.6",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../node_modules/create-require": {
-      "version": "1.1.1",
       "dev": true,
       "license": "MIT"
     },
@@ -3115,11 +3064,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "../../node_modules/make-error": {
-      "version": "1.3.6",
-      "dev": true,
-      "license": "ISC"
     },
     "../../node_modules/mark.js": {
       "version": "8.11.1",
@@ -4035,57 +3979,6 @@
         "node": ">=0.6"
       }
     },
-    "../../node_modules/ts-node": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
-      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dev": true,
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
-    "../../node_modules/ts-node/node_modules/diff": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "../../node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -4229,11 +4122,6 @@
       "engines": {
         "node": ">= 0.4.0"
       }
-    },
-    "../../node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT"
     },
     "../../node_modules/vary": {
       "version": "1.1.2",
@@ -4603,14 +4491,6 @@
       "dev": true,
       "engines": {
         "node": ">=12"
-      }
-    },
-    "../../node_modules/yn": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "../../node_modules/yocto-queue": {

--- a/examples/echo-bot-ts-esm/package-lock.json
+++ b/examples/echo-bot-ts-esm/package-lock.json
@@ -34,7 +34,6 @@
         "husky": "9.1.7",
         "msw": "2.7.0",
         "prettier": "3.4.2",
-        "ts-node": "10.9.2",
         "typedoc": "^0.27.1",
         "typedoc-plugin-markdown": "^4.3.0",
         "typescript": "^5.5.4",

--- a/examples/echo-bot/package-lock.json
+++ b/examples/echo-bot/package-lock.json
@@ -28,7 +28,6 @@
         "husky": "9.1.7",
         "msw": "2.7.0",
         "prettier": "3.4.2",
-        "ts-node": "10.9.2",
         "typedoc": "^0.27.1",
         "typedoc-plugin-markdown": "^4.3.0",
         "typescript": "^5.5.4",

--- a/examples/kitchensink/package-lock.json
+++ b/examples/kitchensink/package-lock.json
@@ -29,7 +29,6 @@
         "husky": "9.1.7",
         "msw": "2.7.0",
         "prettier": "3.4.2",
-        "ts-node": "10.9.2",
         "typedoc": "^0.27.1",
         "typedoc-plugin-markdown": "^4.3.0",
         "typescript": "^5.5.4",
@@ -334,17 +333,6 @@
       "dev": true,
       "dependencies": {
         "statuses": "^2.0.1"
-      }
-    },
-    "../../node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "../../node_modules/@docsearch/css": {
@@ -897,15 +885,6 @@
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
       "dev": true
     },
-    "../../node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
     "../../node_modules/@mswjs/cookies": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
@@ -1191,26 +1170,6 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true
-    },
-    "../../node_modules/@tsconfig/node10": {
-      "version": "1.0.9",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../node_modules/@tsconfig/node16": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
     },
     "../../node_modules/@types/body-parser": {
       "version": "1.19.2",
@@ -2005,11 +1964,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "../../node_modules/arg": {
-      "version": "4.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "../../node_modules/array-flatten": {
       "version": "1.1.1",
       "dev": true,
@@ -2269,11 +2223,6 @@
     },
     "../../node_modules/cookie-signature": {
       "version": "1.0.6",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../node_modules/create-require": {
-      "version": "1.1.1",
       "dev": true,
       "license": "MIT"
     },
@@ -3104,11 +3053,6 @@
         "@babel/types": "^7.24.0",
         "source-map-js": "^1.2.0"
       }
-    },
-    "../../node_modules/make-error": {
-      "version": "1.3.6",
-      "dev": true,
-      "license": "ISC"
     },
     "../../node_modules/mark.js": {
       "version": "8.11.1",
@@ -4051,57 +3995,6 @@
         "node": ">=0.6"
       }
     },
-    "../../node_modules/ts-node": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
-      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dev": true,
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
-    "../../node_modules/ts-node/node_modules/diff": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "../../node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -4233,11 +4126,6 @@
       "engines": {
         "node": ">= 0.4.0"
       }
-    },
-    "../../node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT"
     },
     "../../node_modules/vary": {
       "version": "1.1.2",
@@ -4570,14 +4458,6 @@
       "version": "1.0.2",
       "dev": true,
       "license": "ISC"
-    },
-    "../../node_modules/yn": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/@line/bot-sdk": {
       "resolved": "../..",

--- a/examples/rich-menu/package-lock.json
+++ b/examples/rich-menu/package-lock.json
@@ -27,7 +27,6 @@
         "husky": "9.1.7",
         "msw": "2.7.0",
         "prettier": "3.4.2",
-        "ts-node": "10.9.2",
         "typedoc": "^0.27.1",
         "typedoc-plugin-markdown": "^4.3.0",
         "typescript": "^5.5.4",
@@ -332,17 +331,6 @@
       "dev": true,
       "dependencies": {
         "statuses": "^2.0.1"
-      }
-    },
-    "../../node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "../../node_modules/@docsearch/css": {
@@ -895,15 +883,6 @@
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
       "dev": true
     },
-    "../../node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
     "../../node_modules/@mswjs/cookies": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
@@ -1189,26 +1168,6 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true
-    },
-    "../../node_modules/@tsconfig/node10": {
-      "version": "1.0.9",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../node_modules/@tsconfig/node16": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
     },
     "../../node_modules/@types/body-parser": {
       "version": "1.19.2",
@@ -2003,11 +1962,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "../../node_modules/arg": {
-      "version": "4.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "../../node_modules/array-flatten": {
       "version": "1.1.1",
       "dev": true,
@@ -2267,11 +2221,6 @@
     },
     "../../node_modules/cookie-signature": {
       "version": "1.0.6",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../../node_modules/create-require": {
-      "version": "1.1.1",
       "dev": true,
       "license": "MIT"
     },
@@ -3102,11 +3051,6 @@
         "@babel/types": "^7.24.0",
         "source-map-js": "^1.2.0"
       }
-    },
-    "../../node_modules/make-error": {
-      "version": "1.3.6",
-      "dev": true,
-      "license": "ISC"
     },
     "../../node_modules/mark.js": {
       "version": "8.11.1",
@@ -4049,57 +3993,6 @@
         "node": ">=0.6"
       }
     },
-    "../../node_modules/ts-node": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
-      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dev": true,
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
-    "../../node_modules/ts-node/node_modules/diff": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "../../node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -4231,11 +4124,6 @@
       "engines": {
         "node": ">= 0.4.0"
       }
-    },
-    "../../node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT"
     },
     "../../node_modules/vary": {
       "version": "1.1.2",
@@ -4568,14 +4456,6 @@
       "version": "1.0.2",
       "dev": true,
       "license": "ISC"
-    },
-    "../../node_modules/yn": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/@line/bot-sdk": {
       "resolved": "../..",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "husky": "9.1.7",
         "msw": "2.7.0",
         "prettier": "3.4.2",
-        "ts-node": "10.9.2",
         "typedoc": "^0.27.1",
         "typedoc-plugin-markdown": "^4.3.0",
         "typescript": "^5.5.4",
@@ -481,18 +480,6 @@
       "dependencies": {
         "@types/tough-cookie": "^4.0.5",
         "tough-cookie": "^4.1.4"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@docsearch/css": {
@@ -1224,6 +1211,8 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -1553,30 +1542,6 @@
       "integrity": "sha512-jn7/7ky30idSkd/O5yDBfAnVt+JJpepofP/POZ1iMOxK59cOfqIgg/Dj0eFsjOTMw+4ycJN0uhZH/Eb0bs/EUA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-      "dev": true
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
@@ -2335,18 +2300,11 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
-      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2485,12 +2443,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -2911,12 +2863,6 @@
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
       }
-    },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -3929,12 +3875,6 @@
         "@babel/types": "^7.25.4",
         "source-map-js": "^1.2.0"
       }
-    },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
     },
     "node_modules/mark.js": {
       "version": "8.11.1",
@@ -5193,58 +5133,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/ts-node": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
-      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dev": true,
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ts-node/node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/type-fest": {
       "version": "4.26.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
@@ -5444,12 +5332,6 @@
       "engines": {
         "node": ">= 0.4.0"
       }
-    },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -5871,15 +5753,6 @@
       "dev": true,
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/yoctocolors-cjs": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "husky": "9.1.7",
     "msw": "2.7.0",
     "prettier": "3.4.2",
-    "ts-node": "10.9.2",
     "typedoc": "^0.27.1",
     "typedoc-plugin-markdown": "^4.3.0",
     "typescript": "^5.5.4",


### PR DESCRIPTION
ts-node has been present since the beginning of the project, but it is no longer used. If needed in the future, tsx can be used, and with Node.js v23, execution as TypeScript will be supported by default (though it's not perfect yet), so tsx might not even be necessary. For now, ts-node is no longer needed.