### PR TITLE
Run npm audit fix to update vite

### DIFF
--- a/examples/echo-bot-esm/package-lock.json
+++ b/examples/echo-bot-esm/package-lock.json
@@ -26,7 +26,7 @@
         "express": "5.1.0",
         "finalhandler": "2.1.0",
         "husky": "9.1.7",
-        "msw": "2.11.2",
+        "msw": "2.11.3",
         "prettier": "3.6.2",
         "typedoc": "^0.28.0",
         "typedoc-plugin-markdown": "^4.3.0",
@@ -896,7 +896,7 @@
       "license": "MIT"
     },
     "../../node_modules/@types/node": {
-      "version": "22.18.1",
+      "version": "22.18.8",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1458,7 +1458,7 @@
       "optional": true
     },
     "../../node_modules/axios": {
-      "version": "1.12.0",
+      "version": "1.12.2",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2798,7 +2798,7 @@
       "license": "MIT"
     },
     "../../node_modules/msw": {
-      "version": "2.11.2",
+      "version": "2.11.3",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2808,7 +2808,6 @@
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.39.1",
         "@open-draft/deferred-promise": "^2.2.0",
-        "@open-draft/until": "^2.1.0",
         "@types/cookie": "^0.6.0",
         "@types/statuses": "^2.0.4",
         "graphql": "^16.8.1",
@@ -2821,6 +2820,7 @@
         "strict-event-emitter": "^0.5.1",
         "tough-cookie": "^6.0.0",
         "type-fest": "^4.26.1",
+        "until-async": "^3.0.2",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -3566,7 +3566,7 @@
       }
     },
     "../../node_modules/strip-ansi": {
-      "version": "7.1.0",
+      "version": "7.1.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3787,7 +3787,7 @@
       }
     },
     "../../node_modules/typedoc": {
-      "version": "0.28.12",
+      "version": "0.28.13",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3809,7 +3809,7 @@
       }
     },
     "../../node_modules/typedoc-plugin-markdown": {
-      "version": "4.8.1",
+      "version": "4.9.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3820,7 +3820,7 @@
       }
     },
     "../../node_modules/typescript": {
-      "version": "5.9.2",
+      "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3911,6 +3911,14 @@
         "node": ">= 0.8"
       }
     },
+    "../../node_modules/until-async": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
+      }
+    },
     "../../node_modules/vary": {
       "version": "1.1.2",
       "dev": true,
@@ -3946,7 +3954,7 @@
       }
     },
     "../../node_modules/vite": {
-      "version": "5.4.20",
+      "version": "5.4.21",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4422,6 +4430,20 @@
       "version": "1.1.1",
       "license": "MIT"
     },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-generator-function": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/body-parser": {
       "version": "1.20.3",
       "license": "MIT",
@@ -4452,7 +4474,7 @@
       }
     },
     "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4463,11 +4485,11 @@
       }
     },
     "node_modules/call-bound": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "get-intrinsic": "^1.2.6"
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4665,16 +4687,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-intrinsic": {
-      "version": "1.2.7",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
+        "async-function": "^1.0.0",
+        "async-generator-function": "^1.0.0",
+        "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "get-proto": "^1.0.0",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
@@ -4830,7 +4862,7 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.3",
+      "version": "1.13.4",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/examples/echo-bot-ts-cjs/package-lock.json
+++ b/examples/echo-bot-ts-cjs/package-lock.json
@@ -32,7 +32,7 @@
         "express": "5.1.0",
         "finalhandler": "2.1.0",
         "husky": "9.1.7",
-        "msw": "2.11.2",
+        "msw": "2.11.3",
         "prettier": "3.6.2",
         "typedoc": "^0.28.0",
         "typedoc-plugin-markdown": "^4.3.0",
@@ -902,7 +902,7 @@
       "license": "MIT"
     },
     "../../node_modules/@types/node": {
-      "version": "22.18.1",
+      "version": "22.18.8",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1464,7 +1464,7 @@
       "optional": true
     },
     "../../node_modules/axios": {
-      "version": "1.12.0",
+      "version": "1.12.2",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2804,7 +2804,7 @@
       "license": "MIT"
     },
     "../../node_modules/msw": {
-      "version": "2.11.2",
+      "version": "2.11.3",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2814,7 +2814,6 @@
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.39.1",
         "@open-draft/deferred-promise": "^2.2.0",
-        "@open-draft/until": "^2.1.0",
         "@types/cookie": "^0.6.0",
         "@types/statuses": "^2.0.4",
         "graphql": "^16.8.1",
@@ -2827,6 +2826,7 @@
         "strict-event-emitter": "^0.5.1",
         "tough-cookie": "^6.0.0",
         "type-fest": "^4.26.1",
+        "until-async": "^3.0.2",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -3572,7 +3572,7 @@
       }
     },
     "../../node_modules/strip-ansi": {
-      "version": "7.1.0",
+      "version": "7.1.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3793,7 +3793,7 @@
       }
     },
     "../../node_modules/typedoc": {
-      "version": "0.28.12",
+      "version": "0.28.13",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3815,7 +3815,7 @@
       }
     },
     "../../node_modules/typedoc-plugin-markdown": {
-      "version": "4.8.1",
+      "version": "4.9.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3826,7 +3826,7 @@
       }
     },
     "../../node_modules/typescript": {
-      "version": "5.9.2",
+      "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3917,6 +3917,14 @@
         "node": ">= 0.8"
       }
     },
+    "../../node_modules/until-async": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
+      }
+    },
     "../../node_modules/vary": {
       "version": "1.1.2",
       "dev": true,
@@ -3952,7 +3960,7 @@
       }
     },
     "../../node_modules/vite": {
-      "version": "5.4.20",
+      "version": "5.4.21",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4439,7 +4447,7 @@
       }
     },
     "node_modules/@types/body-parser": {
-      "version": "1.19.3",
+      "version": "1.19.6",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4448,7 +4456,7 @@
       }
     },
     "node_modules/@types/connect": {
-      "version": "3.4.36",
+      "version": "3.4.38",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4456,7 +4464,7 @@
       }
     },
     "node_modules/@types/express": {
-      "version": "4.17.17",
+      "version": "4.17.23",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4467,7 +4475,7 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.36",
+      "version": "4.19.7",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4478,46 +4486,57 @@
       }
     },
     "node_modules/@types/http-errors": {
-      "version": "2.0.2",
+      "version": "2.0.5",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/mime": {
-      "version": "1.3.2",
+      "version": "1.3.5",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.6.3",
+      "version": "20.19.23",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/qs": {
-      "version": "6.9.8",
+      "version": "6.14.0",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
-      "version": "1.2.4",
+      "version": "1.2.7",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {
-      "version": "0.17.1",
+      "version": "1.2.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/mime": "^1",
         "@types/node": "*"
       }
     },
     "node_modules/@types/serve-static": {
-      "version": "1.15.2",
+      "version": "1.15.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
-        "@types/mime": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
         "@types/node": "*"
       }
     },
@@ -4533,7 +4552,7 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.0.1",
+      "version": "6.2.2",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4544,7 +4563,7 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "6.2.1",
+      "version": "6.2.3",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4557,6 +4576,20 @@
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "license": "MIT"
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-generator-function": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -4601,7 +4634,7 @@
       }
     },
     "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4612,11 +4645,11 @@
       }
     },
     "node_modules/call-bound": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "get-intrinsic": "^1.2.6"
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4833,11 +4866,11 @@
       }
     },
     "node_modules/foreground-child": {
-      "version": "3.1.1",
+      "version": "3.3.1",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "cross-spawn": "^7.0.0",
+        "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
       },
       "engines": {
@@ -4868,16 +4901,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-intrinsic": {
-      "version": "1.2.7",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
+        "async-function": "^1.0.0",
+        "async-generator-function": "^1.0.0",
+        "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "get-proto": "^1.0.0",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
@@ -4902,21 +4945,19 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.3.5",
+      "version": "10.4.5",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
-        "jackspeak": "^2.0.3",
-        "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-        "path-scurry": "^1.10.1"
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
       },
       "bin": {
-        "glob": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "glob": "dist/esm/bin.mjs"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -5001,14 +5042,11 @@
       "license": "ISC"
     },
     "node_modules/jackspeak": {
-      "version": "2.3.3",
+      "version": "3.4.3",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -5018,12 +5056,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "10.0.1",
+      "version": "10.4.3",
       "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "14 || >=16.14"
-      }
+      "license": "ISC"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -5081,7 +5116,7 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.3",
+      "version": "9.0.5",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5095,7 +5130,7 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.0.3",
+      "version": "7.1.2",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -5114,7 +5149,7 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.3",
+      "version": "1.13.4",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5133,6 +5168,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "license": "MIT",
@@ -5149,15 +5189,15 @@
       }
     },
     "node_modules/path-scurry": {
-      "version": "1.10.1",
+      "version": "1.11.1",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^9.1.1 || ^10.0.0",
+        "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -5212,17 +5252,14 @@
       }
     },
     "node_modules/rimraf": {
-      "version": "5.0.1",
+      "version": "5.0.10",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "glob": "^10.2.5"
+        "glob": "^10.3.7"
       },
       "bin": {
-        "rimraf": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
+        "rimraf": "dist/esm/bin.mjs"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -5456,7 +5493,7 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.1.0",
+      "version": "7.1.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5508,7 +5545,7 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.3",
+      "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5518,6 +5555,11 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/examples/echo-bot-ts-esm/package-lock.json
+++ b/examples/echo-bot-ts-esm/package-lock.json
@@ -32,7 +32,7 @@
         "express": "5.1.0",
         "finalhandler": "2.1.0",
         "husky": "9.1.7",
-        "msw": "2.11.2",
+        "msw": "2.11.3",
         "prettier": "3.6.2",
         "typedoc": "^0.28.0",
         "typedoc-plugin-markdown": "^4.3.0",
@@ -902,7 +902,7 @@
       "license": "MIT"
     },
     "../../node_modules/@types/node": {
-      "version": "22.18.1",
+      "version": "22.18.8",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1464,7 +1464,7 @@
       "optional": true
     },
     "../../node_modules/axios": {
-      "version": "1.12.0",
+      "version": "1.12.2",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2804,7 +2804,7 @@
       "license": "MIT"
     },
     "../../node_modules/msw": {
-      "version": "2.11.2",
+      "version": "2.11.3",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2814,7 +2814,6 @@
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.39.1",
         "@open-draft/deferred-promise": "^2.2.0",
-        "@open-draft/until": "^2.1.0",
         "@types/cookie": "^0.6.0",
         "@types/statuses": "^2.0.4",
         "graphql": "^16.8.1",
@@ -2827,6 +2826,7 @@
         "strict-event-emitter": "^0.5.1",
         "tough-cookie": "^6.0.0",
         "type-fest": "^4.26.1",
+        "until-async": "^3.0.2",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -3572,7 +3572,7 @@
       }
     },
     "../../node_modules/strip-ansi": {
-      "version": "7.1.0",
+      "version": "7.1.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3793,7 +3793,7 @@
       }
     },
     "../../node_modules/typedoc": {
-      "version": "0.28.12",
+      "version": "0.28.13",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3815,7 +3815,7 @@
       }
     },
     "../../node_modules/typedoc-plugin-markdown": {
-      "version": "4.8.1",
+      "version": "4.9.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3826,7 +3826,7 @@
       }
     },
     "../../node_modules/typescript": {
-      "version": "5.9.2",
+      "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3917,6 +3917,14 @@
         "node": ">= 0.8"
       }
     },
+    "../../node_modules/until-async": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
+      }
+    },
     "../../node_modules/vary": {
       "version": "1.1.2",
       "dev": true,
@@ -3952,7 +3960,7 @@
       }
     },
     "../../node_modules/vite": {
-      "version": "5.4.20",
+      "version": "5.4.21",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4439,7 +4447,7 @@
       }
     },
     "node_modules/@types/body-parser": {
-      "version": "1.19.5",
+      "version": "1.19.6",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4456,7 +4464,7 @@
       }
     },
     "node_modules/@types/express": {
-      "version": "4.17.21",
+      "version": "4.17.23",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4467,7 +4475,7 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.43",
+      "version": "4.19.7",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4478,7 +4486,7 @@
       }
     },
     "node_modules/@types/http-errors": {
-      "version": "2.0.4",
+      "version": "2.0.5",
       "dev": true,
       "license": "MIT"
     },
@@ -4488,15 +4496,15 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.11.30",
+      "version": "20.19.23",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/qs": {
-      "version": "6.9.14",
+      "version": "6.14.0",
       "dev": true,
       "license": "MIT"
     },
@@ -4506,21 +4514,29 @@
       "license": "MIT"
     },
     "node_modules/@types/send": {
-      "version": "0.17.4",
+      "version": "1.2.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/mime": "^1",
         "@types/node": "*"
       }
     },
     "node_modules/@types/serve-static": {
-      "version": "1.15.5",
+      "version": "1.15.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
-        "@types/mime": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
         "@types/node": "*"
       }
     },
@@ -4536,7 +4552,7 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.0.1",
+      "version": "6.2.2",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4547,7 +4563,7 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "6.2.1",
+      "version": "6.2.3",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4560,6 +4576,20 @@
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "license": "MIT"
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-generator-function": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -4604,7 +4634,7 @@
       }
     },
     "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4615,11 +4645,11 @@
       }
     },
     "node_modules/call-bound": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "get-intrinsic": "^1.2.6"
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4836,11 +4866,11 @@
       }
     },
     "node_modules/foreground-child": {
-      "version": "3.1.1",
+      "version": "3.3.1",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "cross-spawn": "^7.0.0",
+        "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
       },
       "engines": {
@@ -4871,16 +4901,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-intrinsic": {
-      "version": "1.2.7",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
+        "async-function": "^1.0.0",
+        "async-generator-function": "^1.0.0",
+        "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "get-proto": "^1.0.0",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
@@ -4905,21 +4945,19 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.3.10",
+      "version": "10.4.5",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
-        "jackspeak": "^2.3.5",
-        "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-        "path-scurry": "^1.10.1"
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -5004,14 +5042,11 @@
       "license": "ISC"
     },
     "node_modules/jackspeak": {
-      "version": "2.3.6",
+      "version": "3.4.3",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -5021,12 +5056,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "10.2.0",
+      "version": "10.4.3",
       "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "14 || >=16.14"
-      }
+      "license": "ISC"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -5084,7 +5116,7 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.3",
+      "version": "9.0.5",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5098,7 +5130,7 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.0.4",
+      "version": "7.1.2",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -5117,7 +5149,7 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.3",
+      "version": "1.13.4",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5136,6 +5168,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "license": "MIT",
@@ -5152,15 +5189,15 @@
       }
     },
     "node_modules/path-scurry": {
-      "version": "1.10.1",
+      "version": "1.11.1",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^9.1.1 || ^10.0.0",
+        "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -5215,7 +5252,7 @@
       }
     },
     "node_modules/rimraf": {
-      "version": "5.0.5",
+      "version": "5.0.10",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5223,9 +5260,6 @@
       },
       "bin": {
         "rimraf": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -5459,7 +5493,7 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.1.0",
+      "version": "7.1.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5511,7 +5545,7 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.3",
+      "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5523,7 +5557,7 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
+      "version": "6.21.0",
       "dev": true,
       "license": "MIT"
     },

--- a/examples/echo-bot/package-lock.json
+++ b/examples/echo-bot/package-lock.json
@@ -26,7 +26,7 @@
         "express": "5.1.0",
         "finalhandler": "2.1.0",
         "husky": "9.1.7",
-        "msw": "2.11.2",
+        "msw": "2.11.3",
         "prettier": "3.6.2",
         "typedoc": "^0.28.0",
         "typedoc-plugin-markdown": "^4.3.0",
@@ -896,7 +896,7 @@
       "license": "MIT"
     },
     "../../node_modules/@types/node": {
-      "version": "22.18.1",
+      "version": "22.18.8",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1458,7 +1458,7 @@
       "optional": true
     },
     "../../node_modules/axios": {
-      "version": "1.12.0",
+      "version": "1.12.2",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2798,7 +2798,7 @@
       "license": "MIT"
     },
     "../../node_modules/msw": {
-      "version": "2.11.2",
+      "version": "2.11.3",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2808,7 +2808,6 @@
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.39.1",
         "@open-draft/deferred-promise": "^2.2.0",
-        "@open-draft/until": "^2.1.0",
         "@types/cookie": "^0.6.0",
         "@types/statuses": "^2.0.4",
         "graphql": "^16.8.1",
@@ -2821,6 +2820,7 @@
         "strict-event-emitter": "^0.5.1",
         "tough-cookie": "^6.0.0",
         "type-fest": "^4.26.1",
+        "until-async": "^3.0.2",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -3566,7 +3566,7 @@
       }
     },
     "../../node_modules/strip-ansi": {
-      "version": "7.1.0",
+      "version": "7.1.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3787,7 +3787,7 @@
       }
     },
     "../../node_modules/typedoc": {
-      "version": "0.28.12",
+      "version": "0.28.13",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3809,7 +3809,7 @@
       }
     },
     "../../node_modules/typedoc-plugin-markdown": {
-      "version": "4.8.1",
+      "version": "4.9.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3820,7 +3820,7 @@
       }
     },
     "../../node_modules/typescript": {
-      "version": "5.9.2",
+      "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3911,6 +3911,14 @@
         "node": ">= 0.8"
       }
     },
+    "../../node_modules/until-async": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
+      }
+    },
     "../../node_modules/vary": {
       "version": "1.1.2",
       "dev": true,
@@ -3946,7 +3954,7 @@
       }
     },
     "../../node_modules/vite": {
-      "version": "5.4.20",
+      "version": "5.4.21",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/examples/kitchensink/package-lock.json
+++ b/examples/kitchensink/package-lock.json
@@ -27,7 +27,7 @@
         "express": "5.1.0",
         "finalhandler": "2.1.0",
         "husky": "9.1.7",
-        "msw": "2.11.2",
+        "msw": "2.11.3",
         "prettier": "3.6.2",
         "typedoc": "^0.28.0",
         "typedoc-plugin-markdown": "^4.3.0",
@@ -897,7 +897,7 @@
       "license": "MIT"
     },
     "../../node_modules/@types/node": {
-      "version": "22.18.1",
+      "version": "22.18.8",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1459,7 +1459,7 @@
       "optional": true
     },
     "../../node_modules/axios": {
-      "version": "1.12.0",
+      "version": "1.12.2",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2799,7 +2799,7 @@
       "license": "MIT"
     },
     "../../node_modules/msw": {
-      "version": "2.11.2",
+      "version": "2.11.3",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2809,7 +2809,6 @@
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.39.1",
         "@open-draft/deferred-promise": "^2.2.0",
-        "@open-draft/until": "^2.1.0",
         "@types/cookie": "^0.6.0",
         "@types/statuses": "^2.0.4",
         "graphql": "^16.8.1",
@@ -2822,6 +2821,7 @@
         "strict-event-emitter": "^0.5.1",
         "tough-cookie": "^6.0.0",
         "type-fest": "^4.26.1",
+        "until-async": "^3.0.2",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -3567,7 +3567,7 @@
       }
     },
     "../../node_modules/strip-ansi": {
-      "version": "7.1.0",
+      "version": "7.1.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3788,7 +3788,7 @@
       }
     },
     "../../node_modules/typedoc": {
-      "version": "0.28.12",
+      "version": "0.28.13",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3810,7 +3810,7 @@
       }
     },
     "../../node_modules/typedoc-plugin-markdown": {
-      "version": "4.8.1",
+      "version": "4.9.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3821,7 +3821,7 @@
       }
     },
     "../../node_modules/typescript": {
-      "version": "5.9.2",
+      "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3912,6 +3912,14 @@
         "node": ">= 0.8"
       }
     },
+    "../../node_modules/until-async": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
+      }
+    },
     "../../node_modules/vary": {
       "version": "1.1.2",
       "dev": true,
@@ -3947,7 +3955,7 @@
       }
     },
     "../../node_modules/vite": {
-      "version": "5.4.20",
+      "version": "5.4.21",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4439,7 +4447,7 @@
       }
     },
     "node_modules/@types/http-cache-semantics": {
-      "version": "4.0.2",
+      "version": "4.0.4",
       "license": "MIT"
     },
     "node_modules/@types/keyv": {
@@ -4450,18 +4458,21 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.6.3",
-      "license": "MIT"
+      "version": "24.9.1",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
     },
     "node_modules/@types/responselike": {
-      "version": "1.0.0",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/yauzl": {
-      "version": "2.10.0",
+      "version": "2.10.3",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4482,6 +4493,20 @@
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "license": "MIT"
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-generator-function": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -4543,7 +4568,7 @@
       }
     },
     "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4554,11 +4579,11 @@
       }
     },
     "node_modules/call-bound": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "get-intrinsic": "^1.2.6"
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4586,24 +4611,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/content-disposition/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/content-type": {
       "version": "1.0.5",
@@ -4699,7 +4706,7 @@
       }
     },
     "node_modules/end-of-stream": {
-      "version": "1.4.4",
+      "version": "1.4.5",
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -4784,24 +4791,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/express/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "license": "BSD-2-Clause",
@@ -4821,10 +4810,10 @@
       }
     },
     "node_modules/extract-zip/node_modules/debug": {
-      "version": "4.3.4",
+      "version": "4.4.3",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -4836,7 +4825,7 @@
       }
     },
     "node_modules/extract-zip/node_modules/ms": {
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT"
     },
     "node_modules/fd-slicer": {
@@ -4883,16 +4872,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-intrinsic": {
-      "version": "1.2.7",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
+        "async-function": "^1.0.0",
+        "async-generator-function": "^1.0.0",
+        "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "get-proto": "^1.0.0",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
@@ -4988,7 +4987,7 @@
       "optional": true
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.1",
+      "version": "4.2.0",
       "license": "BSD-2-Clause"
     },
     "node_modules/http-errors": {
@@ -5042,7 +5041,7 @@
       "license": "MIT"
     },
     "node_modules/keyv": {
-      "version": "4.5.3",
+      "version": "4.5.4",
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -5164,7 +5163,7 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.3",
+      "version": "1.13.4",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5224,7 +5223,7 @@
       }
     },
     "node_modules/pump": {
-      "version": "3.0.0",
+      "version": "3.0.3",
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -5287,6 +5286,24 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -5431,6 +5448,10 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "license": "MIT"
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "license": "MIT",
@@ -5464,10 +5485,13 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.3.2",
+      "version": "2.8.1",
       "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
       }
     },
     "node_modules/yauzl": {

--- a/examples/rich-menu/package-lock.json
+++ b/examples/rich-menu/package-lock.json
@@ -25,7 +25,7 @@
         "express": "5.1.0",
         "finalhandler": "2.1.0",
         "husky": "9.1.7",
-        "msw": "2.11.2",
+        "msw": "2.11.3",
         "prettier": "3.6.2",
         "typedoc": "^0.28.0",
         "typedoc-plugin-markdown": "^4.3.0",
@@ -895,7 +895,7 @@
       "license": "MIT"
     },
     "../../node_modules/@types/node": {
-      "version": "22.18.1",
+      "version": "22.18.8",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1457,7 +1457,7 @@
       "optional": true
     },
     "../../node_modules/axios": {
-      "version": "1.12.0",
+      "version": "1.12.2",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2797,7 +2797,7 @@
       "license": "MIT"
     },
     "../../node_modules/msw": {
-      "version": "2.11.2",
+      "version": "2.11.3",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2807,7 +2807,6 @@
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.39.1",
         "@open-draft/deferred-promise": "^2.2.0",
-        "@open-draft/until": "^2.1.0",
         "@types/cookie": "^0.6.0",
         "@types/statuses": "^2.0.4",
         "graphql": "^16.8.1",
@@ -2820,6 +2819,7 @@
         "strict-event-emitter": "^0.5.1",
         "tough-cookie": "^6.0.0",
         "type-fest": "^4.26.1",
+        "until-async": "^3.0.2",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -3565,7 +3565,7 @@
       }
     },
     "../../node_modules/strip-ansi": {
-      "version": "7.1.0",
+      "version": "7.1.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3786,7 +3786,7 @@
       }
     },
     "../../node_modules/typedoc": {
-      "version": "0.28.12",
+      "version": "0.28.13",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3808,7 +3808,7 @@
       }
     },
     "../../node_modules/typedoc-plugin-markdown": {
-      "version": "4.8.1",
+      "version": "4.9.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3819,7 +3819,7 @@
       }
     },
     "../../node_modules/typescript": {
-      "version": "5.9.2",
+      "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3910,6 +3910,14 @@
         "node": ">= 0.8"
       }
     },
+    "../../node_modules/until-async": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
+      }
+    },
     "../../node_modules/vary": {
       "version": "1.1.2",
       "dev": true,
@@ -3945,7 +3953,7 @@
       }
     },
     "../../node_modules/vite": {
-      "version": "5.4.20",
+      "version": "5.4.21",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5374,9 +5374,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.20",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
-      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
resolve #1423

The main changes of this PR is root `package-lock.json`.

```
$ ./scripts/npm-audit.sh


==> .
found 0 vulnerabilities


==> ./examples/echo-bot
found 0 vulnerabilities


==> ./examples/echo-bot-ts-esm
found 0 vulnerabilities


==> ./examples/echo-bot-ts-cjs
found 0 vulnerabilities


==> ./examples/rich-menu
found 0 vulnerabilities


==> ./examples/kitchensink
found 0 vulnerabilities


==> ./examples/echo-bot-esm
found 0 vulnerabilities
npm audit passed: no vulnerabilities detected
```