### PR TITLE
Set npm version as 11.6.0 in renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -14,6 +14,10 @@
     "dependency upgrade"
   ],
   minimumReleaseAge : "7 days",
+  // To prevent libraries in optionalDependencies from being removed from the lock file
+  constraints: {
+    npm: "11.6.0"
+  },
   packageRules: [
     {
       labels: [


### PR DESCRIPTION
We’re seeing an issue where libraries listed in optionalDependencies are being removed from the lockfile by Renovate. Specifically, axios is dropped from the lockfile, causing CI to fail. We found that pinning npm to 11.6.0 or below resolves the problem, so we’ll update the Renovate configuration to use npm 11.6.0.

However, I can’t reproduce the issue locally even with npm 11.6.1 or later, so the root cause hasn’t been determined.