### PR TITLE
Skip create PR when only git submodule is updated

### DIFF
--- a/.github/workflows/generate-code.yml
+++ b/.github/workflows/generate-code.yml
@@ -40,7 +40,7 @@ jobs:
         run: python3 generate-code.py
       - run: |
           diff_files=$(git --no-pager diff --name-only)
-          diff_excluding_submodule=$(echo "diff_files" | grep -v '^line-openapi$' || true)
+          diff_excluding_submodule=$(echo "$diff_files" | grep -v '^line-openapi$' || true)
 
           echo "diff files: $diff_files"
           echo "diff excluding submodule: $diff_excluding_submodule"

--- a/.github/workflows/generate-code.yml
+++ b/.github/workflows/generate-code.yml
@@ -19,13 +19,13 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
-      - name: Update submodules
-        run: git submodule update --remote --recursive
+#      - name: Update submodules
+#        run: git submodule update --remote --recursive
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         id: setup_node_id
         with:
           node-version: 18
-      - name: actions/setup-java@v3
+      - name: Set up Java
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           distribution: 'temurin'
@@ -39,8 +39,9 @@ jobs:
       - name: Generate code
         run: python3 generate-code.py
       - run: |
-          diff=$(git --no-pager diff --name-only)
-          echo "DIFF_IS_EMPTY=$([[ -z "$diff" ]] && echo 'true' || echo 'false')" >> $GITHUB_ENV
+          diff_files=$(git --no-pager diff --name-only)
+          diff_excluding_submodule=$(echo "$diff" | grep -v '^line-openapi$' || true)
+          echo "DIFF_IS_EMPTY=$([[ -z "$diff_excluding_submodule" ]] && echo 'true' || echo 'false')" >> $GITHUB_ENV
           echo "CURRENT_DATETIME=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
       ## Run if diff exists and pull request, and make CI status failure (but allow renovate bot)
       - if: ${{ github.event_name == 'pull_request' && env.DIFF_IS_EMPTY != 'true' && github.actor != 'renovate[bot]' }}

--- a/.github/workflows/generate-code.yml
+++ b/.github/workflows/generate-code.yml
@@ -19,8 +19,8 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
-#      - name: Update submodules
-#        run: git submodule update --remote --recursive
+      - name: Update submodules
+        run: git submodule update --remote --recursive
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         id: setup_node_id
         with:
@@ -46,7 +46,6 @@ jobs:
           echo "diff excluding submodule: $diff_excluding_submodule"
 
           echo "DIFF_IS_EMPTY=$([[ -z "$diff_excluding_submodule" ]] && echo 'true' || echo 'false')" >> $GITHUB_ENV
-
           echo "CURRENT_DATETIME=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
       ## Run if diff exists and pull request, and make CI status failure (but allow renovate bot)
       - if: ${{ github.event_name == 'pull_request' && env.DIFF_IS_EMPTY != 'true' && github.actor != 'renovate[bot]' }}

--- a/.github/workflows/generate-code.yml
+++ b/.github/workflows/generate-code.yml
@@ -41,7 +41,12 @@ jobs:
       - run: |
           diff_files=$(git --no-pager diff --name-only)
           diff_excluding_submodule=$(echo "$diff" | grep -v '^line-openapi$' || true)
+
+          echo "diff files: $diff_files"
+          echo "diff excluding submodule: $diff_excluding_submodule"
+
           echo "DIFF_IS_EMPTY=$([[ -z "$diff_excluding_submodule" ]] && echo 'true' || echo 'false')" >> $GITHUB_ENV
+
           echo "CURRENT_DATETIME=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
       ## Run if diff exists and pull request, and make CI status failure (but allow renovate bot)
       - if: ${{ github.event_name == 'pull_request' && env.DIFF_IS_EMPTY != 'true' && github.actor != 'renovate[bot]' }}

--- a/.github/workflows/generate-code.yml
+++ b/.github/workflows/generate-code.yml
@@ -40,7 +40,7 @@ jobs:
         run: python3 generate-code.py
       - run: |
           diff_files=$(git --no-pager diff --name-only)
-          diff_excluding_submodule=$(echo "$diff" | grep -v '^line-openapi$' || true)
+          diff_excluding_submodule=$(echo "diff_files" | grep -v '^line-openapi$' || true)
 
           echo "diff files: $diff_files"
           echo "diff excluding submodule: $diff_excluding_submodule"

--- a/lib/shop/model/errorResponse.ts
+++ b/lib/shop/model/errorResponse.ts
@@ -17,4 +17,7 @@ export type ErrorResponse = {
    * @see <a href="https://developers.line.biz/en/reference/partner-docs/#send-mission-stickers-v3">message Documentation</a>
    */
   message: string /**/;
+  hoge: string;
+
+
 };

--- a/lib/shop/model/errorResponse.ts
+++ b/lib/shop/model/errorResponse.ts
@@ -17,5 +17,4 @@ export type ErrorResponse = {
    * @see <a href="https://developers.line.biz/en/reference/partner-docs/#send-mission-stickers-v3">message Documentation</a>
    */
   message: string /**/;
-  hoge: string;
 };

--- a/lib/shop/model/errorResponse.ts
+++ b/lib/shop/model/errorResponse.ts
@@ -17,7 +17,4 @@ export type ErrorResponse = {
    * @see <a href="https://developers.line.biz/en/reference/partner-docs/#send-mission-stickers-v3">message Documentation</a>
    */
   message: string /**/;
-  hoge: string;
-
-
 };

--- a/lib/shop/model/errorResponse.ts
+++ b/lib/shop/model/errorResponse.ts
@@ -17,4 +17,5 @@ export type ErrorResponse = {
    * @see <a href="https://developers.line.biz/en/reference/partner-docs/#send-mission-stickers-v3">message Documentation</a>
    */
   message: string /**/;
+  hoge: string;
 };


### PR DESCRIPTION
Even when only the submodule is updated and the code is not, a PR is created in the bot SDK repository.(like https://github.com/line/line-bot-sdk-nodejs/pull/1208)
If there is no diff in the generated code, I think it's sufficient for Renovate to update the submodule version without creating a PR through the GitHub Actions workflow.

Therefore, this change excludes the submodule from the PR creation conditions and CI failure conditions.