### PR TITLE
Don't use PAT on publish by using trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,6 @@ jobs:
         echo "VERSION=$VERSION" >> $GITHUB_ENV
         node ./scripts/update-version.mjs $VERSION
     - run: npm run release
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_2 }}
 
     - name: Create GitHub Issue on Failure
       if: failure()


### PR DESCRIPTION
Remove PAT from publish workfrow to use https://docs.npmjs.com/trusted-publishers.

After confirming the operation by master merge, delete PAT from secrets and revoke.