### PR TITLE
Add more doc urls

### DIFF
--- a/docs/getting-started/basic-usage.md
+++ b/docs/getting-started/basic-usage.md
@@ -92,3 +92,4 @@ The full examples with comments can be found
 in [examples](https://github.com/line/line-bot-sdk-nodejs/tree/master/examples/).
 
 For the specifications of API, please refer to [API Reference](../apidocs/globals.md).
+See also the [`LineBotClient`](../apidocs/classes/LineBotClient.md) and [`middleware()`](../apidocs/functions/middleware.md) references.

--- a/docs/guide/client.md
+++ b/docs/guide/client.md
@@ -7,7 +7,7 @@ For type signatures of the methods, please refer to [its API reference](../apido
 
 ## Create a client
 
-The `LineBotClient` class is provided by the main module. It bundles the
+The [`LineBotClient`](../apidocs/classes/LineBotClient.md) class is provided by the main module. It bundles the
 channel-access-token based bot APIs (Messaging, Insight, LIFF, etc.) into a
 single object so that you do not need to manage individual clients per API group.
 
@@ -37,7 +37,7 @@ await client.pushMessage({
 ```
 
 For issuing, verifying, or revoking channel access tokens, use
-`channelAccessToken.ChannelAccessTokenClient` directly:
+[`channelAccessToken.ChannelAccessTokenClient`](../apidocs/@line/namespaces/channelAccessToken/classes/ChannelAccessTokenClient.md) directly:
 
 ```js
 import { channelAccessToken } from '@line/bot-sdk';
@@ -102,7 +102,7 @@ await client
 
 There are several error types that may be thrown during client usage.
 
-- `HTTPFetchError`: The server returned a non-2xx HTTP status code. Exposes `status`, `statusText`, `headers`, and `body`.
+- [`HTTPFetchError`](../apidocs/classes/HTTPFetchError.md): The server returned a non-2xx HTTP status code. Exposes `status`, `statusText`, `headers`, and `body`.
 - `TypeError` (native): A network-level failure (DNS, connection refused, etc.) from the underlying `fetch()` call. Not wrapped by the SDK.
 - `SyntaxError` (native): JSON parsing fails for a response body. Not wrapped by the SDK.
 
@@ -132,8 +132,8 @@ stream.on('error', (err) => {
 ```
 
 You can check which method returns `Promise` or `Readable` in the API
-reference of [`LineBotClient`](../apidocs/globals.md). For type signatures of the
+reference of [`LineBotClient`](../apidocs/classes/LineBotClient.md). For type signatures of the
 errors above, please refer to below.
 
-- [HTTPFetchError](https://line.github.io/line-bot-sdk-nodejs/apidocs/classes/HTTPFetchError.html)
-- [SignatureValidationFailed](https://line.github.io/line-bot-sdk-nodejs/apidocs/classes/SignatureValidationFailed.html)
+- [`HTTPFetchError`](../apidocs/classes/HTTPFetchError.md)
+- [`SignatureValidationFailed`](../apidocs/classes/SignatureValidationFailed.md)

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -1,11 +1,11 @@
 # Migration Guide: Client → LineBotClient
 
-The legacy `Client` class is deprecated. Use `LineBotClient` instead.
-The legacy `OAuth` class is deprecated. Use `channelAccessToken.ChannelAccessTokenClient` instead.
+The legacy `Client` class is deprecated. Use [`LineBotClient`](../apidocs/classes/LineBotClient.md) instead.
+The legacy `OAuth` class is deprecated. Use [`channelAccessToken.ChannelAccessTokenClient`](../apidocs/@line/namespaces/channelAccessToken/classes/ChannelAccessTokenClient.md) instead.
 
-`LineBotClient` wraps the Messaging, Insight, LIFF, Audience, Shop, and Module API
+[`LineBotClient`](../apidocs/classes/LineBotClient.md) wraps the Messaging, Insight, LIFF, Audience, Shop, and Module API
 categories. Channel Access Token (OAuth) operations are handled by the separate
-`channelAccessToken.ChannelAccessTokenClient`.
+[`channelAccessToken.ChannelAccessTokenClient`](../apidocs/@line/namespaces/channelAccessToken/classes/ChannelAccessTokenClient.md).
 
 ---
 
@@ -19,7 +19,7 @@ Update `@line/bot-sdk` to v10.8.0
 npm install --ignore-scripts @line/bot-sdk@10.8.0 # just in case
 ```
 
-Both the legacy `Client`/`OAuth` API and the new `LineBotClient` API coexist in
+Both the legacy `Client`/`OAuth` API and the new [`LineBotClient`](../apidocs/classes/LineBotClient.md) API coexist in
 v10, so you can migrate incrementally without breaking existing code.
 
 ### Step 2: Replace client construction
@@ -37,7 +37,7 @@ const oauthClient = new channelAccessToken.ChannelAccessTokenClient({});
 ```
 
 The `channelAccessToken` option is the same. Additional options available on
-`LineBotClientChannelAccessTokenConfig`:
+[`LineBotClientChannelAccessTokenConfig`](../apidocs/interfaces/LineBotClientChannelAccessTokenConfig.md):
 
 | Option | Default | Description |
 |---|---|---|
@@ -47,9 +47,9 @@ The `channelAccessToken` option is the same. Additional options available on
 | `dataApiBaseURL` | `https://api-data.line.me` | Override for `api-data.line.me` endpoints |
 | `managerBaseURL` | `https://manager.line.biz` | Override for `manager.line.biz` endpoints |
 
-> **`httpConfig` is not available in `LineBotClient`.**
+> **`httpConfig` is not available in [`LineBotClient`](../apidocs/classes/LineBotClient.md).**
 > The legacy `ClientConfig` accepted `httpConfig?: Partial<AxiosRequestConfig>` to
-> customise timeout, proxy, and other axios-specific settings. `LineBotClient` uses
+> customise timeout, proxy, and other axios-specific settings. [`LineBotClient`](../apidocs/classes/LineBotClient.md) uses
 > the runtime's native `fetch()` internally, so there is no direct equivalent.
 > `defaultHeaders` and the base-URL overrides above are still supported. If you
 > relied on other axios options (e.g. `timeout`, `proxy`), you will need to
@@ -72,7 +72,7 @@ await client.pushMessage({ to, messages, notificationDisabled });
 
 ### Step 4: Update error handling
 
-`LineBotClient` uses the Fetch API internally and throws `HTTPFetchError` on
+[`LineBotClient`](../apidocs/classes/LineBotClient.md) uses the Fetch API internally and throws [`HTTPFetchError`](../apidocs/classes/HTTPFetchError.md) on
 non-2xx responses. The legacy `Client` used axios and threw `HTTPError`.
 See the [error handling section](#error-handling) below.
 
@@ -95,7 +95,7 @@ npm install @line/bot-sdk@11
 ## Error handling
 
 The legacy `Client` uses axios internally and throws `HTTPError` (which wraps the axios error).
-`LineBotClient` uses the runtime's native `fetch()` and throws `HTTPFetchError` instead.
+[`LineBotClient`](../apidocs/classes/LineBotClient.md) uses the runtime's native `fetch()` and throws [`HTTPFetchError`](../apidocs/classes/HTTPFetchError.md) instead.
 The version of the package does not affect this — the difference is purely which client you use.
 
 ```ts
@@ -126,14 +126,14 @@ try {
 }
 ```
 
-| `HTTPError` (v8) | `HTTPFetchError` (v9+) | Notes |
+| `HTTPError` (v8) | [`HTTPFetchError`](../apidocs/classes/HTTPFetchError.md) (v9+) | Notes |
 |---|---|---|
 | `originalError.response.status` | `status` | |
 | `originalError.response.headers` | `headers` | Now a Fetch `Headers` object |
 | `originalError.response.data` | `body` | Was parsed JSON; now a raw string |
 | `originalError` | deleted | |
 
-`SignatureValidationFailed` is unchanged. In the normal `LineBotClient` fetch path, invalid JSON surfaces as a native `SyntaxError` rather than `JSONParseError`. `JSONParseError` is only thrown in legacy/helper paths that use `ensureJSON()`.
+[`SignatureValidationFailed`](../apidocs/classes/SignatureValidationFailed.md) is unchanged. In the normal [`LineBotClient`](../apidocs/classes/LineBotClient.md) fetch path, invalid JSON surfaces as a native `SyntaxError` rather than [`JSONParseError`](../apidocs/classes/JSONParseError.md). [`JSONParseError`](../apidocs/classes/JSONParseError.md) is only thrown in legacy/helper paths that use `ensureJSON()`.
 
 ---
 
@@ -143,122 +143,122 @@ try {
 
 | Client method | LineBotClient method | Notes |
 |---|---|---|
-| `pushMessage(to, messages, notificationDisabled?, customAggregationUnits?)` | `pushMessage({ to, messages, notificationDisabled, customAggregationUnits }, xLineRetryKey?)` | Arguments wrapped in a request object. Retry key moved to 2nd param. |
-| `replyMessage(replyToken, messages, notificationDisabled?)` | `replyMessage({ replyToken, messages, notificationDisabled })` | Arguments wrapped in a request object. |
-| `multicast(to, messages, notificationDisabled?, customAggregationUnits?)` | `multicast({ to, messages, notificationDisabled, customAggregationUnits }, xLineRetryKey?)` | Arguments wrapped in a request object. Retry key moved to 2nd param. |
-| `narrowcast(messages, recipient?, filter?, limit?, notificationDisabled?)` | `narrowcast({ messages, recipient, filter, limit, notificationDisabled }, xLineRetryKey?)` | Arguments wrapped in a request object. Retry key moved to 2nd param. |
-| `broadcast(messages, notificationDisabled?)` | `broadcast({ messages, notificationDisabled }, xLineRetryKey?)` | Arguments wrapped in a request object. Retry key moved to 2nd param. |
+| `pushMessage(to, messages, notificationDisabled?, customAggregationUnits?)` | [`pushMessage({ to, messages, notificationDisabled, customAggregationUnits }, xLineRetryKey?)`](../apidocs/classes/LineBotClient.md#pushmessage) | Arguments wrapped in a request object. Retry key moved to 2nd param. |
+| `replyMessage(replyToken, messages, notificationDisabled?)` | [`replyMessage({ replyToken, messages, notificationDisabled })`](../apidocs/classes/LineBotClient.md#replymessage) | Arguments wrapped in a request object. |
+| `multicast(to, messages, notificationDisabled?, customAggregationUnits?)` | [`multicast({ to, messages, notificationDisabled, customAggregationUnits }, xLineRetryKey?)`](../apidocs/classes/LineBotClient.md#multicast) | Arguments wrapped in a request object. Retry key moved to 2nd param. |
+| `narrowcast(messages, recipient?, filter?, limit?, notificationDisabled?)` | [`narrowcast({ messages, recipient, filter, limit, notificationDisabled }, xLineRetryKey?)`](../apidocs/classes/LineBotClient.md#narrowcast) | Arguments wrapped in a request object. Retry key moved to 2nd param. |
+| `broadcast(messages, notificationDisabled?)` | [`broadcast({ messages, notificationDisabled }, xLineRetryKey?)`](../apidocs/classes/LineBotClient.md#broadcast) | Arguments wrapped in a request object. Retry key moved to 2nd param. |
 | `setRequestOptionOnce({ retryKey })` | deleted | Pass `xLineRetryKey` as the 2nd argument to `pushMessage` / `multicast` / `narrowcast` / `broadcast` directly. |
 
 ### Message validation
 
 | Client method | LineBotClient method | Notes |
 |---|---|---|
-| `validatePushMessageObjects(messages)` | `validatePush({ messages })` | Renamed. |
-| `validateReplyMessageObjects(messages)` | `validateReply({ messages })` | Renamed. |
-| `validateMulticastMessageObjects(messages)` | `validateMulticast({ messages })` | Renamed. |
-| `validateNarrowcastMessageObjects(messages)` | `validateNarrowcast({ messages })` | Renamed. |
-| `validateBroadcastMessageObjects(messages)` | `validateBroadcast({ messages })` | Renamed. |
+| `validatePushMessageObjects(messages)` | [`validatePush({ messages })`](../apidocs/classes/LineBotClient.md#validatepush) | Renamed. |
+| `validateReplyMessageObjects(messages)` | [`validateReply({ messages })`](../apidocs/classes/LineBotClient.md#validatereply) | Renamed. |
+| `validateMulticastMessageObjects(messages)` | [`validateMulticast({ messages })`](../apidocs/classes/LineBotClient.md#validatemulticast) | Renamed. |
+| `validateNarrowcastMessageObjects(messages)` | [`validateNarrowcast({ messages })`](../apidocs/classes/LineBotClient.md#validatenarrowcast) | Renamed. |
+| `validateBroadcastMessageObjects(messages)` | [`validateBroadcast({ messages })`](../apidocs/classes/LineBotClient.md#validatebroadcast) | Renamed. |
 | `validateCustomAggregationUnits(units)` | deleted | Client-side validation only; no longer provided. |
 
 ### Profile & group
 
 | Client method | LineBotClient method | Notes |
 |---|---|---|
-| `getProfile(userId)` | `getProfile(userId)` | Same. |
-| `getGroupMemberProfile(groupId, userId)` | `getGroupMemberProfile(groupId, userId)` | Same. |
-| `getRoomMemberProfile(roomId, userId)` | `getRoomMemberProfile(roomId, userId)` | Same. |
-| `getGroupMemberIds(groupId)` | `getGroupMembersIds(groupId, start?)` | Renamed (added `s`). No longer auto-paginates; returns a single page. |
-| `getRoomMemberIds(roomId)` | `getRoomMembersIds(roomId, start?)` | Renamed (added `s`). No longer auto-paginates; returns a single page. |
-| `getBotFollowersIds()` | `getFollowers(start?, limit?)` | Renamed. No longer auto-paginates; returns a single page (`GetFollowersResponse`). Loop with the `next` token to retrieve all followers. |
-| `getGroupMembersCount(groupId)` | `getGroupMemberCount(groupId)` | Renamed (removed `s`). |
-| `getRoomMembersCount(roomId)` | `getRoomMemberCount(roomId)` | Renamed (removed `s`). |
-| `getGroupSummary(groupId)` | `getGroupSummary(groupId)` | Same. |
-| `getBotInfo()` | `getBotInfo()` | Same. |
-| `leaveGroup(groupId)` | `leaveGroup(groupId)` | Same. |
-| `leaveRoom(roomId)` | `leaveRoom(roomId)` | Same. |
+| `getProfile(userId)` | [`getProfile(userId)`](../apidocs/classes/LineBotClient.md#getprofile) | Same. |
+| `getGroupMemberProfile(groupId, userId)` | [`getGroupMemberProfile(groupId, userId)`](../apidocs/classes/LineBotClient.md#getgroupmemberprofile) | Same. |
+| `getRoomMemberProfile(roomId, userId)` | [`getRoomMemberProfile(roomId, userId)`](../apidocs/classes/LineBotClient.md#getroommemberprofile) | Same. |
+| `getGroupMemberIds(groupId)` | [`getGroupMembersIds(groupId, start?)`](../apidocs/classes/LineBotClient.md#getgroupmembersids) | Renamed (added `s`). No longer auto-paginates; returns a single page. |
+| `getRoomMemberIds(roomId)` | [`getRoomMembersIds(roomId, start?)`](../apidocs/classes/LineBotClient.md#getroommembersids) | Renamed (added `s`). No longer auto-paginates; returns a single page. |
+| `getBotFollowersIds()` | [`getFollowers(start?, limit?)`](../apidocs/classes/LineBotClient.md#getfollowers) | Renamed. No longer auto-paginates; returns a single page (`GetFollowersResponse`). Loop with the `next` token to retrieve all followers. |
+| `getGroupMembersCount(groupId)` | [`getGroupMemberCount(groupId)`](../apidocs/classes/LineBotClient.md#getgroupmembercount) | Renamed (removed `s`). |
+| `getRoomMembersCount(roomId)` | [`getRoomMemberCount(roomId)`](../apidocs/classes/LineBotClient.md#getroommembercount) | Renamed (removed `s`). |
+| `getGroupSummary(groupId)` | [`getGroupSummary(groupId)`](../apidocs/classes/LineBotClient.md#getgroupsummary) | Same. |
+| `getBotInfo()` | [`getBotInfo()`](../apidocs/classes/LineBotClient.md#getbotinfo) | Same. |
+| `leaveGroup(groupId)` | [`leaveGroup(groupId)`](../apidocs/classes/LineBotClient.md#leavegroup) | Same. |
+| `leaveRoom(roomId)` | [`leaveRoom(roomId)`](../apidocs/classes/LineBotClient.md#leaveroom) | Same. |
 
 ### Message content
 
 | Client method | LineBotClient method | Notes |
 |---|---|---|
-| `getMessageContent(messageId)` | `getMessageContent(messageId)` | Same. Returns `Readable`. |
+| `getMessageContent(messageId)` | [`getMessageContent(messageId)`](../apidocs/classes/LineBotClient.md#getmessagecontent) | Same. Returns `Readable`. |
 
 ### Rich menu
 
 | Client method | LineBotClient method | Notes |
 |---|---|---|
-| `getRichMenu(richMenuId)` | `getRichMenu(richMenuId)` | Same. |
-| `createRichMenu(richMenu)` | `createRichMenu(richMenuRequest)` | Return type changed from `string` to `RichMenuIdResponse`. |
-| `deleteRichMenu(richMenuId)` | `deleteRichMenu(richMenuId)` | Same. |
-| `getRichMenuAliasList()` | `getRichMenuAliasList()` | Same. |
-| `getRichMenuAlias(richMenuAliasId)` | `getRichMenuAlias(richMenuAliasId)` | Same. |
-| `createRichMenuAlias(richMenuId, richMenuAliasId)` | `createRichMenuAlias({ richMenuId, richMenuAliasId })` | Arguments wrapped in a request object. |
-| `deleteRichMenuAlias(richMenuAliasId)` | `deleteRichMenuAlias(richMenuAliasId)` | Same. |
-| `updateRichMenuAlias(richMenuAliasId, richMenuId)` | `updateRichMenuAlias(richMenuAliasId, { richMenuId })` | 2nd argument wrapped in a request object. |
-| `getRichMenuIdOfUser(userId)` | `getRichMenuIdOfUser(userId)` | Return type changed from `string` to `RichMenuIdResponse`. |
-| `linkRichMenuToUser(userId, richMenuId)` | `linkRichMenuIdToUser(userId, richMenuId)` | Renamed. |
-| `unlinkRichMenuFromUser(userId)` | `unlinkRichMenuIdFromUser(userId)` | Renamed. |
-| `linkRichMenuToMultipleUsers(richMenuId, userIds[])` | `linkRichMenuIdToUsers({ richMenuId, userIds })` | Renamed. Arguments wrapped in a request object. |
-| `unlinkRichMenusFromMultipleUsers(userIds[])` | `unlinkRichMenuIdFromUsers({ userIds })` | Renamed. Arguments wrapped in a request object. |
-| `getRichMenuImage(richMenuId)` | `getRichMenuImage(richMenuId)` | Same. |
-| `setRichMenuImage(richMenuId, data, contentType?)` | `setRichMenuImage(richMenuId, body?)` | `body` is now `Blob` (optional) instead of `Buffer \| Readable`. `contentType` removed. |
-| `getRichMenuList()` | `getRichMenuList()` | Return type changed from `RichMenuResponse[]` to `RichMenuListResponse`. |
-| `setDefaultRichMenu(richMenuId)` | `setDefaultRichMenu(richMenuId)` | Same. |
-| `getDefaultRichMenuId()` | `getDefaultRichMenuId()` | Return type changed from `string` to `RichMenuIdResponse`. |
-| `deleteDefaultRichMenu()` | `cancelDefaultRichMenu()` | Renamed. |
-| `validateRichMenu(richMenu)` | `validateRichMenuObject(richMenu)` | Renamed. |
+| `getRichMenu(richMenuId)` | [`getRichMenu(richMenuId)`](../apidocs/classes/LineBotClient.md#getrichmenu) | Same. |
+| `createRichMenu(richMenu)` | [`createRichMenu(richMenuRequest)`](../apidocs/classes/LineBotClient.md#createrichmenu) | Return type changed from `string` to `RichMenuIdResponse`. |
+| `deleteRichMenu(richMenuId)` | [`deleteRichMenu(richMenuId)`](../apidocs/classes/LineBotClient.md#deleterichmenu) | Same. |
+| `getRichMenuAliasList()` | [`getRichMenuAliasList()`](../apidocs/classes/LineBotClient.md#getrichmenualiaslist) | Same. |
+| `getRichMenuAlias(richMenuAliasId)` | [`getRichMenuAlias(richMenuAliasId)`](../apidocs/classes/LineBotClient.md#getrichmenualias) | Same. |
+| `createRichMenuAlias(richMenuId, richMenuAliasId)` | [`createRichMenuAlias({ richMenuId, richMenuAliasId })`](../apidocs/classes/LineBotClient.md#createrichmenualias) | Arguments wrapped in a request object. |
+| `deleteRichMenuAlias(richMenuAliasId)` | [`deleteRichMenuAlias(richMenuAliasId)`](../apidocs/classes/LineBotClient.md#deleterichmenualias) | Same. |
+| `updateRichMenuAlias(richMenuAliasId, richMenuId)` | [`updateRichMenuAlias(richMenuAliasId, { richMenuId })`](../apidocs/classes/LineBotClient.md#updaterichmenualias) | 2nd argument wrapped in a request object. |
+| `getRichMenuIdOfUser(userId)` | [`getRichMenuIdOfUser(userId)`](../apidocs/classes/LineBotClient.md#getrichmenuidofuser) | Return type changed from `string` to `RichMenuIdResponse`. |
+| `linkRichMenuToUser(userId, richMenuId)` | [`linkRichMenuIdToUser(userId, richMenuId)`](../apidocs/classes/LineBotClient.md#linkrichmenuidtouser) | Renamed. |
+| `unlinkRichMenuFromUser(userId)` | [`unlinkRichMenuIdFromUser(userId)`](../apidocs/classes/LineBotClient.md#unlinkrichmenuidfromuser) | Renamed. |
+| `linkRichMenuToMultipleUsers(richMenuId, userIds[])` | [`linkRichMenuIdToUsers({ richMenuId, userIds })`](../apidocs/classes/LineBotClient.md#linkrichmenuidtousers) | Renamed. Arguments wrapped in a request object. |
+| `unlinkRichMenusFromMultipleUsers(userIds[])` | [`unlinkRichMenuIdFromUsers({ userIds })`](../apidocs/classes/LineBotClient.md#unlinkrichmenuidfromusers) | Renamed. Arguments wrapped in a request object. |
+| `getRichMenuImage(richMenuId)` | [`getRichMenuImage(richMenuId)`](../apidocs/classes/LineBotClient.md#getrichmenuimage) | Same. |
+| `setRichMenuImage(richMenuId, data, contentType?)` | [`setRichMenuImage(richMenuId, body?)`](../apidocs/classes/LineBotClient.md#setrichmenuimage) | `body` is now `Blob` (optional) instead of `Buffer \| Readable`. `contentType` removed. |
+| `getRichMenuList()` | [`getRichMenuList()`](../apidocs/classes/LineBotClient.md#getrichmenulist) | Return type changed from `RichMenuResponse[]` to `RichMenuListResponse`. |
+| `setDefaultRichMenu(richMenuId)` | [`setDefaultRichMenu(richMenuId)`](../apidocs/classes/LineBotClient.md#setdefaultrichmenu) | Same. |
+| `getDefaultRichMenuId()` | [`getDefaultRichMenuId()`](../apidocs/classes/LineBotClient.md#getdefaultrichmenuid) | Return type changed from `string` to `RichMenuIdResponse`. |
+| `deleteDefaultRichMenu()` | [`cancelDefaultRichMenu()`](../apidocs/classes/LineBotClient.md#canceldefaultrichmenu) | Renamed. |
+| `validateRichMenu(richMenu)` | [`validateRichMenuObject(richMenu)`](../apidocs/classes/LineBotClient.md#validaterichmenuobject) | Renamed. |
 
 ### Webhook
 
 | Client method | LineBotClient method | Notes |
 |---|---|---|
-| `setWebhookEndpointUrl(endpoint)` | `setWebhookEndpoint({ endpoint })` | Renamed. Argument wrapped in a request object. |
-| `getWebhookEndpointInfo()` | `getWebhookEndpoint()` | Renamed. |
-| `testWebhookEndpoint(endpoint?)` | `testWebhookEndpoint({ endpoint }?)` | Argument wrapped in a request object. The entire request object is optional. |
+| `setWebhookEndpointUrl(endpoint)` | [`setWebhookEndpoint({ endpoint })`](../apidocs/classes/LineBotClient.md#setwebhookendpoint) | Renamed. Argument wrapped in a request object. |
+| `getWebhookEndpointInfo()` | [`getWebhookEndpoint()`](../apidocs/classes/LineBotClient.md#getwebhookendpoint) | Renamed. |
+| `testWebhookEndpoint(endpoint?)` | [`testWebhookEndpoint({ endpoint }?)`](../apidocs/classes/LineBotClient.md#testwebhookendpoint) | Argument wrapped in a request object. The entire request object is optional. |
 
 ### Link token
 
 | Client method | LineBotClient method | Notes |
 |---|---|---|
-| `getLinkToken(userId)` | `issueLinkToken(userId)` | Renamed. Return type changed from `string` to `IssueLinkTokenResponse`. |
+| `getLinkToken(userId)` | [`issueLinkToken(userId)`](../apidocs/classes/LineBotClient.md#issuelinktoken) | Renamed. Return type changed from `string` to `IssueLinkTokenResponse`. |
 
 ### Message delivery stats
 
 | Client method | LineBotClient method | Notes |
 |---|---|---|
-| `getNumberOfSentReplyMessages(date)` | `getNumberOfSentReplyMessages(date)` | Same. |
-| `getNumberOfSentPushMessages(date)` | `getNumberOfSentPushMessages(date)` | Same. |
-| `getNumberOfSentMulticastMessages(date)` | `getNumberOfSentMulticastMessages(date)` | Same. |
-| `getNumberOfSentBroadcastMessages(date)` | `getNumberOfSentBroadcastMessages(date)` | Same. |
-| `getNarrowcastProgress(requestId)` | `getNarrowcastProgress(requestId)` | Same. |
-| `getTargetLimitForAdditionalMessages()` | `getMessageQuota()` | Renamed. |
-| `getNumberOfMessagesSentThisMonth()` | `getMessageQuotaConsumption()` | Renamed. |
+| `getNumberOfSentReplyMessages(date)` | [`getNumberOfSentReplyMessages(date)`](../apidocs/classes/LineBotClient.md#getnumberofsentreplymessages) | Same. |
+| `getNumberOfSentPushMessages(date)` | [`getNumberOfSentPushMessages(date)`](../apidocs/classes/LineBotClient.md#getnumberofsentpushmessages) | Same. |
+| `getNumberOfSentMulticastMessages(date)` | [`getNumberOfSentMulticastMessages(date)`](../apidocs/classes/LineBotClient.md#getnumberofsentmulticastmessages) | Same. |
+| `getNumberOfSentBroadcastMessages(date)` | [`getNumberOfSentBroadcastMessages(date)`](../apidocs/classes/LineBotClient.md#getnumberofsentbroadcastmessages) | Same. |
+| `getNarrowcastProgress(requestId)` | [`getNarrowcastProgress(requestId)`](../apidocs/classes/LineBotClient.md#getnarrowcastprogress) | Same. |
+| `getTargetLimitForAdditionalMessages()` | [`getMessageQuota()`](../apidocs/classes/LineBotClient.md#getmessagequota) | Renamed. |
+| `getNumberOfMessagesSentThisMonth()` | [`getMessageQuotaConsumption()`](../apidocs/classes/LineBotClient.md#getmessagequotaconsumption) | Renamed. |
 
 ### Insight
 
 | Client method | LineBotClient method | Notes |
 |---|---|---|
-| `getNumberOfMessageDeliveries(date)` | `getNumberOfMessageDeliveries(date)` | Same. |
-| `getNumberOfFollowers(date)` | `getNumberOfFollowers(date?)` | `date` is now optional. |
-| `getFriendDemographics()` | `getFriendsDemographics()` | Renamed (added `s`). |
-| `getUserInteractionStatistics(requestId)` | `getMessageEvent(requestId)` | Renamed. |
-| `getStatisticsPerUnit(unit, from, to)` | `getStatisticsPerUnit(unit, from, to)` | Same. |
+| `getNumberOfMessageDeliveries(date)` | [`getNumberOfMessageDeliveries(date)`](../apidocs/classes/LineBotClient.md#getnumberofmessagedeliveries) | Same. |
+| `getNumberOfFollowers(date)` | [`getNumberOfFollowers(date?)`](../apidocs/classes/LineBotClient.md#getnumberoffollowers) | `date` is now optional. |
+| `getFriendDemographics()` | [`getFriendsDemographics()`](../apidocs/classes/LineBotClient.md#getfriendsdemographics) | Renamed (added `s`). |
+| `getUserInteractionStatistics(requestId)` | [`getMessageEvent(requestId)`](../apidocs/classes/LineBotClient.md#getmessageevent) | Renamed. |
+| `getStatisticsPerUnit(unit, from, to)` | [`getStatisticsPerUnit(unit, from, to)`](../apidocs/classes/LineBotClient.md#getstatisticsperunit) | Same. |
 
 ### Audience
 
 | Client method | LineBotClient method | Notes |
 |---|---|---|
-| `createUploadAudienceGroup({ description, isIfaAudience?, audiences?, uploadDescription? })` | `createAudienceGroup({ description, isIfaAudience, audiences, uploadDescription })` | Renamed. |
-| `createUploadAudienceGroupByFile({ description, isIfaAudience?, uploadDescription?, file })` | `createAudienceForUploadingUserIds(file, description?, isIfaAudience?, uploadDescription?)` | Renamed. `file` type changed from `Buffer \| Readable` to `Blob`. |
-| `updateUploadAudienceGroup({ audienceGroupId, description?, uploadDescription?, audiences })` | `addAudienceToAudienceGroup({ audienceGroupId, uploadDescription, audiences })` then, if `description` was used, also call `updateAudienceGroupDescription(audienceGroupId, { description })` | Renamed. `description` requires a separate call. The legacy per-request `httpConfig` argument has no direct replacement in `LineBotClient`. |
-| `updateUploadAudienceGroupByFile({ audienceGroupId, uploadDescription?, file })` | `addUserIdsToAudience(file, audienceGroupId?, uploadDescription?)` | Renamed. `file` type changed from `Buffer \| Readable` to `Blob`. The legacy per-request `httpConfig` argument has no direct replacement in `LineBotClient`. |
-| `createClickAudienceGroup({ description, requestId, clickUrl? })` | `createClickBasedAudienceGroup({ description, requestId, clickUrl })` | Renamed. |
-| `createImpAudienceGroup({ requestId, description })` | `createImpBasedAudienceGroup({ requestId, description })` | Renamed. |
-| `setDescriptionAudienceGroup(description, audienceGroupId)` | `updateAudienceGroupDescription(audienceGroupId, { description })` | Renamed. Argument order reversed. `audienceGroupId` type changed from `string` to `number`. |
-| `deleteAudienceGroup(audienceGroupId)` | `deleteAudienceGroup(audienceGroupId)` | `audienceGroupId` type changed from `string` to `number`. |
-| `getAudienceGroup(audienceGroupId)` | `getAudienceData(audienceGroupId)` | Renamed. `audienceGroupId` type changed from `string` to `number`. |
-| `getAudienceGroups(page, description?, status?, size?, createRoute?, includesExternalPublicGroups?)` | `getAudienceGroups(page, description?, status?, size?, includesExternalPublicGroups?, createRoute?)` | Last two arguments swapped. |
+| `createUploadAudienceGroup({ description, isIfaAudience?, audiences?, uploadDescription? })` | [`createAudienceGroup({ description, isIfaAudience, audiences, uploadDescription })`](../apidocs/classes/LineBotClient.md#createaudiencegroup) | Renamed. |
+| `createUploadAudienceGroupByFile({ description, isIfaAudience?, uploadDescription?, file })` | [`createAudienceForUploadingUserIds(file, description?, isIfaAudience?, uploadDescription?)`](../apidocs/classes/LineBotClient.md#createaudienceforuploadinguserids) | Renamed. `file` type changed from `Buffer \| Readable` to `Blob`. |
+| `updateUploadAudienceGroup({ audienceGroupId, description?, uploadDescription?, audiences })` | [`addAudienceToAudienceGroup({ audienceGroupId, uploadDescription, audiences })`](../apidocs/classes/LineBotClient.md#addaudiencetoaudiencegroup) then, if `description` was used, also call [`updateAudienceGroupDescription(audienceGroupId, { description })`](../apidocs/classes/LineBotClient.md#updateaudiencegroupdescription) | Renamed. `description` requires a separate call. The legacy per-request `httpConfig` argument has no direct replacement in `LineBotClient`. |
+| `updateUploadAudienceGroupByFile({ audienceGroupId, uploadDescription?, file })` | [`addUserIdsToAudience(file, audienceGroupId?, uploadDescription?)`](../apidocs/classes/LineBotClient.md#adduseridstoaudience) | Renamed. `file` type changed from `Buffer \| Readable` to `Blob`. The legacy per-request `httpConfig` argument has no direct replacement in `LineBotClient`. |
+| `createClickAudienceGroup({ description, requestId, clickUrl? })` | [`createClickBasedAudienceGroup({ description, requestId, clickUrl })`](../apidocs/classes/LineBotClient.md#createclickbasedaudiencegroup) | Renamed. |
+| `createImpAudienceGroup({ requestId, description })` | [`createImpBasedAudienceGroup({ requestId, description })`](../apidocs/classes/LineBotClient.md#createimpbasedaudiencegroup) | Renamed. |
+| `setDescriptionAudienceGroup(description, audienceGroupId)` | [`updateAudienceGroupDescription(audienceGroupId, { description })`](../apidocs/classes/LineBotClient.md#updateaudiencegroupdescription) | Renamed. Argument order reversed. `audienceGroupId` type changed from `string` to `number`. |
+| `deleteAudienceGroup(audienceGroupId)` | [`deleteAudienceGroup(audienceGroupId)`](../apidocs/classes/LineBotClient.md#deleteaudiencegroup) | `audienceGroupId` type changed from `string` to `number`. |
+| `getAudienceGroup(audienceGroupId)` | [`getAudienceData(audienceGroupId)`](../apidocs/classes/LineBotClient.md#getaudiencedata) | Renamed. `audienceGroupId` type changed from `string` to `number`. |
+| `getAudienceGroups(page, description?, status?, size?, createRoute?, includesExternalPublicGroups?)` | [`getAudienceGroups(page, description?, status?, size?, includesExternalPublicGroups?, createRoute?)`](../apidocs/classes/LineBotClient.md#getaudiencegroups) | Last two arguments swapped. |
 | `getAudienceGroupAuthorityLevel()` | deleted | No equivalent in current API. |
 | `changeAudienceGroupAuthorityLevel(authorityLevel)` | deleted | No equivalent in current API. |
 
@@ -266,7 +266,7 @@ try {
 
 ## Method mapping: OAuth → channelAccessToken.ChannelAccessTokenClient
 
-`OAuth` methods are not on `LineBotClient`. They live on `channelAccessToken.ChannelAccessTokenClient`,
+`OAuth` methods are not on [`LineBotClient`](../apidocs/classes/LineBotClient.md). They live on [`channelAccessToken.ChannelAccessTokenClient`](../apidocs/@line/namespaces/channelAccessToken/classes/ChannelAccessTokenClient.md),
 which is constructed without a channel access token:
 
 ```js
@@ -276,13 +276,13 @@ const oauthClient = new channelAccessToken.ChannelAccessTokenClient({});
 
 | OAuth method | ChannelAccessTokenClient method | Notes |
 |---|---|---|
-| `issueAccessToken(client_id, client_secret)` | `issueChannelToken('client_credentials', client_id, client_secret)` | Renamed. `grant_type` is now an explicit argument. |
-| `revokeAccessToken(access_token)` | `revokeChannelToken(access_token)` | Renamed. |
-| `verifyAccessToken(access_token)` | `verifyChannelTokenByJWT(access_token)` | Renamed. Verifies a v2.1 (JWT-issued) channel access token. |
+| `issueAccessToken(client_id, client_secret)` | [`issueChannelToken('client_credentials', client_id, client_secret)`](../apidocs/@line/namespaces/channelAccessToken/classes/ChannelAccessTokenClient.md#issuechanneltoken) | Renamed. `grant_type` is now an explicit argument. |
+| `revokeAccessToken(access_token)` | [`revokeChannelToken(access_token)`](../apidocs/@line/namespaces/channelAccessToken/classes/ChannelAccessTokenClient.md#revokechanneltoken) | Renamed. |
+| `verifyAccessToken(access_token)` | [`verifyChannelTokenByJWT(access_token)`](../apidocs/@line/namespaces/channelAccessToken/classes/ChannelAccessTokenClient.md#verifychanneltokenbyjwt) | Renamed. Verifies a v2.1 (JWT-issued) channel access token. |
 | `verifyIdToken(id_token, client_id, nonce?, user_id?)` | deleted | No direct equivalent. |
-| `issueChannelAccessTokenV2_1(client_assertion)` | `issueChannelTokenByJWT('client_credentials', 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer', client_assertion)` | Renamed. `grant_type` and `client_assertion_type` are now explicit arguments. |
-| `getChannelAccessTokenKeyIdsV2_1(client_assertion)` | `getsAllValidChannelAccessTokenKeyIds('urn:ietf:params:oauth:client-assertion-type:jwt-bearer', client_assertion)` | Renamed. `client_assertion_type` is now an explicit argument. Response shape changed: `key_ids` → `kids`. |
-| `revokeChannelAccessTokenV2_1(client_id, client_secret, access_token)` | `revokeChannelTokenByJWT(client_id, client_secret, access_token)` | Renamed. |
+| `issueChannelAccessTokenV2_1(client_assertion)` | [`issueChannelTokenByJWT('client_credentials', 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer', client_assertion)`](../apidocs/@line/namespaces/channelAccessToken/classes/ChannelAccessTokenClient.md#issuechanneltokenbyjwt) | Renamed. `grant_type` and `client_assertion_type` are now explicit arguments. |
+| `getChannelAccessTokenKeyIdsV2_1(client_assertion)` | [`getsAllValidChannelAccessTokenKeyIds('urn:ietf:params:oauth:client-assertion-type:jwt-bearer', client_assertion)`](../apidocs/@line/namespaces/channelAccessToken/classes/ChannelAccessTokenClient.md#getsallvalidchannelaccesstokenkeyids) | Renamed. `client_assertion_type` is now an explicit argument. Response shape changed: `key_ids` → `kids`. |
+| `revokeChannelAccessTokenV2_1(client_id, client_secret, access_token)` | [`revokeChannelTokenByJWT(client_id, client_secret, access_token)`](../apidocs/@line/namespaces/channelAccessToken/classes/ChannelAccessTokenClient.md#revokechanneltokenbyjwt) | Renamed. |
 
 ---
 
@@ -292,184 +292,184 @@ Most types in `lib/types.ts` are deprecated. Use the generated types from the
 sub-namespaces exported by `@line/bot-sdk`.
 
 > **Note:** A few helper types in `lib/types.ts` are still used by the current
-> generated clients and are **not** deprecated: `ApiResponseType<T>`,
-> `MessageAPIResponseBase`, `LINE_REQUEST_ID_HTTP_HEADER_NAME`,
-> `LINE_SIGNATURE_HTTP_HEADER_NAME`, and `MiddlewareConfig`.
+> generated clients and are **not** deprecated: [`ApiResponseType<T>`](../apidocs/interfaces/ApiResponseType.md),
+> [`MessageAPIResponseBase`](../apidocs/type-aliases/MessageAPIResponseBase.md), `LINE_REQUEST_ID_HTTP_HEADER_NAME`,
+> `LINE_SIGNATURE_HTTP_HEADER_NAME`, and [`MiddlewareConfig`](../apidocs/interfaces/MiddlewareConfig.md).
 
 ### Config types
 
 | Old type | New type | Notes |
 |---|---|---|
-| `Config` | _(no single replacement)_ | Split: use `LineBotClientChannelAccessTokenConfig` for client (`channelAccessToken`) and `MiddlewareConfig` for middleware (`channelSecret`). |
-| `ClientConfig` | `LineBotClientChannelAccessTokenConfig` | From `@line/bot-sdk` |
-| `MiddlewareConfig` | `MiddlewareConfig` | Unchanged. No longer extends `Config`; only `channelSecret` is needed. |
+| `Config` | _(no single replacement)_ | Split: use [`LineBotClientChannelAccessTokenConfig`](../apidocs/interfaces/LineBotClientChannelAccessTokenConfig.md) for client (`channelAccessToken`) and [`MiddlewareConfig`](../apidocs/interfaces/MiddlewareConfig.md) for middleware (`channelSecret`). |
+| `ClientConfig` | [`LineBotClientChannelAccessTokenConfig`](../apidocs/interfaces/LineBotClientChannelAccessTokenConfig.md) | From `@line/bot-sdk` |
+| [`MiddlewareConfig`](../apidocs/interfaces/MiddlewareConfig.md) | [`MiddlewareConfig`](../apidocs/interfaces/MiddlewareConfig.md) | Unchanged. No longer extends `Config`; only `channelSecret` is needed. |
 
 ### Webhook event types
 
 | Old type | New type | Notes |
 |---|---|---|
-| `WebhookRequestBody` | `webhook.CallbackRequest` | From `@line/bot-sdk` |
-| `WebhookEvent` | `webhook.Event` | From `@line/bot-sdk` |
-| `EventBase` | `webhook.EventBase` | From `@line/bot-sdk` |
-| `ReplyableEvent` | _(no direct equivalent)_ | In the new API, `replyToken` is included directly in each replyable event type (e.g. `webhook.MessageEvent`). |
-| `EventSource` | `webhook.Source` | From `@line/bot-sdk` |
-| `User` _(source)_ | `webhook.UserSource` | From `@line/bot-sdk` |
-| `Group` _(source)_ | `webhook.GroupSource` | From `@line/bot-sdk` |
-| `Room` _(source)_ | `webhook.RoomSource` | From `@line/bot-sdk` |
-| `DeliveryContext` | `webhook.DeliveryContext` | From `@line/bot-sdk` |
-| `MessageEvent` | `webhook.MessageEvent` | From `@line/bot-sdk` |
-| `UnsendEvent` | `webhook.UnsendEvent` | From `@line/bot-sdk` |
-| `FollowEvent` | `webhook.FollowEvent` | From `@line/bot-sdk` |
-| `UnfollowEvent` | `webhook.UnfollowEvent` | From `@line/bot-sdk` |
-| `JoinEvent` | `webhook.JoinEvent` | From `@line/bot-sdk` |
-| `LeaveEvent` | `webhook.LeaveEvent` | From `@line/bot-sdk` |
-| `MemberJoinEvent` | `webhook.MemberJoinedEvent` | Renamed (added `d`). |
-| `MemberLeaveEvent` | `webhook.MemberLeftEvent` | Renamed. |
-| `PostbackEvent` | `webhook.PostbackEvent` | From `@line/bot-sdk` |
-| `VideoPlayCompleteEvent` | `webhook.VideoPlayCompleteEvent` | From `@line/bot-sdk` |
-| `BeaconEvent` | `webhook.BeaconEvent` | From `@line/bot-sdk` |
-| `AccountLinkEvent` | `webhook.AccountLinkEvent` | From `@line/bot-sdk` |
-| `DeliveryEvent` | `webhook.PnpDeliveryCompletionEvent` | Renamed. |
+| `WebhookRequestBody` | [`webhook.CallbackRequest`](../apidocs/@line/namespaces/webhook/type-aliases/CallbackRequest.md) | From `@line/bot-sdk` |
+| `WebhookEvent` | [`webhook.Event`](../apidocs/@line/namespaces/webhook/type-aliases/Event.md) | From `@line/bot-sdk` |
+| `EventBase` | [`webhook.EventBase`](../apidocs/@line/namespaces/webhook/type-aliases/EventBase.md) | From `@line/bot-sdk` |
+| `ReplyableEvent` | _(no direct equivalent)_ | In the new API, `replyToken` is included directly in each replyable event type (e.g. [`webhook.MessageEvent`](../apidocs/@line/namespaces/webhook/type-aliases/MessageEvent.md)). |
+| `EventSource` | [`webhook.Source`](../apidocs/@line/namespaces/webhook/type-aliases/Source.md) | From `@line/bot-sdk` |
+| `User` _(source)_ | [`webhook.UserSource`](../apidocs/@line/namespaces/webhook/type-aliases/UserSource.md) | From `@line/bot-sdk` |
+| `Group` _(source)_ | [`webhook.GroupSource`](../apidocs/@line/namespaces/webhook/type-aliases/GroupSource.md) | From `@line/bot-sdk` |
+| `Room` _(source)_ | [`webhook.RoomSource`](../apidocs/@line/namespaces/webhook/type-aliases/RoomSource.md) | From `@line/bot-sdk` |
+| `DeliveryContext` | [`webhook.DeliveryContext`](../apidocs/@line/namespaces/webhook/type-aliases/DeliveryContext.md) | From `@line/bot-sdk` |
+| `MessageEvent` | [`webhook.MessageEvent`](../apidocs/@line/namespaces/webhook/type-aliases/MessageEvent.md) | From `@line/bot-sdk` |
+| `UnsendEvent` | [`webhook.UnsendEvent`](../apidocs/@line/namespaces/webhook/type-aliases/UnsendEvent.md) | From `@line/bot-sdk` |
+| `FollowEvent` | [`webhook.FollowEvent`](../apidocs/@line/namespaces/webhook/type-aliases/FollowEvent.md) | From `@line/bot-sdk` |
+| `UnfollowEvent` | [`webhook.UnfollowEvent`](../apidocs/@line/namespaces/webhook/type-aliases/UnfollowEvent.md) | From `@line/bot-sdk` |
+| `JoinEvent` | [`webhook.JoinEvent`](../apidocs/@line/namespaces/webhook/type-aliases/JoinEvent.md) | From `@line/bot-sdk` |
+| `LeaveEvent` | [`webhook.LeaveEvent`](../apidocs/@line/namespaces/webhook/type-aliases/LeaveEvent.md) | From `@line/bot-sdk` |
+| `MemberJoinEvent` | [`webhook.MemberJoinedEvent`](../apidocs/@line/namespaces/webhook/type-aliases/MemberJoinedEvent.md) | Renamed (added `d`). |
+| `MemberLeaveEvent` | [`webhook.MemberLeftEvent`](../apidocs/@line/namespaces/webhook/type-aliases/MemberLeftEvent.md) | Renamed. |
+| `PostbackEvent` | [`webhook.PostbackEvent`](../apidocs/@line/namespaces/webhook/type-aliases/PostbackEvent.md) | From `@line/bot-sdk` |
+| `VideoPlayCompleteEvent` | [`webhook.VideoPlayCompleteEvent`](../apidocs/@line/namespaces/webhook/type-aliases/VideoPlayCompleteEvent.md) | From `@line/bot-sdk` |
+| `BeaconEvent` | [`webhook.BeaconEvent`](../apidocs/@line/namespaces/webhook/type-aliases/BeaconEvent.md) | From `@line/bot-sdk` |
+| `AccountLinkEvent` | [`webhook.AccountLinkEvent`](../apidocs/@line/namespaces/webhook/type-aliases/AccountLinkEvent.md) | From `@line/bot-sdk` |
+| `DeliveryEvent` | [`webhook.PnpDeliveryCompletionEvent`](../apidocs/@line/namespaces/webhook/type-aliases/PnpDeliveryCompletionEvent.md) | Renamed. |
 
 ### Webhook message content types
 
 | Old type | New type | Notes |
 |---|---|---|
-| `EventMessage` | `webhook.MessageContent` | Renamed. |
-| `EventMessageBase` | `webhook.MessageContentBase` | Renamed. |
-| `TextEventMessage` | `webhook.TextMessageContent` | Renamed. |
-| `ImageEventMessage` | `webhook.ImageMessageContent` | Renamed. |
-| `VideoEventMessage` | `webhook.VideoMessageContent` | Renamed. |
-| `AudioEventMessage` | `webhook.AudioMessageContent` | Renamed. |
-| `FileEventMessage` | `webhook.FileMessageContent` | Renamed. |
-| `LocationEventMessage` | `webhook.LocationMessageContent` | Renamed. |
-| `StickerEventMessage` | `webhook.StickerMessageContent` | Renamed. |
-| `ContentProvider` | `webhook.ContentProvider` | From `@line/bot-sdk` |
-| `Postback` | `webhook.PostbackContent` | Renamed. |
+| `EventMessage` | [`webhook.MessageContent`](../apidocs/@line/namespaces/webhook/type-aliases/MessageContent.md) | Renamed. |
+| `EventMessageBase` | [`webhook.MessageContentBase`](../apidocs/@line/namespaces/webhook/type-aliases/MessageContentBase.md) | Renamed. |
+| `TextEventMessage` | [`webhook.TextMessageContent`](../apidocs/@line/namespaces/webhook/type-aliases/TextMessageContent.md) | Renamed. |
+| `ImageEventMessage` | [`webhook.ImageMessageContent`](../apidocs/@line/namespaces/webhook/type-aliases/ImageMessageContent.md) | Renamed. |
+| `VideoEventMessage` | [`webhook.VideoMessageContent`](../apidocs/@line/namespaces/webhook/type-aliases/VideoMessageContent.md) | Renamed. |
+| `AudioEventMessage` | [`webhook.AudioMessageContent`](../apidocs/@line/namespaces/webhook/type-aliases/AudioMessageContent.md) | Renamed. |
+| `FileEventMessage` | [`webhook.FileMessageContent`](../apidocs/@line/namespaces/webhook/type-aliases/FileMessageContent.md) | Renamed. |
+| `LocationEventMessage` | [`webhook.LocationMessageContent`](../apidocs/@line/namespaces/webhook/type-aliases/LocationMessageContent.md) | Renamed. |
+| `StickerEventMessage` | [`webhook.StickerMessageContent`](../apidocs/@line/namespaces/webhook/type-aliases/StickerMessageContent.md) | Renamed. |
+| `ContentProvider` | [`webhook.ContentProvider`](../apidocs/@line/namespaces/webhook/type-aliases/ContentProvider.md) | From `@line/bot-sdk` |
+| `Postback` | [`webhook.PostbackContent`](../apidocs/@line/namespaces/webhook/type-aliases/PostbackContent.md) | Renamed. |
 
 ### Outbound message types
 
 | Old type | New type | Notes |
 |---|---|---|
-| `MessageCommon` | `messagingApi.MessageBase` | Renamed. |
-| `Message` | `messagingApi.Message` | From `@line/bot-sdk` |
-| `TextMessage` | `messagingApi.TextMessage` | From `@line/bot-sdk` |
-| `ImageMessage` | `messagingApi.ImageMessage` | From `@line/bot-sdk` |
-| `VideoMessage` | `messagingApi.VideoMessage` | From `@line/bot-sdk` |
-| `AudioMessage` | `messagingApi.AudioMessage` | From `@line/bot-sdk` |
-| `LocationMessage` | `messagingApi.LocationMessage` | From `@line/bot-sdk` |
-| `StickerMessage` | `messagingApi.StickerMessage` | From `@line/bot-sdk` |
-| `ImageMapMessage` | `messagingApi.ImagemapMessage` | Renamed (lowercase `m`). |
-| `TemplateMessage` | `messagingApi.TemplateMessage` | From `@line/bot-sdk` |
-| `FlexMessage` | `messagingApi.FlexMessage` | From `@line/bot-sdk` |
-| `ImageMapAction` | `messagingApi.ImagemapAction` | Renamed (lowercase `m`). |
-| `ImageMapActionBase` | `messagingApi.ImagemapActionBase` | Renamed (lowercase `m`). |
-| `ImageMapURIAction` | `messagingApi.URIImagemapAction` | Renamed. |
-| `ImageMapMessageAction` | `messagingApi.MessageImagemapAction` | Renamed. |
-| `Area` | `messagingApi.ImagemapArea` | Renamed. |
+| `MessageCommon` | [`messagingApi.MessageBase`](../apidocs/@line/namespaces/messagingApi/type-aliases/MessageBase.md) | Renamed. |
+| `Message` | [`messagingApi.Message`](../apidocs/@line/namespaces/messagingApi/type-aliases/Message.md) | From `@line/bot-sdk` |
+| `TextMessage` | [`messagingApi.TextMessage`](../apidocs/@line/namespaces/messagingApi/type-aliases/TextMessage.md) | From `@line/bot-sdk` |
+| `ImageMessage` | [`messagingApi.ImageMessage`](../apidocs/@line/namespaces/messagingApi/type-aliases/ImageMessage.md) | From `@line/bot-sdk` |
+| `VideoMessage` | [`messagingApi.VideoMessage`](../apidocs/@line/namespaces/messagingApi/type-aliases/VideoMessage.md) | From `@line/bot-sdk` |
+| `AudioMessage` | [`messagingApi.AudioMessage`](../apidocs/@line/namespaces/messagingApi/type-aliases/AudioMessage.md) | From `@line/bot-sdk` |
+| `LocationMessage` | [`messagingApi.LocationMessage`](../apidocs/@line/namespaces/messagingApi/type-aliases/LocationMessage.md) | From `@line/bot-sdk` |
+| `StickerMessage` | [`messagingApi.StickerMessage`](../apidocs/@line/namespaces/messagingApi/type-aliases/StickerMessage.md) | From `@line/bot-sdk` |
+| `ImageMapMessage` | [`messagingApi.ImagemapMessage`](../apidocs/@line/namespaces/messagingApi/type-aliases/ImagemapMessage.md) | Renamed (lowercase `m`). |
+| `TemplateMessage` | [`messagingApi.TemplateMessage`](../apidocs/@line/namespaces/messagingApi/type-aliases/TemplateMessage.md) | From `@line/bot-sdk` |
+| `FlexMessage` | [`messagingApi.FlexMessage`](../apidocs/@line/namespaces/messagingApi/type-aliases/FlexMessage.md) | From `@line/bot-sdk` |
+| `ImageMapAction` | [`messagingApi.ImagemapAction`](../apidocs/@line/namespaces/messagingApi/type-aliases/ImagemapAction.md) | Renamed (lowercase `m`). |
+| `ImageMapActionBase` | [`messagingApi.ImagemapActionBase`](../apidocs/@line/namespaces/messagingApi/type-aliases/ImagemapActionBase.md) | Renamed (lowercase `m`). |
+| `ImageMapURIAction` | [`messagingApi.URIImagemapAction`](../apidocs/@line/namespaces/messagingApi/type-aliases/URIImagemapAction.md) | Renamed. |
+| `ImageMapMessageAction` | [`messagingApi.MessageImagemapAction`](../apidocs/@line/namespaces/messagingApi/type-aliases/MessageImagemapAction.md) | Renamed. |
+| `Area` | [`messagingApi.ImagemapArea`](../apidocs/@line/namespaces/messagingApi/type-aliases/ImagemapArea.md) | Renamed. |
 
 ### Flex types
 
 | Old type | New type | Notes |
 |---|---|---|
-| `FlexContainer` | `messagingApi.FlexContainer` | From `@line/bot-sdk` |
-| `FlexBubble` | `messagingApi.FlexBubble` | From `@line/bot-sdk` |
-| `FlexBubbleStyle` | `messagingApi.FlexBubbleStyles` | Renamed (added `s`). |
-| `FlexBlockStyle` | `messagingApi.FlexBlockStyle` | From `@line/bot-sdk` |
-| `FlexCarousel` | `messagingApi.FlexCarousel` | From `@line/bot-sdk` |
-| `FlexComponent` | `messagingApi.FlexComponent` | From `@line/bot-sdk` |
-| `FlexBox` | `messagingApi.FlexBox` | From `@line/bot-sdk` |
-| `Offset` | _(no direct equivalent)_ | Fields (`position`, `offsetTop`, `offsetBottom`, `offsetStart`, `offsetEnd`) are now inlined into each Flex component type (e.g. `messagingApi.FlexBox`). `messagingApi.FlexOffset` is an unrelated string union for sizing keywords. |
-| `Background` | `messagingApi.FlexBoxBackground` | Renamed. |
-| `FlexButton` | `messagingApi.FlexButton` | From `@line/bot-sdk` |
-| `FlexFiller` | `messagingApi.FlexFiller` | From `@line/bot-sdk` |
-| `FlexIcon` | `messagingApi.FlexIcon` | From `@line/bot-sdk` |
-| `FlexImage` | `messagingApi.FlexImage` | From `@line/bot-sdk` |
-| `FlexVideo` | `messagingApi.FlexVideo` | From `@line/bot-sdk` |
-| `FlexSeparator` | `messagingApi.FlexSeparator` | From `@line/bot-sdk` |
-| `FlexText` | `messagingApi.FlexText` | From `@line/bot-sdk` |
-| `FlexSpacer` | _(removed)_ | Not part of `messagingApi.FlexComponent` in the new API. Use `messagingApi.FlexFiller` or box padding instead. |
-| `FlexSpan` | `messagingApi.FlexSpan` | From `@line/bot-sdk` |
+| `FlexContainer` | [`messagingApi.FlexContainer`](../apidocs/@line/namespaces/messagingApi/type-aliases/FlexContainer.md) | From `@line/bot-sdk` |
+| `FlexBubble` | [`messagingApi.FlexBubble`](../apidocs/@line/namespaces/messagingApi/type-aliases/FlexBubble.md) | From `@line/bot-sdk` |
+| `FlexBubbleStyle` | [`messagingApi.FlexBubbleStyles`](../apidocs/@line/namespaces/messagingApi/type-aliases/FlexBubbleStyles.md) | Renamed (added `s`). |
+| `FlexBlockStyle` | [`messagingApi.FlexBlockStyle`](../apidocs/@line/namespaces/messagingApi/type-aliases/FlexBlockStyle.md) | From `@line/bot-sdk` |
+| `FlexCarousel` | [`messagingApi.FlexCarousel`](../apidocs/@line/namespaces/messagingApi/type-aliases/FlexCarousel.md) | From `@line/bot-sdk` |
+| `FlexComponent` | [`messagingApi.FlexComponent`](../apidocs/@line/namespaces/messagingApi/type-aliases/FlexComponent.md) | From `@line/bot-sdk` |
+| `FlexBox` | [`messagingApi.FlexBox`](../apidocs/@line/namespaces/messagingApi/type-aliases/FlexBox.md) | From `@line/bot-sdk` |
+| `Offset` | _(no direct equivalent)_ | Fields (`position`, `offsetTop`, `offsetBottom`, `offsetStart`, `offsetEnd`) are now inlined into each Flex component type (e.g. [`messagingApi.FlexBox`](../apidocs/@line/namespaces/messagingApi/type-aliases/FlexBox.md)). [`messagingApi.FlexOffset`](../apidocs/@line/namespaces/messagingApi/type-aliases/FlexOffset.md) is an unrelated string union for sizing keywords. |
+| `Background` | [`messagingApi.FlexBoxBackground`](../apidocs/@line/namespaces/messagingApi/type-aliases/FlexBoxBackground.md) | Renamed. |
+| `FlexButton` | [`messagingApi.FlexButton`](../apidocs/@line/namespaces/messagingApi/type-aliases/FlexButton.md) | From `@line/bot-sdk` |
+| `FlexFiller` | [`messagingApi.FlexFiller`](../apidocs/@line/namespaces/messagingApi/type-aliases/FlexFiller.md) | From `@line/bot-sdk` |
+| `FlexIcon` | [`messagingApi.FlexIcon`](../apidocs/@line/namespaces/messagingApi/type-aliases/FlexIcon.md) | From `@line/bot-sdk` |
+| `FlexImage` | [`messagingApi.FlexImage`](../apidocs/@line/namespaces/messagingApi/type-aliases/FlexImage.md) | From `@line/bot-sdk` |
+| `FlexVideo` | [`messagingApi.FlexVideo`](../apidocs/@line/namespaces/messagingApi/type-aliases/FlexVideo.md) | From `@line/bot-sdk` |
+| `FlexSeparator` | [`messagingApi.FlexSeparator`](../apidocs/@line/namespaces/messagingApi/type-aliases/FlexSeparator.md) | From `@line/bot-sdk` |
+| `FlexText` | [`messagingApi.FlexText`](../apidocs/@line/namespaces/messagingApi/type-aliases/FlexText.md) | From `@line/bot-sdk` |
+| `FlexSpacer` | _(removed)_ | Not part of [`messagingApi.FlexComponent`](../apidocs/@line/namespaces/messagingApi/type-aliases/FlexComponent.md) in the new API. Use [`messagingApi.FlexFiller`](../apidocs/@line/namespaces/messagingApi/type-aliases/FlexFiller.md) or box padding instead. |
+| `FlexSpan` | [`messagingApi.FlexSpan`](../apidocs/@line/namespaces/messagingApi/type-aliases/FlexSpan.md) | From `@line/bot-sdk` |
 
 ### Template types
 
 | Old type | New type | Notes |
 |---|---|---|
-| `TemplateContent` | `messagingApi.Template` | Renamed. |
-| `TemplateButtons` | `messagingApi.ButtonsTemplate` | Renamed. |
-| `TemplateConfirm` | `messagingApi.ConfirmTemplate` | Renamed. |
-| `TemplateCarousel` | `messagingApi.CarouselTemplate` | Renamed. |
-| `TemplateColumn` | `messagingApi.CarouselColumn` | Renamed. |
-| `TemplateImageCarousel` | `messagingApi.ImageCarouselTemplate` | Renamed. |
-| `TemplateImageColumn` | `messagingApi.ImageCarouselColumn` | Renamed. |
+| `TemplateContent` | [`messagingApi.Template`](../apidocs/@line/namespaces/messagingApi/type-aliases/Template.md) | Renamed. |
+| `TemplateButtons` | [`messagingApi.ButtonsTemplate`](../apidocs/@line/namespaces/messagingApi/type-aliases/ButtonsTemplate.md) | Renamed. |
+| `TemplateConfirm` | [`messagingApi.ConfirmTemplate`](../apidocs/@line/namespaces/messagingApi/type-aliases/ConfirmTemplate.md) | Renamed. |
+| `TemplateCarousel` | [`messagingApi.CarouselTemplate`](../apidocs/@line/namespaces/messagingApi/type-aliases/CarouselTemplate.md) | Renamed. |
+| `TemplateColumn` | [`messagingApi.CarouselColumn`](../apidocs/@line/namespaces/messagingApi/type-aliases/CarouselColumn.md) | Renamed. |
+| `TemplateImageCarousel` | [`messagingApi.ImageCarouselTemplate`](../apidocs/@line/namespaces/messagingApi/type-aliases/ImageCarouselTemplate.md) | Renamed. |
+| `TemplateImageColumn` | [`messagingApi.ImageCarouselColumn`](../apidocs/@line/namespaces/messagingApi/type-aliases/ImageCarouselColumn.md) | Renamed. |
 
 ### Action / quick reply types
 
 | Old type | New type | Notes |
 |---|---|---|
-| `QuickReply` | `messagingApi.QuickReply` | From `@line/bot-sdk` |
-| `QuickReplyItem` | `messagingApi.QuickReplyItem` | From `@line/bot-sdk` |
-| `Sender` | `messagingApi.Sender` | From `@line/bot-sdk` |
-| `Action` | `messagingApi.Action` | From `@line/bot-sdk` |
-| `PostbackAction` | `messagingApi.PostbackAction` | From `@line/bot-sdk` |
-| `MessageAction` | `messagingApi.MessageAction` | From `@line/bot-sdk` |
-| `URIAction` | `messagingApi.URIAction` | From `@line/bot-sdk` |
-| `AltURI` | `messagingApi.AltUri` | Renamed (lowercase `ri`). |
-| `DatetimePickerAction` | `messagingApi.DatetimePickerAction` | From `@line/bot-sdk` |
-| `RichMenuSwitchAction` | `messagingApi.RichMenuSwitchAction` | From `@line/bot-sdk` |
+| `QuickReply` | [`messagingApi.QuickReply`](../apidocs/@line/namespaces/messagingApi/type-aliases/QuickReply.md) | From `@line/bot-sdk` |
+| `QuickReplyItem` | [`messagingApi.QuickReplyItem`](../apidocs/@line/namespaces/messagingApi/type-aliases/QuickReplyItem.md) | From `@line/bot-sdk` |
+| `Sender` | [`messagingApi.Sender`](../apidocs/@line/namespaces/messagingApi/type-aliases/Sender.md) | From `@line/bot-sdk` |
+| `Action` | [`messagingApi.Action`](../apidocs/@line/namespaces/messagingApi/type-aliases/Action.md) | From `@line/bot-sdk` |
+| `PostbackAction` | [`messagingApi.PostbackAction`](../apidocs/@line/namespaces/messagingApi/type-aliases/PostbackAction.md) | From `@line/bot-sdk` |
+| `MessageAction` | [`messagingApi.MessageAction`](../apidocs/@line/namespaces/messagingApi/type-aliases/MessageAction.md) | From `@line/bot-sdk` |
+| `URIAction` | [`messagingApi.URIAction`](../apidocs/@line/namespaces/messagingApi/type-aliases/URIAction.md) | From `@line/bot-sdk` |
+| `AltURI` | [`messagingApi.AltUri`](../apidocs/@line/namespaces/messagingApi/type-aliases/AltUri.md) | Renamed (lowercase `ri`). |
+| `DatetimePickerAction` | [`messagingApi.DatetimePickerAction`](../apidocs/@line/namespaces/messagingApi/type-aliases/DatetimePickerAction.md) | From `@line/bot-sdk` |
+| `RichMenuSwitchAction` | [`messagingApi.RichMenuSwitchAction`](../apidocs/@line/namespaces/messagingApi/type-aliases/RichMenuSwitchAction.md) | From `@line/bot-sdk` |
 
 ### Rich menu types
 
 | Old type | New type | Notes |
 |---|---|---|
-| `Size` | `messagingApi.RichMenuSize` | Renamed. |
-| `RichMenu` | `messagingApi.RichMenuRequest` | Renamed. |
-| `RichMenuResponse` | `messagingApi.RichMenuResponse` | From `@line/bot-sdk` |
-| `GetRichMenuAliasResponse` | `messagingApi.RichMenuAliasResponse` | Renamed. |
-| `GetRichMenuAliasListResponse` | `messagingApi.RichMenuAliasListResponse` | Renamed. |
+| `Size` | [`messagingApi.RichMenuSize`](../apidocs/@line/namespaces/messagingApi/type-aliases/RichMenuSize.md) | Renamed. |
+| `RichMenu` | [`messagingApi.RichMenuRequest`](../apidocs/@line/namespaces/messagingApi/type-aliases/RichMenuRequest.md) | Renamed. |
+| `RichMenuResponse` | [`messagingApi.RichMenuResponse`](../apidocs/@line/namespaces/messagingApi/type-aliases/RichMenuResponse.md) | From `@line/bot-sdk` |
+| `GetRichMenuAliasResponse` | [`messagingApi.RichMenuAliasResponse`](../apidocs/@line/namespaces/messagingApi/type-aliases/RichMenuAliasResponse.md) | Renamed. |
+| `GetRichMenuAliasListResponse` | [`messagingApi.RichMenuAliasListResponse`](../apidocs/@line/namespaces/messagingApi/type-aliases/RichMenuAliasListResponse.md) | Renamed. |
 
 ### Response / stats types
 
 | Old type | New type | Notes |
 |---|---|---|
-| `Profile` | `messagingApi.UserProfileResponse` | Renamed. |
-| `BotInfoResponse` | `messagingApi.BotInfoResponse` | From `@line/bot-sdk` |
-| `GroupSummaryResponse` | `messagingApi.GroupSummaryResponse` | From `@line/bot-sdk` |
-| `MembersCountResponse` | `messagingApi.GroupMemberCountResponse` or `messagingApi.RoomMemberCountResponse` | Split into two types. |
-| `WebhookEndpointInfoResponse` | `messagingApi.GetWebhookEndpointResponse` | Renamed. |
-| `TestWebhookEndpointResponse` | `messagingApi.TestWebhookEndpointResponse` | From `@line/bot-sdk` |
-| `TargetLimitForAdditionalMessages` | `messagingApi.MessageQuotaResponse` | Renamed. |
-| `NumberOfMessagesSentThisMonth` | `messagingApi.QuotaConsumptionResponse` | Renamed. |
-| `NumberOfMessagesSentResponse` | `messagingApi.NumberOfMessagesResponse` | Renamed. |
-| `NarrowcastProgressResponse` | `messagingApi.NarrowcastProgressResponse` | From `@line/bot-sdk` |
+| `Profile` | [`messagingApi.UserProfileResponse`](../apidocs/@line/namespaces/messagingApi/type-aliases/UserProfileResponse.md) | Renamed. |
+| `BotInfoResponse` | [`messagingApi.BotInfoResponse`](../apidocs/@line/namespaces/messagingApi/type-aliases/BotInfoResponse.md) | From `@line/bot-sdk` |
+| `GroupSummaryResponse` | [`messagingApi.GroupSummaryResponse`](../apidocs/@line/namespaces/messagingApi/type-aliases/GroupSummaryResponse.md) | From `@line/bot-sdk` |
+| `MembersCountResponse` | [`messagingApi.GroupMemberCountResponse`](../apidocs/@line/namespaces/messagingApi/type-aliases/GroupMemberCountResponse.md) or [`messagingApi.RoomMemberCountResponse`](../apidocs/@line/namespaces/messagingApi/type-aliases/RoomMemberCountResponse.md) | Split into two types. |
+| `WebhookEndpointInfoResponse` | [`messagingApi.GetWebhookEndpointResponse`](../apidocs/@line/namespaces/messagingApi/type-aliases/GetWebhookEndpointResponse.md) | Renamed. |
+| `TestWebhookEndpointResponse` | [`messagingApi.TestWebhookEndpointResponse`](../apidocs/@line/namespaces/messagingApi/type-aliases/TestWebhookEndpointResponse.md) | From `@line/bot-sdk` |
+| `TargetLimitForAdditionalMessages` | [`messagingApi.MessageQuotaResponse`](../apidocs/@line/namespaces/messagingApi/type-aliases/MessageQuotaResponse.md) | Renamed. |
+| `NumberOfMessagesSentThisMonth` | [`messagingApi.QuotaConsumptionResponse`](../apidocs/@line/namespaces/messagingApi/type-aliases/QuotaConsumptionResponse.md) | Renamed. |
+| `NumberOfMessagesSentResponse` | [`messagingApi.NumberOfMessagesResponse`](../apidocs/@line/namespaces/messagingApi/type-aliases/NumberOfMessagesResponse.md) | Renamed. |
+| `NarrowcastProgressResponse` | [`messagingApi.NarrowcastProgressResponse`](../apidocs/@line/namespaces/messagingApi/type-aliases/NarrowcastProgressResponse.md) | From `@line/bot-sdk` |
 
 ### Insight types
 
 | Old type | New type | Notes |
 |---|---|---|
-| `NumberOfMessageDeliveries` | `insight.GetNumberOfMessageDeliveriesResponse` | Renamed. |
-| `NumberOfFollowers` | `insight.GetNumberOfFollowersResponse` | Renamed. |
-| `NumberOfMessageDeliveriesResponse` | `insight.GetNumberOfMessageDeliveriesResponse` | Renamed. |
-| `NumberOfFollowersResponse` | `insight.GetNumberOfFollowersResponse` | Renamed. |
-| `FriendDemographics` | `insight.GetFriendsDemographicsResponse` | Renamed. |
-| `UserInteractionStatistics` | `insight.GetMessageEventResponse` | Renamed. |
+| `NumberOfMessageDeliveries` | [`insight.GetNumberOfMessageDeliveriesResponse`](../apidocs/@line/namespaces/insight/type-aliases/GetNumberOfMessageDeliveriesResponse.md) | Renamed. |
+| `NumberOfFollowers` | [`insight.GetNumberOfFollowersResponse`](../apidocs/@line/namespaces/insight/type-aliases/GetNumberOfFollowersResponse.md) | Renamed. |
+| `NumberOfMessageDeliveriesResponse` | [`insight.GetNumberOfMessageDeliveriesResponse`](../apidocs/@line/namespaces/insight/type-aliases/GetNumberOfMessageDeliveriesResponse.md) | Renamed. |
+| `NumberOfFollowersResponse` | [`insight.GetNumberOfFollowersResponse`](../apidocs/@line/namespaces/insight/type-aliases/GetNumberOfFollowersResponse.md) | Renamed. |
+| `FriendDemographics` | [`insight.GetFriendsDemographicsResponse`](../apidocs/@line/namespaces/insight/type-aliases/GetFriendsDemographicsResponse.md) | Renamed. |
+| `UserInteractionStatistics` | [`insight.GetMessageEventResponse`](../apidocs/@line/namespaces/insight/type-aliases/GetMessageEventResponse.md) | Renamed. |
 | `InsightStatisticsResponse` | _(no direct equivalent)_ | Shared base type. In the new API, the `status` field is inlined into each concrete response type. |
-| `StatisticsPerUnit` | `insight.GetStatisticsPerUnitResponse` | Renamed. |
+| `StatisticsPerUnit` | [`insight.GetStatisticsPerUnitResponse`](../apidocs/@line/namespaces/insight/type-aliases/GetStatisticsPerUnitResponse.md) | Renamed. |
 
 ### Narrowcast types
 
 | Old type | New type | Notes |
 |---|---|---|
-| `ReceieptObject` | `messagingApi.Recipient` | Renamed (also fixes typo). Union structure differs: old type used `FilterOperatorObject` wrappers; new type includes `OperatorRecipient` as a direct variant. |
-| `DemographicFilterObject` | `messagingApi.DemographicFilter` | Union structure differs: old type used `FilterOperatorObject` wrappers; new type includes `OperatorDemographicFilter` as a direct variant. |
+| `ReceieptObject` | [`messagingApi.Recipient`](../apidocs/@line/namespaces/messagingApi/type-aliases/Recipient.md) | Renamed (also fixes typo). Union structure differs: old type used `FilterOperatorObject` wrappers; new type includes `OperatorRecipient` as a direct variant. |
+| `DemographicFilterObject` | [`messagingApi.DemographicFilter`](../apidocs/@line/namespaces/messagingApi/type-aliases/DemographicFilter.md) | Union structure differs: old type used `FilterOperatorObject` wrappers; new type includes `OperatorDemographicFilter` as a direct variant. |
 
 ### Audience types
 
 | Old type | New type | Notes |
 |---|---|---|
-| `AudienceGroupStatus` | `manageAudience.AudienceGroupStatus` | From `@line/bot-sdk` |
-| `AudienceGroupCreateRoute` | `manageAudience.AudienceGroupCreateRoute` | From `@line/bot-sdk` |
-| `AudienceGroup` | `manageAudience.AudienceGroup` | From `@line/bot-sdk` |
+| `AudienceGroupStatus` | [`manageAudience.AudienceGroupStatus`](../apidocs/@line/namespaces/manageAudience/type-aliases/AudienceGroupStatus.md) | From `@line/bot-sdk` |
+| `AudienceGroupCreateRoute` | [`manageAudience.AudienceGroupCreateRoute`](../apidocs/@line/namespaces/manageAudience/type-aliases/AudienceGroupCreateRoute.md) | From `@line/bot-sdk` |
+| `AudienceGroup` | [`manageAudience.AudienceGroup`](../apidocs/@line/namespaces/manageAudience/type-aliases/AudienceGroup.md) | From `@line/bot-sdk` |
 | `AudienceGroups` | `manageAudience.AudienceGroup[]` | No longer a named type. |
 | `AudienceGroupAuthorityLevel` | deleted | No equivalent in current API. |
 
@@ -478,7 +478,7 @@ sub-namespaces exported by `@line/bot-sdk`.
 | Old type | New type | Notes |
 |---|---|---|
 | `ChannelAccessToken` | No single equivalent. See below. | Shape depends on which method was called. |
-| `VerifyAccessToken` | `channelAccessToken.VerifyChannelAccessTokenResponse` | Renamed. |
+| `VerifyAccessToken` | [`channelAccessToken.VerifyChannelAccessTokenResponse`](../apidocs/@line/namespaces/channelAccessToken/type-aliases/VerifyChannelAccessTokenResponse.md) | Renamed. |
 | `VerifyIDToken` | deleted | No direct equivalent. |
 
 > **`ChannelAccessToken` has no single replacement.**
@@ -494,8 +494,8 @@ sub-namespaces exported by `@line/bot-sdk`.
 
 | Old class | New class | Notes |
 |---|---|---|
-| `HTTPError` | `HTTPFetchError` | Different properties; see [error handling](#error-handling). |
+| `HTTPError` | [`HTTPFetchError`](../apidocs/classes/HTTPFetchError.md) | Different properties; see [error handling](#error-handling). |
 | `RequestError` | _(no equivalent)_ | Axios network/connection error. `LineBotClient` does not wrap these; native `fetch()` throws a `TypeError` instead. |
 | `ReadError` | _(no equivalent)_ | Axios read error. `LineBotClient` does not wrap these; native `fetch()` errors propagate unwrapped. |
-| `SignatureValidationFailed` | `SignatureValidationFailed` | Unchanged. |
-| `JSONParseError` | `JSONParseError` | Unchanged. |
+| [`SignatureValidationFailed`](../apidocs/classes/SignatureValidationFailed.md) | [`SignatureValidationFailed`](../apidocs/classes/SignatureValidationFailed.md) | Unchanged. |
+| [`JSONParseError`](../apidocs/classes/JSONParseError.md) | [`JSONParseError`](../apidocs/classes/JSONParseError.md) | Unchanged. |

--- a/docs/guide/typescript.md
+++ b/docs/guide/typescript.md
@@ -21,6 +21,8 @@ const config = {
 const c = LineBotClient.fromChannelAccessToken(config) // will throw a compile error
 ```
 
+> See the [`LineBotClient`](../apidocs/classes/LineBotClient.md) API reference for the full list of available methods.
+
 Also, when building a complex message object, you can make use of types for
 its fields.
 

--- a/docs/guide/webhook.md
+++ b/docs/guide/webhook.md
@@ -15,7 +15,7 @@ of the official document.
 **Signature validation** is checking if a request is actually sent from real
 LINE servers, not a fraud. The validation is conducted by checking
 the [X-Line-Signature](https://developers.line.biz/en/reference/messaging-api/#signature-validation) header
-and request body. There is a [`validateSignature()`](../apidocs/globals.html#validatesignature)
+and request body. There is a [`validateSignature()`](../apidocs/functions/validateSignature.md)
 function to do this.
 
 **Webhook event object parsing** is literally parsing webhook event objects,
@@ -23,7 +23,7 @@ which contains information of each webhook event. The objects are provided as
 request body in JSON format, so any body parser will work here.
 
 There is a function to generate a [connect](https://github.com/senchalabs/connect) middleware,
-[`middleware()`](https://github.com/line/line-bot-sdk-nodejs/blob/master/lib/middleware.ts), to conduct both of them. If
+[`middleware()`](../apidocs/functions/middleware.md), to conduct both of them. If
 your server can make use of connect middlewares, such as [Express](https://expressjs.com/),
 using the middleware is a recommended way to build a webhook server.
 
@@ -100,17 +100,17 @@ However, there are environments where `req.body` is pre-parsed, such as
 [Firebase Cloud Functions](https://firebase.google.com/docs/functions/http-events).
 If it parses the body into string or buffer, the middleware will use the body
 as it is and work just fine. If the pre-parsed body is an object, the webhook
-middleware will fail to work. In the case, please use [`validateSignature()`](../apidocs/globals.html#validatesignature)
+middleware will fail to work. In the case, please use [`validateSignature()`](../apidocs/functions/validateSignature.md)
 manually with raw body.
 
 ## Error handling
 
-There are two types of errors thrown by the middleware, one is `SignatureValidationFailed`
-and the other is `JSONParseError`.
+There are two types of errors thrown by the middleware, one is [`SignatureValidationFailed`](../apidocs/classes/SignatureValidationFailed.md)
+and the other is [`JSONParseError`](../apidocs/classes/JSONParseError.md).
 
-- `SignatureValidationFailed` is thrown when a request doesn't have a signature.
-- `SignatureValidationFailed` is thrown when a request has a wrong signature.
-- `JSONParseError` occurs when a request body cannot be parsed as JSON.
+- [`SignatureValidationFailed`](../apidocs/classes/SignatureValidationFailed.md) is thrown when a request doesn't have a signature.
+- [`SignatureValidationFailed`](../apidocs/classes/SignatureValidationFailed.md) is thrown when a request has a wrong signature.
+- [`JSONParseError`](../apidocs/classes/JSONParseError.md) occurs when a request body cannot be parsed as JSON.
 
 For type references of the errors, please refer to [the API reference](../apidocs/globals.md).
 


### PR DESCRIPTION
Currently `code` is written in document, it's highlighted but there is no link, so when we click it, nothing happens.
This change add more urls to document site to resolve this. If md file doesn't exist, building document in test job will fail so there is no link error in this patch.

You can check this patch in your local with `npm run apidocs && npm run docs`.
