### PR TITLE
Update dependency typescript to v5.9.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "1.0.0-test",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/node": "^22.0.0",
-        "axios": "^1.12.0"
+        "@types/node": "^22.0.0"
       },
       "devDependencies": {
         "@types/express": "5.0.3",
@@ -5153,9 +5152,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {


### PR DESCRIPTION
Resolve https://github.com/line/line-bot-sdk-nodejs/pull/1351


https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-9.html#notable-behavioral-changes
From TS5.9, more strict type check is added. Though warns are reported only in deprecated code, but let's fix to make build succeeded.