### PR TITLE
Drop Node.js 18 support

### DIFF
--- a/.github/workflows/deploy-doc.yml
+++ b/.github/workflows/deploy-doc.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 18
+          node-version: 24
 
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0

--- a/.github/workflows/generate-code.yml
+++ b/.github/workflows/generate-code.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         id: setup_node_id
         with:
-          node-version: 18
+          node-version: 24
       - name: Set up Java
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     # Setup .npmrc file to publish to GitHub Packages
     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
-        node-version: 18
+        node-version: 24
         registry-url: 'https://registry.npmjs.org'
     - run: npm install
     - name: Update version in package.json, package-lock.json, and lib/version.ts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
       matrix:
         # https://nodejs.org/en/about/releases/
         node:
-          - '18'
           - '20'
           - '20.12.2'
           - '22'

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ line-bot-sdk-nodejs documentation: https://line.github.io/line-bot-sdk-nodejs/#g
 
 ## Requirements
 
-* **Node.js** 18 or higher
+* **Node.js** 20 or higher
 
 ## Installation
 

--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -1,6 +1,6 @@
 # Requirements
 
-* **Node.js** >= 18.
+* **Node.js** >= 20.
   * It uses ES2022.
 * [**npm**](https://www.npmjs.com/), preferably >=10
 

--- a/examples/echo-bot-esm/package-lock.json
+++ b/examples/echo-bot-esm/package-lock.json
@@ -20,22 +20,22 @@
         "@types/node": "^22.0.0"
       },
       "devDependencies": {
-        "@types/express": "5.0.0",
+        "@types/express": "5.0.2",
         "@types/finalhandler": "1.2.3",
         "@vitest/coverage-v8": "^3.0.0",
-        "express": "4.21.2",
-        "finalhandler": "1.3.1",
+        "express": "5.1.0",
+        "finalhandler": "2.1.0",
         "husky": "9.1.7",
-        "msw": "2.7.0",
-        "prettier": "3.4.2",
-        "typedoc": "^0.27.1",
+        "msw": "2.8.4",
+        "prettier": "3.5.3",
+        "typedoc": "^0.28.0",
         "typedoc-plugin-markdown": "^4.3.0",
         "typescript": "^5.5.4",
         "vitepress": "^1.0.1",
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "axios": "^1.7.4"

--- a/examples/echo-bot-ts-cjs/README.md
+++ b/examples/echo-bot-ts-cjs/README.md
@@ -6,7 +6,7 @@ This tutorial will help you set up a LINE Echo Bot from scratch.
 
 ## Prerequisite
 
-- Node.js version 18 or higher
+- Node.js version 20 or higher
 - You've created a channel in the LINE Developers Console, and got your channel access token and channel secret.
   - Read https://developers.line.biz/en/docs/messaging-api/getting-started/#using-console if you haven't done this yet.
 

--- a/examples/echo-bot-ts-cjs/package-lock.json
+++ b/examples/echo-bot-ts-cjs/package-lock.json
@@ -26,22 +26,22 @@
         "@types/node": "^22.0.0"
       },
       "devDependencies": {
-        "@types/express": "5.0.0",
+        "@types/express": "5.0.2",
         "@types/finalhandler": "1.2.3",
         "@vitest/coverage-v8": "^3.0.0",
-        "express": "4.21.2",
-        "finalhandler": "1.3.1",
+        "express": "5.1.0",
+        "finalhandler": "2.1.0",
         "husky": "9.1.7",
-        "msw": "2.7.0",
-        "prettier": "3.4.2",
-        "typedoc": "^0.27.1",
+        "msw": "2.8.4",
+        "prettier": "3.5.3",
+        "typedoc": "^0.28.0",
         "typedoc-plugin-markdown": "^4.3.0",
         "typescript": "^5.5.4",
         "vitepress": "^1.0.1",
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "axios": "^1.7.4"

--- a/examples/echo-bot-ts-esm/README.md
+++ b/examples/echo-bot-ts-esm/README.md
@@ -6,7 +6,7 @@ This tutorial will help you set up a LINE Echo Bot from scratch.
 
 ## Prerequisite
 
-- Node.js version 18 or higher
+- Node.js version 20 or higher
 - You've created a channel in the LINE Developers Console, and got your channel access token and channel secret.
   - Read https://developers.line.biz/en/docs/messaging-api/getting-started/#using-console if you haven't done this yet.
 

--- a/examples/echo-bot-ts-esm/package-lock.json
+++ b/examples/echo-bot-ts-esm/package-lock.json
@@ -26,22 +26,22 @@
         "@types/node": "^22.0.0"
       },
       "devDependencies": {
-        "@types/express": "5.0.0",
+        "@types/express": "5.0.2",
         "@types/finalhandler": "1.2.3",
         "@vitest/coverage-v8": "^3.0.0",
-        "express": "4.21.2",
-        "finalhandler": "1.3.1",
+        "express": "5.1.0",
+        "finalhandler": "2.1.0",
         "husky": "9.1.7",
-        "msw": "2.7.0",
-        "prettier": "3.4.2",
-        "typedoc": "^0.27.1",
+        "msw": "2.8.4",
+        "prettier": "3.5.3",
+        "typedoc": "^0.28.0",
         "typedoc-plugin-markdown": "^4.3.0",
         "typescript": "^5.5.4",
         "vitepress": "^1.0.1",
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "axios": "^1.7.4"

--- a/examples/echo-bot/package-lock.json
+++ b/examples/echo-bot/package-lock.json
@@ -20,22 +20,22 @@
         "@types/node": "^22.0.0"
       },
       "devDependencies": {
-        "@types/express": "5.0.0",
+        "@types/express": "5.0.2",
         "@types/finalhandler": "1.2.3",
         "@vitest/coverage-v8": "^3.0.0",
-        "express": "4.21.2",
-        "finalhandler": "1.3.1",
+        "express": "5.1.0",
+        "finalhandler": "2.1.0",
         "husky": "9.1.7",
-        "msw": "2.7.0",
-        "prettier": "3.4.2",
-        "typedoc": "^0.27.1",
+        "msw": "2.8.4",
+        "prettier": "3.5.3",
+        "typedoc": "^0.28.0",
         "typedoc-plugin-markdown": "^4.3.0",
         "typescript": "^5.5.4",
         "vitepress": "^1.0.1",
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "axios": "^1.7.4"

--- a/examples/kitchensink/package-lock.json
+++ b/examples/kitchensink/package-lock.json
@@ -21,22 +21,22 @@
         "@types/node": "^22.0.0"
       },
       "devDependencies": {
-        "@types/express": "5.0.0",
+        "@types/express": "5.0.2",
         "@types/finalhandler": "1.2.3",
         "@vitest/coverage-v8": "^3.0.0",
-        "express": "4.21.2",
-        "finalhandler": "1.3.1",
+        "express": "5.1.0",
+        "finalhandler": "2.1.0",
         "husky": "9.1.7",
-        "msw": "2.7.0",
-        "prettier": "3.4.2",
-        "typedoc": "^0.27.1",
+        "msw": "2.8.4",
+        "prettier": "3.5.3",
+        "typedoc": "^0.28.0",
         "typedoc-plugin-markdown": "^4.3.0",
         "typescript": "^5.5.4",
         "vitepress": "^1.0.1",
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "axios": "^1.7.4"

--- a/examples/rich-menu/package-lock.json
+++ b/examples/rich-menu/package-lock.json
@@ -19,22 +19,22 @@
         "@types/node": "^22.0.0"
       },
       "devDependencies": {
-        "@types/express": "5.0.0",
+        "@types/express": "5.0.2",
         "@types/finalhandler": "1.2.3",
         "@vitest/coverage-v8": "^3.0.0",
-        "express": "4.21.2",
-        "finalhandler": "1.3.1",
+        "express": "5.1.0",
+        "finalhandler": "2.1.0",
         "husky": "9.1.7",
-        "msw": "2.7.0",
-        "prettier": "3.4.2",
-        "typedoc": "^0.27.1",
+        "msw": "2.8.4",
+        "prettier": "3.5.3",
+        "typedoc": "^0.28.0",
         "typedoc-plugin-markdown": "^4.3.0",
         "typescript": "^5.5.4",
         "vitepress": "^1.0.1",
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "axios": "^1.7.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "axios": "^1.7.4"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Node.js SDK for LINE Messaging API",
   "type": "module",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "main": "./dist/cjs/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Resolved #1259 

TODO
- [x] Remove CI by Node.js 18 from Status checks that are required.