### PR TITLE
Modify permission for release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,4 +58,9 @@ jobs:
 
   deploy-docs:
     needs: [release-package]
+    permissions:
+      contents: read
+      pages: write
+      issues: write
+      id-token: write
     uses: ./.github/workflows/deploy-doc.yml


### PR DESCRIPTION
Fix https://github.com/line/line-bot-sdk-nodejs/pull/1202

When using a reusable workflow, it seems that the caller must define all necessary permissions for the callee. (This is the same for secrets as well.)

reference: https://docs.github.com/en/actions/sharing-automations/reusing-workflows#supported-keywords-for-jobs-that-call-a-reusable-workflow

failed job: https://github.com/line/line-bot-sdk-nodejs/actions/runs/14100786655