### PR TITLE
Use github actor id instead of bot name to avoid renaming issues

### DIFF
--- a/.github/workflows/generate-code.yml
+++ b/.github/workflows/generate-code.yml
@@ -54,7 +54,7 @@ jobs:
           ${{
             (github.event_name == 'pull_request' || github.event_name == 'merge_group')
             && env.DIFF_IS_EMPTY != 'true'
-            && github.actor_id != 29139614
+            && github.actor_id != '29139614'
           }}
         run: |
           echo "There are changes in the generated codes. Please run 'generate-code.py' and commit the changes." >&2


### PR DESCRIPTION
This PR modifies the GitHub Actions workflow to use the GitHub actor ID instead of the bot name. This change helps avoid issues related to renaming the bot, ensuring that the workflow continues to function correctly even if the bot's name changes.
 See https://github.com/renovatebot/renovate/discussions/37842.

https://api.github.com/users/renovate%5Bbot%5D
> {
>   "login": "renovate[bot]",
>   "id": 29139614,
>   ...
> }

