### PR TITLE
Allow to skip signature verification

### DIFF
--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -62,7 +62,6 @@ export default function middleware(config: Types.MiddlewareConfig): Middleware {
       }
     })();
 
-    // Check if signature verification should be skipped
     const shouldSkipVerification =
       config.skipSignatureVerification && config.skipSignatureVerification();
 

--- a/lib/middleware.ts
+++ b/lib/middleware.ts
@@ -62,7 +62,14 @@ export default function middleware(config: Types.MiddlewareConfig): Middleware {
       }
     })();
 
-    if (!validateSignature(body, secret, signature)) {
+    // Check if signature verification should be skipped
+    const shouldSkipVerification =
+      config.skipSignatureVerification && config.skipSignatureVerification();
+
+    if (
+      !shouldSkipVerification &&
+      !validateSignature(body, secret, signature)
+    ) {
       next(
         new SignatureValidationFailed("signature validation failed", {
           signature,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -15,6 +15,14 @@ export interface ClientConfig extends Config {
 
 export interface MiddlewareConfig extends Config {
   channelSecret: string;
+
+  // skipSignatureValidation is a function that determines whether to skip
+  // webhook signature verification.
+  //
+  // If the function returns true, the signature verification step is skipped.
+  // This can be useful in scenarios such as when you're in the process of updating
+  // the channel secret and need to temporarily bypass verification to avoid disruptions.
+  skipSignatureVerification?: () => boolean;
 }
 
 export type Profile = {

--- a/test/middleware.spec.ts
+++ b/test/middleware.spec.ts
@@ -13,6 +13,19 @@ const TEST_PORT = parseInt(process.env.TEST_PORT || "1234", 10);
 
 const m = middleware({ channelSecret: "test_channel_secret" });
 
+// Middleware with skipSignatureVerification function (always true)
+const mWithSkipAlwaysTrue = middleware({
+  channelSecret: "test_channel_secret",
+  skipSignatureVerification: () => true,
+});
+
+// Middleware with skipSignatureVerification function (dynamic behavior based on environment variable)
+let shouldSkipSignature = false;
+const mWithDynamicSkip = middleware({
+  channelSecret: "test_channel_secret",
+  skipSignatureVerification: () => shouldSkipSignature,
+});
+
 const getRecentReq = (): { body: Types.WebhookRequestBody } =>
   JSON.parse(readFileSync(join(__dirname, "helpers/request.json")).toString());
 
@@ -53,8 +66,95 @@ describe("middleware test", () => {
   beforeAll(() => {
     listen(TEST_PORT, m);
   });
+
+  describe("With skipSignatureVerification functionality", () => {
+    // Port for always-true skip function
+    let alwaysTruePort: number;
+    // Port for dynamic skip function
+    let dynamicSkipPort: number;
+
+    beforeAll(() => {
+      alwaysTruePort = TEST_PORT + 1;
+      dynamicSkipPort = TEST_PORT + 2;
+      listen(alwaysTruePort, mWithSkipAlwaysTrue);
+      return listen(dynamicSkipPort, mWithDynamicSkip);
+    });
+
+    afterAll(() => {
+      close(alwaysTruePort);
+      return close(dynamicSkipPort);
+    });
+
+    it("should skip signature verification when skipSignatureVerification returns true", async () => {
+      const client = new HTTPClient({
+        baseURL: `http://localhost:${alwaysTruePort}`,
+        defaultHeaders: {
+          "X-Line-Signature": "invalid_signature",
+        },
+      });
+
+      // This should work even with invalid signature because verification is skipped
+      await client.post("/webhook", {
+        events: [webhook],
+        destination: DESTINATION,
+      });
+
+      const req = getRecentReq();
+      deepEqual(req.body.destination, DESTINATION);
+      deepEqual(req.body.events, [webhook]);
+    });
+
+    it("should respect dynamic skipSignatureVerification behavior - when true", async () => {
+      // Set to skip verification
+      shouldSkipSignature = true;
+
+      const client = new HTTPClient({
+        baseURL: `http://localhost:${dynamicSkipPort}`,
+        defaultHeaders: {
+          "X-Line-Signature": "invalid_signature",
+        },
+      });
+
+      // This should work even with invalid signature because verification is skipped
+      await client.post("/webhook", {
+        events: [webhook],
+        destination: DESTINATION,
+      });
+
+      const req = getRecentReq();
+      deepEqual(req.body.destination, DESTINATION);
+      deepEqual(req.body.events, [webhook]);
+    });
+
+    it("should respect dynamic skipSignatureVerification behavior - when false", async () => {
+      // Set to NOT skip verification
+      shouldSkipSignature = false;
+
+      const client = new HTTPClient({
+        baseURL: `http://localhost:${dynamicSkipPort}`,
+        defaultHeaders: {
+          "X-Line-Signature": "invalid_signature",
+        },
+      });
+
+      try {
+        // This should fail because signature verification is not skipped
+        await client.post("/webhook", {
+          events: [webhook],
+          destination: DESTINATION,
+        });
+        ok(false, "Expected to throw an error due to invalid signature");
+      } catch (err) {
+        if (err instanceof HTTPError) {
+          equal(err.statusCode, 401);
+        } else {
+          throw err;
+        }
+      }
+    });
+  });
   afterAll(() => {
-    close();
+    close(TEST_PORT);
   });
 
   describe("Succeeds on parsing valid request", () => {


### PR DESCRIPTION
## Changes

- Allow skipping signature verification for webhooks

## Motivation

The signature returned with webhooks is calculated using a single channel secret. If the bot owner changes their channel secret, the signature for webhooks starts being calculated using the new channel secret. To avoid signature verification failures, the bot owner must update the channel secret on their server, which is used for signature verification. However, if there is a timing mismatch in the update—and such a mismatch is almost unavoidable—verification will fail during that period.

In such cases, having an option to skip signature verification for webhooks would be a convenient way to avoid these issues.
