### PR TITLE
refactor: replace Object.assign with spread operator in http-axios

### DIFF
--- a/lib/http-axios.ts
+++ b/lib/http-axios.ts
@@ -23,9 +23,10 @@ export default class HTTPClient {
     const { baseURL, defaultHeaders } = config;
     this.instance = axios.create({
       baseURL,
-      headers: Object.assign({}, defaultHeaders, {
+      headers: {
+        ...defaultHeaders,
         "User-Agent": USER_AGENT,
-      }),
+      },
     });
 
     this.instance.interceptors.response.use(


### PR DESCRIPTION
Replace Object.assign({}, defaultHeaders, {...}) with modern spread operator syntax for better readability and consistency with modern JavaScript patterns.