### PR TITLE
Bye line things

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ FAQ: https://developers.line.biz/en/faq/
 News: https://developers.line.biz/en/news/
 
 ## Versioning
-This project respects semantic versioning
 
-See http://semver.org/
+This project respects semantic versioning.
+- See https://semver.org/
+
+However, if a feature that was publicly released is discontinued for business reasons and becomes completely unusable, we will release changes as a patch release.
 
 ## Contributing
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -60,9 +60,6 @@ export type WebhookEvent =
   | VideoPlayCompleteEvent
   | BeaconEvent
   | AccountLinkEvent
-  | DeviceLinkEvent
-  | DeviceUnlinkEvent
-  | LINEThingsScenarioExecutionEvent
   | DeliveryEvent;
 
 export type EventBase = {
@@ -268,110 +265,6 @@ export type AccountLinkEvent = ReplyableEvent & {
      */
     nonce: string;
   };
-};
-
-/**
- * Indicates that a LINE Things-compatible device has been linked with LINE by a user operation.
- * For more information, see [Receiving device link events via webhook](https://developers.line.biz/en/docs/line-things/develop-bot/#link-event).
- */
-export type DeviceLinkEvent = ReplyableEvent & {
-  type: "things";
-  things: {
-    /**
-     * Device ID of the LINE Things-compatible device that was linked with LINE
-     */
-    deviceId: string;
-    type: "link";
-  };
-};
-
-/**
- * Indicates that a LINE Things-compatible device has been unlinked from LINE by a user operation.
- * For more information, see [Receiving device unlink events via webhook](https://developers.line.biz/en/docs/line-things/develop-bot/#unlink-event).
- */
-export type DeviceUnlinkEvent = ReplyableEvent & {
-  type: "things";
-  things: {
-    /**
-     * Device ID of the LINE Things-compatible device that was unlinked with LINE
-     */
-    deviceId: string;
-    type: "unlink";
-  };
-};
-
-export type LINEThingsScenarioExecutionEvent = ReplyableEvent & {
-  type: "things";
-  things: {
-    type: "scenarioResult";
-    /**
-     * Device ID of the device that executed the scenario
-     */
-    deviceId: string;
-    result: {
-      /**
-       * Scenario ID executed
-       */
-      scenarioId: string;
-      /**
-       * Revision number of the scenario set containing the executed scenario
-       */
-      revision: number;
-      /**
-       * Timestamp for when execution of scenario action started (milliseconds, LINE app time)
-       */
-      startTime: number;
-      /**
-       * Timestamp for when execution of scenario was completed (milliseconds, LINE app time)
-       */
-      endtime: number;
-      /**
-       * Scenario execution completion status
-       * See also [things.resultCode definitions](https://developers.line.biz/en/reference/messaging-api/#things-resultcode).
-       */
-      resultCode: "success" | "gatt_error" | "runtime_error";
-      /**
-       * Execution result of individual operations specified in action
-       * Note that an array of actions specified in a scenario has the following characteristics
-       *  - The actions defined in a scenario are performed sequentially, from top to bottom.
-       *  - Each action produces some result when executed.
-       *    Even actions that do not generate data, such as `SLEEP`, return an execution result of type `void`.
-       *    The number of items in an action array may be 0.
-       *
-       * Therefore, things.actionResults has the following properties:
-       *  - The number of items in the array matches the number of actions defined in the scenario.
-       *  - The order of execution results matches the order in which actions are performed.
-       *    That is, in a scenario set with multiple `GATT_READ` actions,
-       *    the results are returned in the order in which each individual `GATT_READ` action was performed.
-       *  - If 0 actions are defined in the scenario, the number of items in things.actionResults will be 0.
-       */
-      actionResults: Array<LINEThingsActionResult>;
-      /**
-       * Data contained in notification
-       * The value is Base64-encoded binary data.
-       * Only included for scenarios where `trigger.type = BLE_NOTIFICATION`.
-       */
-      bleNotificationPayload?: string;
-      /**
-       * Error reason
-       */
-      errorReason?: string;
-    };
-  };
-};
-
-export type LINEThingsActionResult = {
-  /**
-   * `void`, `binary`
-   * Depends on `type` of the executed action.
-   * This property is always included if `things.actionResults` is not empty.
-   */
-  type: "void" | "binary";
-  /**
-   * Base64-encoded binary data
-   *  This property is always included when `things.actionResults[].type` is `binary`.
-   */
-  data?: string;
 };
 
 /**


### PR DESCRIPTION
https://github.com/line/line-openapi/pull/112 is a cleanup PR for line things, but it appears to break several tests by deleting this change. 
Let’s remove those tests beforehand.

and more, this change updates our versioning in README.
-  We'll release changes as a patch version when we close features due to some business reasons.

Note we clean up auto-generated webhook code for line things in another PR, though this PR deletes manual code.