### PR TITLE
Migrate renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,49 +1,25 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    "helpers:pinGitHubActionDigestsToSemver"
-  ],
-  "timezone": "Asia/Tokyo",
-  "automerge": true,
-  "platformAutomerge": true,
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: ["config:recommended", "helpers:pinGitHubActionDigestsToSemver"],
+  timezone: "Asia/Tokyo",
+  automerge: true,
+  platformAutomerge: true,
   "git-submodules": {
-    "enabled": true
+    enabled: true,
   },
-  "labels": [
-    "dependency upgrade"
-  ],
-  "packageRules": [
+  labels: ["dependency upgrade"],
+  packageRules: [
     {
-      "matchPackagePatterns": [
-        "line-openapi"
-      ],
-      "labels": [
-        "dependency upgrade",
-        "line-openapi-update"
-      ],
-      // In many cases, we would like to update line-openapi by dispatching the GitHub workflow during working
-      // hours, as there are code changes.
-      // If that is forgotten, there's a possibility that line-openapi updates or code changes won't happen at
-      // all, so we allow it to run at night just in case.
-      "schedule": [
-        "after 11pm",
-        "before 4am"
-      ]
+      labels: ["dependency upgrade", "line-openapi-update"],
+      schedule: ["after 11pm", "before 4am"],
+      matchPackageNames: ["/line-openapi/"],
     },
     {
-      "matchPaths": [
-        "examples/*"
-      ],
-      "postUpgradeTasks": {
-        "commands": [
-          "npm install"
-        ],
-        "fileFilters": [
-          "package.json",
-          "package-lock.json"
-        ]
-      }
-    }
-  ]
+      matchFileNames: ["examples/*"],
+      postUpgradeTasks: {
+        commands: ["npm install"],
+        fileFilters: ["package.json", "package-lock.json"],
+      },
+    },
+  ],
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,24 +1,48 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["config:recommended", "helpers:pinGitHubActionDigestsToSemver"],
+  extends: [
+    "config:recommended",
+    "helpers:pinGitHubActionDigestsToSemver"
+  ],
   timezone: "Asia/Tokyo",
   automerge: true,
   platformAutomerge: true,
   "git-submodules": {
     enabled: true,
   },
-  labels: ["dependency upgrade"],
+  labels: [
+    "dependency upgrade"
+  ],
   packageRules: [
     {
-      labels: ["dependency upgrade", "line-openapi-update"],
-      schedule: ["after 11pm", "before 4am"],
-      matchPackageNames: ["/line-openapi/"],
+      labels: [
+        "dependency upgrade",
+        "line-openapi-update"
+      ],
+      // In many cases, we would like to update line-openapi by dispatching the GitHub workflow during working
+      // hours, as there are code changes.
+      // If that is forgotten, there's a possibility that line-openapi updates or code changes won't happen at
+      // all, so we allow it to run at night just in case.
+      schedule: [
+        "after 11pm",
+        "before 4am"
+      ],
+      matchPackageNames: [
+        "/line-openapi/"
+      ],
     },
     {
-      matchFileNames: ["examples/*"],
+      matchFileNames: [
+        "examples/*"
+      ],
       postUpgradeTasks: {
-        commands: ["npm install"],
-        fileFilters: ["package.json", "package-lock.json"],
+        commands: [
+          "npm install"
+        ],
+        fileFilters: [
+          "package.json",
+          "package-lock.json"
+        ],
       },
     },
   ],


### PR DESCRIPTION
Renovate's auto migrator removes comments and disrupts the format.

In this change, I have tried to preserve the original file as much as possible.

Close https://github.com/line/line-bot-sdk-nodejs/pull/1204
