### PR TITLE
Prevent path traversal

### DIFF
--- a/generator/src/main/resources/line-bot-sdk-nodejs-generator/api-single.pebble
+++ b/generator/src/main/resources/line-bot-sdk-nodejs-generator/api-single.pebble
@@ -8,7 +8,7 @@
 import { {{import.classname}} } from '{{import.filename}}.js';
 {% endfor %}
 import * as Types from "../../types.js";
-import {ensureJSON} from "../../utils.js";
+import { ensureJSON, buildPath } from "../../utils.js";
 import {Readable} from "node:stream";
 
 import HTTPFetchClient, { convertResponseToReadable, mergeHeaders } from "../../http-fetch.js";

--- a/generator/src/main/resources/line-bot-sdk-nodejs-generator/apiBody/multipart.pebble
+++ b/generator/src/main/resources/line-bot-sdk-nodejs-generator/apiBody/multipart.pebble
@@ -1,4 +1,11 @@
 {# @pebvariable name="op" type="org.openapitools.codegen.CodegenOperation" #}
+{% if op.pathParams|length > 0 -%}
+        const path = buildPath("{{ op.path }}", {
+{% for param in op.pathParams -%}
+            {{ param.paramName }}: {{ param.paramName }},
+{% endfor %}
+        });
+{% endif -%}
         const form = new FormData();
 {% for param in op.formParams -%}
         {% if param.isFile -%}
@@ -8,10 +15,7 @@
         {% endif -%}
 {% endfor %}
         const res = await this.httpClient.{{op.httpMethod|lower}}{% if op.hasFormParams %}Form{% endif %}Multipart(
-            "{{op.path}}"
-{% for param in op.pathParams -%}
-                    .replace("{{ "{" + param.paramName + "}" }}", String({{ param.paramName }}))
-{% endfor %},
+            {% if op.pathParams|length > 0 %}path{% else %}"{{ op.path }}"{% endif %},
             form,
         );
         const text = await res.text();

--- a/generator/src/main/resources/line-bot-sdk-nodejs-generator/apiBody/multipart.pebble
+++ b/generator/src/main/resources/line-bot-sdk-nodejs-generator/apiBody/multipart.pebble
@@ -1,8 +1,8 @@
 {# @pebvariable name="op" type="org.openapitools.codegen.CodegenOperation" #}
 {% if op.pathParams|length > 0 -%}
-        const path = buildPath("{{ op.path }}", {
+        const requestPath = buildPath("{{ op.path }}", {
 {% for param in op.pathParams -%}
-            {{ param.paramName }}: {{ param.paramName }},
+            "{{ param.baseName }}": {{ param.paramName }},
 {% endfor %}
         });
 {% endif -%}
@@ -15,7 +15,7 @@
         {% endif -%}
 {% endfor %}
         const res = await this.httpClient.{{op.httpMethod|lower}}{% if op.hasFormParams %}Form{% endif %}Multipart(
-            {% if op.pathParams|length > 0 %}path{% else %}"{{ op.path }}"{% endif %},
+            {% if op.pathParams|length > 0 %}requestPath{% else %}"{{ op.path }}"{% endif %},
             form,
         );
         const text = await res.text();

--- a/generator/src/main/resources/line-bot-sdk-nodejs-generator/apiBody/normal.pebble
+++ b/generator/src/main/resources/line-bot-sdk-nodejs-generator/apiBody/normal.pebble
@@ -1,16 +1,16 @@
 {# @pebvariable name="op" type="org.openapitools.codegen.CodegenOperation" #}
 
 {% if op.pathParams|length > 0 -%}
-        const path = buildPath("{{ op.path }}", {
+        const requestPath = buildPath("{{ op.path }}", {
         {% for param in op.pathParams -%}
-            {{ param.paramName }}: {{ param.paramName }},
+            "{{ param.baseName }}": {{ param.paramName }},
         {% endfor -%}
         });
 {% endif -%}
 
 {% if op.isResponseFile %}
         const response = await this.httpClient.{{op.httpMethod|lower}}(
-            {% if op.pathParams|length > 0 %}path{% else %}"{{ op.path }}"{% endif %}
+            {% if op.pathParams|length > 0 %}requestPath{% else %}"{{ op.path }}"{% endif %}
         );
         return {httpResponse: response, body: convertResponseToReadable(response)};
 {% else %}
@@ -48,7 +48,7 @@
     {% endif %}
 
         const res = await this.httpClient.{{op.httpMethod|lower}}{% if op.hasFormParams %}Form{% endif %}{% if op.isMultipart %}Multipart{% endif %}{% if op.hasBodyParam and op.bodyParam.isFile %}BinaryContent{% endif %}(
-            {% if op.pathParams|length > 0 %}path{% else %}"{{ op.path }}"{% endif %},
+            {% if op.pathParams|length > 0 %}requestPath{% else %}"{{ op.path }}"{% endif %},
             {% if op.hasBodyParam -%}
             params,
             {%- elseif op.hasFormParams -%}

--- a/generator/src/main/resources/line-bot-sdk-nodejs-generator/apiBody/normal.pebble
+++ b/generator/src/main/resources/line-bot-sdk-nodejs-generator/apiBody/normal.pebble
@@ -1,10 +1,16 @@
 {# @pebvariable name="op" type="org.openapitools.codegen.CodegenOperation" #}
 
+{% if op.pathParams|length > 0 -%}
+        const path = buildPath("{{ op.path }}", {
+        {% for param in op.pathParams -%}
+            {{ param.paramName }}: {{ param.paramName }},
+        {% endfor -%}
+        });
+{% endif -%}
+
 {% if op.isResponseFile %}
-        const response = await this.httpClient.{{op.httpMethod|lower}}("{{op.path}}"
-        {% for param in op.pathParams %}
-            .replace('{' + "{{param.baseName}}" + '}', String({{param.paramName}}))
-        {% endfor %}
+        const response = await this.httpClient.{{op.httpMethod|lower}}(
+            {% if op.pathParams|length > 0 %}path{% else %}"{{ op.path }}"{% endif %}
         );
         return {httpResponse: response, body: convertResponseToReadable(response)};
 {% else %}
@@ -42,14 +48,14 @@
     {% endif %}
 
         const res = await this.httpClient.{{op.httpMethod|lower}}{% if op.hasFormParams %}Form{% endif %}{% if op.isMultipart %}Multipart{% endif %}{% if op.hasBodyParam and op.bodyParam.isFile %}BinaryContent{% endif %}(
-            "{{ op.path }}"
-        {% for param in op.pathParams %}
-                .replace("{{ "{" + param.paramName + "}" }}", String({{ param.paramName }}))
-        {% endfor %},
-
-            {% if op.hasBodyParam %}params,
-            {% elseif op.hasFormParams %}formParams,
-            {% elseif op.hasQueryParams %}queryParams,{% endif %}
+            {% if op.pathParams|length > 0 %}path{% else %}"{{ op.path }}"{% endif %},
+            {% if op.hasBodyParam -%}
+            params,
+            {%- elseif op.hasFormParams -%}
+            formParams,
+            {%- elseif op.hasQueryParams -%}
+            queryParams,
+            {%- endif -%}
             {% if op.hasHeaderParams %}{headers: headerParams},{% endif %}
         );
         const text = await res.text();

--- a/lib/channel-access-token/api/channelAccessTokenClient.ts
+++ b/lib/channel-access-token/api/channelAccessTokenClient.ts
@@ -19,7 +19,7 @@ import { IssueStatelessChannelAccessTokenResponse } from "../model/issueStateles
 import { VerifyChannelAccessTokenResponse } from "../model/verifyChannelAccessTokenResponse.js";
 
 import * as Types from "../../types.js";
-import { ensureJSON } from "../../utils.js";
+import { ensureJSON, buildPath } from "../../utils.js";
 import { Readable } from "node:stream";
 
 import HTTPFetchClient, {

--- a/lib/insight/api/insightClient.ts
+++ b/lib/insight/api/insightClient.ts
@@ -18,7 +18,7 @@ import { GetNumberOfMessageDeliveriesResponse } from "../model/getNumberOfMessag
 import { GetStatisticsPerUnitResponse } from "../model/getStatisticsPerUnitResponse.js";
 
 import * as Types from "../../types.js";
-import { ensureJSON } from "../../utils.js";
+import { ensureJSON, buildPath } from "../../utils.js";
 import { Readable } from "node:stream";
 
 import HTTPFetchClient, {

--- a/lib/liff/api/liffClient.ts
+++ b/lib/liff/api/liffClient.ts
@@ -17,7 +17,7 @@ import { GetAllLiffAppsResponse } from "../model/getAllLiffAppsResponse.js";
 import { UpdateLiffAppRequest } from "../model/updateLiffAppRequest.js";
 
 import * as Types from "../../types.js";
-import { ensureJSON } from "../../utils.js";
+import { ensureJSON, buildPath } from "../../utils.js";
 import { Readable } from "node:stream";
 
 import HTTPFetchClient, {
@@ -108,9 +108,11 @@ export class LiffClient {
   public async deleteLIFFAppWithHttpInfo(
     liffId: string,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
-    const res = await this.httpClient.delete(
-      "/liff/v1/apps/{liffId}".replace("{liffId}", String(liffId)),
-    );
+    const path = buildPath("/liff/v1/apps/{liffId}", {
+      liffId: liffId,
+    });
+
+    const res = await this.httpClient.delete(path);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -169,12 +171,13 @@ export class LiffClient {
     liffId: string,
     updateLiffAppRequest: UpdateLiffAppRequest,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
+    const path = buildPath("/liff/v1/apps/{liffId}", {
+      liffId: liffId,
+    });
+
     const params = updateLiffAppRequest;
 
-    const res = await this.httpClient.put(
-      "/liff/v1/apps/{liffId}".replace("{liffId}", String(liffId)),
-      params,
-    );
+    const res = await this.httpClient.put(path, params);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };

--- a/lib/liff/api/liffClient.ts
+++ b/lib/liff/api/liffClient.ts
@@ -108,11 +108,11 @@ export class LiffClient {
   public async deleteLIFFAppWithHttpInfo(
     liffId: string,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
-    const path = buildPath("/liff/v1/apps/{liffId}", {
+    const requestPath = buildPath("/liff/v1/apps/{liffId}", {
       liffId: liffId,
     });
 
-    const res = await this.httpClient.delete(path);
+    const res = await this.httpClient.delete(requestPath);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -171,13 +171,13 @@ export class LiffClient {
     liffId: string,
     updateLiffAppRequest: UpdateLiffAppRequest,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
-    const path = buildPath("/liff/v1/apps/{liffId}", {
+    const requestPath = buildPath("/liff/v1/apps/{liffId}", {
       liffId: liffId,
     });
 
     const params = updateLiffAppRequest;
 
-    const res = await this.httpClient.put(path, params);
+    const res = await this.httpClient.put(requestPath, params);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };

--- a/lib/manage-audience/api/manageAudienceBlobClient.ts
+++ b/lib/manage-audience/api/manageAudienceBlobClient.ts
@@ -14,7 +14,7 @@
 import { CreateAudienceGroupResponse } from "../model/createAudienceGroupResponse.js";
 
 import * as Types from "../../types.js";
-import { ensureJSON } from "../../utils.js";
+import { ensureJSON, buildPath } from "../../utils.js";
 import { Readable } from "node:stream";
 
 import HTTPFetchClient, {

--- a/lib/manage-audience/api/manageAudienceClient.ts
+++ b/lib/manage-audience/api/manageAudienceClient.ts
@@ -225,11 +225,11 @@ export class ManageAudienceClient {
   public async deleteAudienceGroupWithHttpInfo(
     audienceGroupId: number,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
-    const path = buildPath("/v2/bot/audienceGroup/{audienceGroupId}", {
+    const requestPath = buildPath("/v2/bot/audienceGroup/{audienceGroupId}", {
       audienceGroupId: audienceGroupId,
     });
 
-    const res = await this.httpClient.delete(path);
+    const res = await this.httpClient.delete(requestPath);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -256,11 +256,11 @@ export class ManageAudienceClient {
   public async getAudienceDataWithHttpInfo(
     audienceGroupId: number,
   ): Promise<Types.ApiResponseType<GetAudienceDataResponse>> {
-    const path = buildPath("/v2/bot/audienceGroup/{audienceGroupId}", {
+    const requestPath = buildPath("/v2/bot/audienceGroup/{audienceGroupId}", {
       audienceGroupId: audienceGroupId,
     });
 
-    const res = await this.httpClient.get(path);
+    const res = await this.httpClient.get(requestPath);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -360,11 +360,14 @@ export class ManageAudienceClient {
   public async getSharedAudienceDataWithHttpInfo(
     audienceGroupId: number,
   ): Promise<Types.ApiResponseType<GetSharedAudienceDataResponse>> {
-    const path = buildPath("/v2/bot/audienceGroup/shared/{audienceGroupId}", {
-      audienceGroupId: audienceGroupId,
-    });
+    const requestPath = buildPath(
+      "/v2/bot/audienceGroup/shared/{audienceGroupId}",
+      {
+        audienceGroupId: audienceGroupId,
+      },
+    );
 
-    const res = await this.httpClient.get(path);
+    const res = await this.httpClient.get(requestPath);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -473,7 +476,7 @@ export class ManageAudienceClient {
     audienceGroupId: number,
     updateAudienceGroupDescriptionRequest: UpdateAudienceGroupDescriptionRequest,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
-    const path = buildPath(
+    const requestPath = buildPath(
       "/v2/bot/audienceGroup/{audienceGroupId}/updateDescription",
       {
         audienceGroupId: audienceGroupId,
@@ -482,7 +485,7 @@ export class ManageAudienceClient {
 
     const params = updateAudienceGroupDescriptionRequest;
 
-    const res = await this.httpClient.put(path, params);
+    const res = await this.httpClient.put(requestPath, params);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };

--- a/lib/manage-audience/api/manageAudienceClient.ts
+++ b/lib/manage-audience/api/manageAudienceClient.ts
@@ -28,7 +28,7 @@ import { GetSharedAudienceGroupsResponse } from "../model/getSharedAudienceGroup
 import { UpdateAudienceGroupDescriptionRequest } from "../model/updateAudienceGroupDescriptionRequest.js";
 
 import * as Types from "../../types.js";
-import { ensureJSON } from "../../utils.js";
+import { ensureJSON, buildPath } from "../../utils.js";
 import { Readable } from "node:stream";
 
 import HTTPFetchClient, {
@@ -225,12 +225,11 @@ export class ManageAudienceClient {
   public async deleteAudienceGroupWithHttpInfo(
     audienceGroupId: number,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
-    const res = await this.httpClient.delete(
-      "/v2/bot/audienceGroup/{audienceGroupId}".replace(
-        "{audienceGroupId}",
-        String(audienceGroupId),
-      ),
-    );
+    const path = buildPath("/v2/bot/audienceGroup/{audienceGroupId}", {
+      audienceGroupId: audienceGroupId,
+    });
+
+    const res = await this.httpClient.delete(path);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -257,12 +256,11 @@ export class ManageAudienceClient {
   public async getAudienceDataWithHttpInfo(
     audienceGroupId: number,
   ): Promise<Types.ApiResponseType<GetAudienceDataResponse>> {
-    const res = await this.httpClient.get(
-      "/v2/bot/audienceGroup/{audienceGroupId}".replace(
-        "{audienceGroupId}",
-        String(audienceGroupId),
-      ),
-    );
+    const path = buildPath("/v2/bot/audienceGroup/{audienceGroupId}", {
+      audienceGroupId: audienceGroupId,
+    });
+
+    const res = await this.httpClient.get(path);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -362,12 +360,11 @@ export class ManageAudienceClient {
   public async getSharedAudienceDataWithHttpInfo(
     audienceGroupId: number,
   ): Promise<Types.ApiResponseType<GetSharedAudienceDataResponse>> {
-    const res = await this.httpClient.get(
-      "/v2/bot/audienceGroup/shared/{audienceGroupId}".replace(
-        "{audienceGroupId}",
-        String(audienceGroupId),
-      ),
-    );
+    const path = buildPath("/v2/bot/audienceGroup/shared/{audienceGroupId}", {
+      audienceGroupId: audienceGroupId,
+    });
+
+    const res = await this.httpClient.get(path);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -476,15 +473,16 @@ export class ManageAudienceClient {
     audienceGroupId: number,
     updateAudienceGroupDescriptionRequest: UpdateAudienceGroupDescriptionRequest,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
+    const path = buildPath(
+      "/v2/bot/audienceGroup/{audienceGroupId}/updateDescription",
+      {
+        audienceGroupId: audienceGroupId,
+      },
+    );
+
     const params = updateAudienceGroupDescriptionRequest;
 
-    const res = await this.httpClient.put(
-      "/v2/bot/audienceGroup/{audienceGroupId}/updateDescription".replace(
-        "{audienceGroupId}",
-        String(audienceGroupId),
-      ),
-      params,
-    );
+    const res = await this.httpClient.put(path, params);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };

--- a/lib/messaging-api/api/messagingApiBlobClient.ts
+++ b/lib/messaging-api/api/messagingApiBlobClient.ts
@@ -14,7 +14,7 @@
 import { GetMessageContentTranscodingResponse } from "../model/getMessageContentTranscodingResponse.js";
 
 import * as Types from "../../types.js";
-import { ensureJSON } from "../../utils.js";
+import { ensureJSON, buildPath } from "../../utils.js";
 import { Readable } from "node:stream";
 
 import HTTPFetchClient, {
@@ -70,12 +70,11 @@ export class MessagingApiBlobClient {
   public async getMessageContentWithHttpInfo(
     messageId: string,
   ): Promise<Types.ApiResponseType<Readable>> {
-    const response = await this.httpClient.get(
-      "/v2/bot/message/{messageId}/content".replace(
-        "{" + "messageId" + "}",
-        String(messageId),
-      ),
-    );
+    const path = buildPath("/v2/bot/message/{messageId}/content", {
+      messageId: messageId,
+    });
+
+    const response = await this.httpClient.get(path);
     return {
       httpResponse: response,
       body: convertResponseToReadable(response),
@@ -101,12 +100,11 @@ export class MessagingApiBlobClient {
   public async getMessageContentPreviewWithHttpInfo(
     messageId: string,
   ): Promise<Types.ApiResponseType<Readable>> {
-    const response = await this.httpClient.get(
-      "/v2/bot/message/{messageId}/content/preview".replace(
-        "{" + "messageId" + "}",
-        String(messageId),
-      ),
-    );
+    const path = buildPath("/v2/bot/message/{messageId}/content/preview", {
+      messageId: messageId,
+    });
+
+    const response = await this.httpClient.get(path);
     return {
       httpResponse: response,
       body: convertResponseToReadable(response),
@@ -136,12 +134,11 @@ export class MessagingApiBlobClient {
   public async getMessageContentTranscodingByMessageIdWithHttpInfo(
     messageId: string,
   ): Promise<Types.ApiResponseType<GetMessageContentTranscodingResponse>> {
-    const res = await this.httpClient.get(
-      "/v2/bot/message/{messageId}/content/transcoding".replace(
-        "{messageId}",
-        String(messageId),
-      ),
-    );
+    const path = buildPath("/v2/bot/message/{messageId}/content/transcoding", {
+      messageId: messageId,
+    });
+
+    const res = await this.httpClient.get(path);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -166,12 +163,11 @@ export class MessagingApiBlobClient {
   public async getRichMenuImageWithHttpInfo(
     richMenuId: string,
   ): Promise<Types.ApiResponseType<Readable>> {
-    const response = await this.httpClient.get(
-      "/v2/bot/richmenu/{richMenuId}/content".replace(
-        "{" + "richMenuId" + "}",
-        String(richMenuId),
-      ),
-    );
+    const path = buildPath("/v2/bot/richmenu/{richMenuId}/content", {
+      richMenuId: richMenuId,
+    });
+
+    const response = await this.httpClient.get(path);
     return {
       httpResponse: response,
       body: convertResponseToReadable(response),
@@ -203,15 +199,13 @@ export class MessagingApiBlobClient {
     richMenuId: string,
     body: Blob,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
+    const path = buildPath("/v2/bot/richmenu/{richMenuId}/content", {
+      richMenuId: richMenuId,
+    });
+
     const params = body;
 
-    const res = await this.httpClient.postBinaryContent(
-      "/v2/bot/richmenu/{richMenuId}/content".replace(
-        "{richMenuId}",
-        String(richMenuId),
-      ),
-      params,
-    );
+    const res = await this.httpClient.postBinaryContent(path, params);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };

--- a/lib/messaging-api/api/messagingApiBlobClient.ts
+++ b/lib/messaging-api/api/messagingApiBlobClient.ts
@@ -70,11 +70,11 @@ export class MessagingApiBlobClient {
   public async getMessageContentWithHttpInfo(
     messageId: string,
   ): Promise<Types.ApiResponseType<Readable>> {
-    const path = buildPath("/v2/bot/message/{messageId}/content", {
+    const requestPath = buildPath("/v2/bot/message/{messageId}/content", {
       messageId: messageId,
     });
 
-    const response = await this.httpClient.get(path);
+    const response = await this.httpClient.get(requestPath);
     return {
       httpResponse: response,
       body: convertResponseToReadable(response),
@@ -100,11 +100,14 @@ export class MessagingApiBlobClient {
   public async getMessageContentPreviewWithHttpInfo(
     messageId: string,
   ): Promise<Types.ApiResponseType<Readable>> {
-    const path = buildPath("/v2/bot/message/{messageId}/content/preview", {
-      messageId: messageId,
-    });
+    const requestPath = buildPath(
+      "/v2/bot/message/{messageId}/content/preview",
+      {
+        messageId: messageId,
+      },
+    );
 
-    const response = await this.httpClient.get(path);
+    const response = await this.httpClient.get(requestPath);
     return {
       httpResponse: response,
       body: convertResponseToReadable(response),
@@ -134,11 +137,14 @@ export class MessagingApiBlobClient {
   public async getMessageContentTranscodingByMessageIdWithHttpInfo(
     messageId: string,
   ): Promise<Types.ApiResponseType<GetMessageContentTranscodingResponse>> {
-    const path = buildPath("/v2/bot/message/{messageId}/content/transcoding", {
-      messageId: messageId,
-    });
+    const requestPath = buildPath(
+      "/v2/bot/message/{messageId}/content/transcoding",
+      {
+        messageId: messageId,
+      },
+    );
 
-    const res = await this.httpClient.get(path);
+    const res = await this.httpClient.get(requestPath);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -163,11 +169,11 @@ export class MessagingApiBlobClient {
   public async getRichMenuImageWithHttpInfo(
     richMenuId: string,
   ): Promise<Types.ApiResponseType<Readable>> {
-    const path = buildPath("/v2/bot/richmenu/{richMenuId}/content", {
+    const requestPath = buildPath("/v2/bot/richmenu/{richMenuId}/content", {
       richMenuId: richMenuId,
     });
 
-    const response = await this.httpClient.get(path);
+    const response = await this.httpClient.get(requestPath);
     return {
       httpResponse: response,
       body: convertResponseToReadable(response),
@@ -199,13 +205,13 @@ export class MessagingApiBlobClient {
     richMenuId: string,
     body: Blob,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
-    const path = buildPath("/v2/bot/richmenu/{richMenuId}/content", {
+    const requestPath = buildPath("/v2/bot/richmenu/{richMenuId}/content", {
       richMenuId: richMenuId,
     });
 
     const params = body;
 
-    const res = await this.httpClient.postBinaryContent(path, params);
+    const res = await this.httpClient.postBinaryContent(requestPath, params);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };

--- a/lib/messaging-api/api/messagingApiClient.ts
+++ b/lib/messaging-api/api/messagingApiClient.ts
@@ -65,7 +65,7 @@ import { UserProfileResponse } from "../model/userProfileResponse.js";
 import { ValidateMessageRequest } from "../model/validateMessageRequest.js";
 
 import * as Types from "../../types.js";
-import { ensureJSON } from "../../utils.js";
+import { ensureJSON, buildPath } from "../../utils.js";
 import { Readable } from "node:stream";
 
 import HTTPFetchClient, {
@@ -137,7 +137,6 @@ export class MessagingApiClient {
     const res = await this.httpClient.post(
       "/v2/bot/message/broadcast",
       params,
-
       { headers: headerParams },
     );
     const text = await res.text();
@@ -189,9 +188,11 @@ export class MessagingApiClient {
   public async closeCouponWithHttpInfo(
     couponId: string,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
-    const res = await this.httpClient.put(
-      "/v2/bot/coupon/{couponId}/close".replace("{couponId}", String(couponId)),
-    );
+    const path = buildPath("/v2/bot/coupon/{couponId}/close", {
+      couponId: couponId,
+    });
+
+    const res = await this.httpClient.put(path);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -307,12 +308,11 @@ export class MessagingApiClient {
   public async deleteRichMenuWithHttpInfo(
     richMenuId: string,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
-    const res = await this.httpClient.delete(
-      "/v2/bot/richmenu/{richMenuId}".replace(
-        "{richMenuId}",
-        String(richMenuId),
-      ),
-    );
+    const path = buildPath("/v2/bot/richmenu/{richMenuId}", {
+      richMenuId: richMenuId,
+    });
+
+    const res = await this.httpClient.delete(path);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -339,12 +339,11 @@ export class MessagingApiClient {
   public async deleteRichMenuAliasWithHttpInfo(
     richMenuAliasId: string,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
-    const res = await this.httpClient.delete(
-      "/v2/bot/richmenu/alias/{richMenuAliasId}".replace(
-        "{richMenuAliasId}",
-        String(richMenuAliasId),
-      ),
-    );
+    const path = buildPath("/v2/bot/richmenu/alias/{richMenuAliasId}", {
+      richMenuAliasId: richMenuAliasId,
+    });
+
+    const res = await this.httpClient.delete(path);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -460,9 +459,11 @@ export class MessagingApiClient {
   public async getCouponDetailWithHttpInfo(
     couponId: string,
   ): Promise<Types.ApiResponseType<CouponResponse>> {
-    const res = await this.httpClient.get(
-      "/v2/bot/coupon/{couponId}".replace("{couponId}", String(couponId)),
-    );
+    const path = buildPath("/v2/bot/coupon/{couponId}", {
+      couponId: couponId,
+    });
+
+    const res = await this.httpClient.get(path);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -553,12 +554,11 @@ export class MessagingApiClient {
   public async getGroupMemberCountWithHttpInfo(
     groupId: string,
   ): Promise<Types.ApiResponseType<GroupMemberCountResponse>> {
-    const res = await this.httpClient.get(
-      "/v2/bot/group/{groupId}/members/count".replace(
-        "{groupId}",
-        String(groupId),
-      ),
-    );
+    const path = buildPath("/v2/bot/group/{groupId}/members/count", {
+      groupId: groupId,
+    });
+
+    const res = await this.httpClient.get(path);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -589,13 +589,12 @@ export class MessagingApiClient {
     groupId: string,
     userId: string,
   ): Promise<Types.ApiResponseType<GroupUserProfileResponse>> {
-    const res = await this.httpClient.get(
-      "/v2/bot/group/{groupId}/member/{userId}"
+    const path = buildPath("/v2/bot/group/{groupId}/member/{userId}", {
+      groupId: groupId,
+      userId: userId,
+    });
 
-        .replace("{groupId}", String(groupId))
-
-        .replace("{userId}", String(userId)),
-    );
+    const res = await this.httpClient.get(path);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -626,6 +625,10 @@ export class MessagingApiClient {
     groupId: string,
     start?: string,
   ): Promise<Types.ApiResponseType<MembersIdsResponse>> {
+    const path = buildPath("/v2/bot/group/{groupId}/members/ids", {
+      groupId: groupId,
+    });
+
     const queryParams = {
       start: start,
     };
@@ -635,13 +638,7 @@ export class MessagingApiClient {
       }
     });
 
-    const res = await this.httpClient.get(
-      "/v2/bot/group/{groupId}/members/ids".replace(
-        "{groupId}",
-        String(groupId),
-      ),
-      queryParams,
-    );
+    const res = await this.httpClient.get(path, queryParams);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -666,9 +663,11 @@ export class MessagingApiClient {
   public async getGroupSummaryWithHttpInfo(
     groupId: string,
   ): Promise<Types.ApiResponseType<GroupSummaryResponse>> {
-    const res = await this.httpClient.get(
-      "/v2/bot/group/{groupId}/summary".replace("{groupId}", String(groupId)),
-    );
+    const path = buildPath("/v2/bot/group/{groupId}/summary", {
+      groupId: groupId,
+    });
+
+    const res = await this.httpClient.get(path);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -709,6 +708,10 @@ export class MessagingApiClient {
     start?: string,
     limit?: number,
   ): Promise<Types.ApiResponseType<GetJoinedMembershipUsersResponse>> {
+    const path = buildPath("/v2/bot/membership/{membershipId}/users/ids", {
+      membershipId: membershipId,
+    });
+
     const queryParams = {
       start: start,
       limit: limit,
@@ -719,13 +722,7 @@ export class MessagingApiClient {
       }
     });
 
-    const res = await this.httpClient.get(
-      "/v2/bot/membership/{membershipId}/users/ids".replace(
-        "{membershipId}",
-        String(membershipId),
-      ),
-      queryParams,
-    );
+    const res = await this.httpClient.get(path, queryParams);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -775,12 +772,11 @@ export class MessagingApiClient {
   public async getMembershipSubscriptionWithHttpInfo(
     userId: string,
   ): Promise<Types.ApiResponseType<GetMembershipSubscriptionResponse>> {
-    const res = await this.httpClient.get(
-      "/v2/bot/membership/subscription/{userId}".replace(
-        "{userId}",
-        String(userId),
-      ),
-    );
+    const path = buildPath("/v2/bot/membership/subscription/{userId}", {
+      userId: userId,
+    });
+
+    const res = await this.httpClient.get(path);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -1085,9 +1081,11 @@ export class MessagingApiClient {
   public async getProfileWithHttpInfo(
     userId: string,
   ): Promise<Types.ApiResponseType<UserProfileResponse>> {
-    const res = await this.httpClient.get(
-      "/v2/bot/profile/{userId}".replace("{userId}", String(userId)),
-    );
+    const path = buildPath("/v2/bot/profile/{userId}", {
+      userId: userId,
+    });
+
+    const res = await this.httpClient.get(path);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -1112,12 +1110,11 @@ export class MessagingApiClient {
   public async getRichMenuWithHttpInfo(
     richMenuId: string,
   ): Promise<Types.ApiResponseType<RichMenuResponse>> {
-    const res = await this.httpClient.get(
-      "/v2/bot/richmenu/{richMenuId}".replace(
-        "{richMenuId}",
-        String(richMenuId),
-      ),
-    );
+    const path = buildPath("/v2/bot/richmenu/{richMenuId}", {
+      richMenuId: richMenuId,
+    });
+
+    const res = await this.httpClient.get(path);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -1144,12 +1141,11 @@ export class MessagingApiClient {
   public async getRichMenuAliasWithHttpInfo(
     richMenuAliasId: string,
   ): Promise<Types.ApiResponseType<RichMenuAliasResponse>> {
-    const res = await this.httpClient.get(
-      "/v2/bot/richmenu/alias/{richMenuAliasId}".replace(
-        "{richMenuAliasId}",
-        String(richMenuAliasId),
-      ),
-    );
+    const path = buildPath("/v2/bot/richmenu/alias/{richMenuAliasId}", {
+      richMenuAliasId: richMenuAliasId,
+    });
+
+    const res = await this.httpClient.get(path);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -1238,9 +1234,11 @@ export class MessagingApiClient {
   public async getRichMenuIdOfUserWithHttpInfo(
     userId: string,
   ): Promise<Types.ApiResponseType<RichMenuIdResponse>> {
-    const res = await this.httpClient.get(
-      "/v2/bot/user/{userId}/richmenu".replace("{userId}", String(userId)),
-    );
+    const path = buildPath("/v2/bot/user/{userId}/richmenu", {
+      userId: userId,
+    });
+
+    const res = await this.httpClient.get(path);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -1290,9 +1288,11 @@ export class MessagingApiClient {
   public async getRoomMemberCountWithHttpInfo(
     roomId: string,
   ): Promise<Types.ApiResponseType<RoomMemberCountResponse>> {
-    const res = await this.httpClient.get(
-      "/v2/bot/room/{roomId}/members/count".replace("{roomId}", String(roomId)),
-    );
+    const path = buildPath("/v2/bot/room/{roomId}/members/count", {
+      roomId: roomId,
+    });
+
+    const res = await this.httpClient.get(path);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -1323,13 +1323,12 @@ export class MessagingApiClient {
     roomId: string,
     userId: string,
   ): Promise<Types.ApiResponseType<RoomUserProfileResponse>> {
-    const res = await this.httpClient.get(
-      "/v2/bot/room/{roomId}/member/{userId}"
+    const path = buildPath("/v2/bot/room/{roomId}/member/{userId}", {
+      roomId: roomId,
+      userId: userId,
+    });
 
-        .replace("{roomId}", String(roomId))
-
-        .replace("{userId}", String(userId)),
-    );
+    const res = await this.httpClient.get(path);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -1360,6 +1359,10 @@ export class MessagingApiClient {
     roomId: string,
     start?: string,
   ): Promise<Types.ApiResponseType<MembersIdsResponse>> {
+    const path = buildPath("/v2/bot/room/{roomId}/members/ids", {
+      roomId: roomId,
+    });
+
     const queryParams = {
       start: start,
     };
@@ -1369,10 +1372,7 @@ export class MessagingApiClient {
       }
     });
 
-    const res = await this.httpClient.get(
-      "/v2/bot/room/{roomId}/members/ids".replace("{roomId}", String(roomId)),
-      queryParams,
-    );
+    const res = await this.httpClient.get(path, queryParams);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -1420,9 +1420,11 @@ export class MessagingApiClient {
   public async issueLinkTokenWithHttpInfo(
     userId: string,
   ): Promise<Types.ApiResponseType<IssueLinkTokenResponse>> {
-    const res = await this.httpClient.post(
-      "/v2/bot/user/{userId}/linkToken".replace("{userId}", String(userId)),
-    );
+    const path = buildPath("/v2/bot/user/{userId}/linkToken", {
+      userId: userId,
+    });
+
+    const res = await this.httpClient.post(path);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -1449,9 +1451,11 @@ export class MessagingApiClient {
   public async leaveGroupWithHttpInfo(
     groupId: string,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
-    const res = await this.httpClient.post(
-      "/v2/bot/group/{groupId}/leave".replace("{groupId}", String(groupId)),
-    );
+    const path = buildPath("/v2/bot/group/{groupId}/leave", {
+      groupId: groupId,
+    });
+
+    const res = await this.httpClient.post(path);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -1478,9 +1482,11 @@ export class MessagingApiClient {
   public async leaveRoomWithHttpInfo(
     roomId: string,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
-    const res = await this.httpClient.post(
-      "/v2/bot/room/{roomId}/leave".replace("{roomId}", String(roomId)),
-    );
+    const path = buildPath("/v2/bot/room/{roomId}/leave", {
+      roomId: roomId,
+    });
+
+    const res = await this.httpClient.post(path);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -1512,13 +1518,12 @@ export class MessagingApiClient {
     userId: string,
     richMenuId: string,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
-    const res = await this.httpClient.post(
-      "/v2/bot/user/{userId}/richmenu/{richMenuId}"
+    const path = buildPath("/v2/bot/user/{userId}/richmenu/{richMenuId}", {
+      userId: userId,
+      richMenuId: richMenuId,
+    });
 
-        .replace("{userId}", String(userId))
-
-        .replace("{richMenuId}", String(richMenuId)),
-    );
+    const res = await this.httpClient.post(path);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -1706,7 +1711,6 @@ export class MessagingApiClient {
     const res = await this.httpClient.post(
       "/v2/bot/message/multicast",
       params,
-
       { headers: headerParams },
     );
     const text = await res.text();
@@ -1749,7 +1753,6 @@ export class MessagingApiClient {
     const res = await this.httpClient.post(
       "/v2/bot/message/narrowcast",
       params,
-
       { headers: headerParams },
     );
     const text = await res.text();
@@ -1790,12 +1793,9 @@ export class MessagingApiClient {
       ...(xLineRetryKey != null ? { "X-Line-Retry-Key": xLineRetryKey } : {}),
     };
 
-    const res = await this.httpClient.post(
-      "/v2/bot/message/push",
-      params,
-
-      { headers: headerParams },
-    );
+    const res = await this.httpClient.post("/v2/bot/message/push", params, {
+      headers: headerParams,
+    });
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -1839,12 +1839,9 @@ export class MessagingApiClient {
         : {}),
     };
 
-    const res = await this.httpClient.post(
-      "/bot/pnp/push",
-      params,
-
-      { headers: headerParams },
-    );
+    const res = await this.httpClient.post("/bot/pnp/push", params, {
+      headers: headerParams,
+    });
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -1929,12 +1926,11 @@ export class MessagingApiClient {
   public async setDefaultRichMenuWithHttpInfo(
     richMenuId: string,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
-    const res = await this.httpClient.post(
-      "/v2/bot/user/all/richmenu/{richMenuId}".replace(
-        "{richMenuId}",
-        String(richMenuId),
-      ),
-    );
+    const path = buildPath("/v2/bot/user/all/richmenu/{richMenuId}", {
+      richMenuId: richMenuId,
+    });
+
+    const res = await this.httpClient.post(path);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -2063,9 +2059,11 @@ export class MessagingApiClient {
   public async unlinkRichMenuIdFromUserWithHttpInfo(
     userId: string,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
-    const res = await this.httpClient.delete(
-      "/v2/bot/user/{userId}/richmenu".replace("{userId}", String(userId)),
-    );
+    const path = buildPath("/v2/bot/user/{userId}/richmenu", {
+      userId: userId,
+    });
+
+    const res = await this.httpClient.delete(path);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -2137,15 +2135,13 @@ export class MessagingApiClient {
     richMenuAliasId: string,
     updateRichMenuAliasRequest: UpdateRichMenuAliasRequest,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
+    const path = buildPath("/v2/bot/richmenu/alias/{richMenuAliasId}", {
+      richMenuAliasId: richMenuAliasId,
+    });
+
     const params = updateRichMenuAliasRequest;
 
-    const res = await this.httpClient.post(
-      "/v2/bot/richmenu/alias/{richMenuAliasId}".replace(
-        "{richMenuAliasId}",
-        String(richMenuAliasId),
-      ),
-      params,
-    );
+    const res = await this.httpClient.post(path, params);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };

--- a/lib/messaging-api/api/messagingApiClient.ts
+++ b/lib/messaging-api/api/messagingApiClient.ts
@@ -188,11 +188,11 @@ export class MessagingApiClient {
   public async closeCouponWithHttpInfo(
     couponId: string,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
-    const path = buildPath("/v2/bot/coupon/{couponId}/close", {
+    const requestPath = buildPath("/v2/bot/coupon/{couponId}/close", {
       couponId: couponId,
     });
 
-    const res = await this.httpClient.put(path);
+    const res = await this.httpClient.put(requestPath);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -308,11 +308,11 @@ export class MessagingApiClient {
   public async deleteRichMenuWithHttpInfo(
     richMenuId: string,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
-    const path = buildPath("/v2/bot/richmenu/{richMenuId}", {
+    const requestPath = buildPath("/v2/bot/richmenu/{richMenuId}", {
       richMenuId: richMenuId,
     });
 
-    const res = await this.httpClient.delete(path);
+    const res = await this.httpClient.delete(requestPath);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -339,11 +339,11 @@ export class MessagingApiClient {
   public async deleteRichMenuAliasWithHttpInfo(
     richMenuAliasId: string,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
-    const path = buildPath("/v2/bot/richmenu/alias/{richMenuAliasId}", {
+    const requestPath = buildPath("/v2/bot/richmenu/alias/{richMenuAliasId}", {
       richMenuAliasId: richMenuAliasId,
     });
 
-    const res = await this.httpClient.delete(path);
+    const res = await this.httpClient.delete(requestPath);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -459,11 +459,11 @@ export class MessagingApiClient {
   public async getCouponDetailWithHttpInfo(
     couponId: string,
   ): Promise<Types.ApiResponseType<CouponResponse>> {
-    const path = buildPath("/v2/bot/coupon/{couponId}", {
+    const requestPath = buildPath("/v2/bot/coupon/{couponId}", {
       couponId: couponId,
     });
 
-    const res = await this.httpClient.get(path);
+    const res = await this.httpClient.get(requestPath);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -554,11 +554,11 @@ export class MessagingApiClient {
   public async getGroupMemberCountWithHttpInfo(
     groupId: string,
   ): Promise<Types.ApiResponseType<GroupMemberCountResponse>> {
-    const path = buildPath("/v2/bot/group/{groupId}/members/count", {
+    const requestPath = buildPath("/v2/bot/group/{groupId}/members/count", {
       groupId: groupId,
     });
 
-    const res = await this.httpClient.get(path);
+    const res = await this.httpClient.get(requestPath);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -589,12 +589,12 @@ export class MessagingApiClient {
     groupId: string,
     userId: string,
   ): Promise<Types.ApiResponseType<GroupUserProfileResponse>> {
-    const path = buildPath("/v2/bot/group/{groupId}/member/{userId}", {
+    const requestPath = buildPath("/v2/bot/group/{groupId}/member/{userId}", {
       groupId: groupId,
       userId: userId,
     });
 
-    const res = await this.httpClient.get(path);
+    const res = await this.httpClient.get(requestPath);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -625,7 +625,7 @@ export class MessagingApiClient {
     groupId: string,
     start?: string,
   ): Promise<Types.ApiResponseType<MembersIdsResponse>> {
-    const path = buildPath("/v2/bot/group/{groupId}/members/ids", {
+    const requestPath = buildPath("/v2/bot/group/{groupId}/members/ids", {
       groupId: groupId,
     });
 
@@ -638,7 +638,7 @@ export class MessagingApiClient {
       }
     });
 
-    const res = await this.httpClient.get(path, queryParams);
+    const res = await this.httpClient.get(requestPath, queryParams);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -663,11 +663,11 @@ export class MessagingApiClient {
   public async getGroupSummaryWithHttpInfo(
     groupId: string,
   ): Promise<Types.ApiResponseType<GroupSummaryResponse>> {
-    const path = buildPath("/v2/bot/group/{groupId}/summary", {
+    const requestPath = buildPath("/v2/bot/group/{groupId}/summary", {
       groupId: groupId,
     });
 
-    const res = await this.httpClient.get(path);
+    const res = await this.httpClient.get(requestPath);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -708,9 +708,12 @@ export class MessagingApiClient {
     start?: string,
     limit?: number,
   ): Promise<Types.ApiResponseType<GetJoinedMembershipUsersResponse>> {
-    const path = buildPath("/v2/bot/membership/{membershipId}/users/ids", {
-      membershipId: membershipId,
-    });
+    const requestPath = buildPath(
+      "/v2/bot/membership/{membershipId}/users/ids",
+      {
+        membershipId: membershipId,
+      },
+    );
 
     const queryParams = {
       start: start,
@@ -722,7 +725,7 @@ export class MessagingApiClient {
       }
     });
 
-    const res = await this.httpClient.get(path, queryParams);
+    const res = await this.httpClient.get(requestPath, queryParams);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -772,11 +775,11 @@ export class MessagingApiClient {
   public async getMembershipSubscriptionWithHttpInfo(
     userId: string,
   ): Promise<Types.ApiResponseType<GetMembershipSubscriptionResponse>> {
-    const path = buildPath("/v2/bot/membership/subscription/{userId}", {
+    const requestPath = buildPath("/v2/bot/membership/subscription/{userId}", {
       userId: userId,
     });
 
-    const res = await this.httpClient.get(path);
+    const res = await this.httpClient.get(requestPath);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -1081,11 +1084,11 @@ export class MessagingApiClient {
   public async getProfileWithHttpInfo(
     userId: string,
   ): Promise<Types.ApiResponseType<UserProfileResponse>> {
-    const path = buildPath("/v2/bot/profile/{userId}", {
+    const requestPath = buildPath("/v2/bot/profile/{userId}", {
       userId: userId,
     });
 
-    const res = await this.httpClient.get(path);
+    const res = await this.httpClient.get(requestPath);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -1110,11 +1113,11 @@ export class MessagingApiClient {
   public async getRichMenuWithHttpInfo(
     richMenuId: string,
   ): Promise<Types.ApiResponseType<RichMenuResponse>> {
-    const path = buildPath("/v2/bot/richmenu/{richMenuId}", {
+    const requestPath = buildPath("/v2/bot/richmenu/{richMenuId}", {
       richMenuId: richMenuId,
     });
 
-    const res = await this.httpClient.get(path);
+    const res = await this.httpClient.get(requestPath);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -1141,11 +1144,11 @@ export class MessagingApiClient {
   public async getRichMenuAliasWithHttpInfo(
     richMenuAliasId: string,
   ): Promise<Types.ApiResponseType<RichMenuAliasResponse>> {
-    const path = buildPath("/v2/bot/richmenu/alias/{richMenuAliasId}", {
+    const requestPath = buildPath("/v2/bot/richmenu/alias/{richMenuAliasId}", {
       richMenuAliasId: richMenuAliasId,
     });
 
-    const res = await this.httpClient.get(path);
+    const res = await this.httpClient.get(requestPath);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -1234,11 +1237,11 @@ export class MessagingApiClient {
   public async getRichMenuIdOfUserWithHttpInfo(
     userId: string,
   ): Promise<Types.ApiResponseType<RichMenuIdResponse>> {
-    const path = buildPath("/v2/bot/user/{userId}/richmenu", {
+    const requestPath = buildPath("/v2/bot/user/{userId}/richmenu", {
       userId: userId,
     });
 
-    const res = await this.httpClient.get(path);
+    const res = await this.httpClient.get(requestPath);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -1288,11 +1291,11 @@ export class MessagingApiClient {
   public async getRoomMemberCountWithHttpInfo(
     roomId: string,
   ): Promise<Types.ApiResponseType<RoomMemberCountResponse>> {
-    const path = buildPath("/v2/bot/room/{roomId}/members/count", {
+    const requestPath = buildPath("/v2/bot/room/{roomId}/members/count", {
       roomId: roomId,
     });
 
-    const res = await this.httpClient.get(path);
+    const res = await this.httpClient.get(requestPath);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -1323,12 +1326,12 @@ export class MessagingApiClient {
     roomId: string,
     userId: string,
   ): Promise<Types.ApiResponseType<RoomUserProfileResponse>> {
-    const path = buildPath("/v2/bot/room/{roomId}/member/{userId}", {
+    const requestPath = buildPath("/v2/bot/room/{roomId}/member/{userId}", {
       roomId: roomId,
       userId: userId,
     });
 
-    const res = await this.httpClient.get(path);
+    const res = await this.httpClient.get(requestPath);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -1359,7 +1362,7 @@ export class MessagingApiClient {
     roomId: string,
     start?: string,
   ): Promise<Types.ApiResponseType<MembersIdsResponse>> {
-    const path = buildPath("/v2/bot/room/{roomId}/members/ids", {
+    const requestPath = buildPath("/v2/bot/room/{roomId}/members/ids", {
       roomId: roomId,
     });
 
@@ -1372,7 +1375,7 @@ export class MessagingApiClient {
       }
     });
 
-    const res = await this.httpClient.get(path, queryParams);
+    const res = await this.httpClient.get(requestPath, queryParams);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -1420,11 +1423,11 @@ export class MessagingApiClient {
   public async issueLinkTokenWithHttpInfo(
     userId: string,
   ): Promise<Types.ApiResponseType<IssueLinkTokenResponse>> {
-    const path = buildPath("/v2/bot/user/{userId}/linkToken", {
+    const requestPath = buildPath("/v2/bot/user/{userId}/linkToken", {
       userId: userId,
     });
 
-    const res = await this.httpClient.post(path);
+    const res = await this.httpClient.post(requestPath);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -1451,11 +1454,11 @@ export class MessagingApiClient {
   public async leaveGroupWithHttpInfo(
     groupId: string,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
-    const path = buildPath("/v2/bot/group/{groupId}/leave", {
+    const requestPath = buildPath("/v2/bot/group/{groupId}/leave", {
       groupId: groupId,
     });
 
-    const res = await this.httpClient.post(path);
+    const res = await this.httpClient.post(requestPath);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -1482,11 +1485,11 @@ export class MessagingApiClient {
   public async leaveRoomWithHttpInfo(
     roomId: string,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
-    const path = buildPath("/v2/bot/room/{roomId}/leave", {
+    const requestPath = buildPath("/v2/bot/room/{roomId}/leave", {
       roomId: roomId,
     });
 
-    const res = await this.httpClient.post(path);
+    const res = await this.httpClient.post(requestPath);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -1518,12 +1521,15 @@ export class MessagingApiClient {
     userId: string,
     richMenuId: string,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
-    const path = buildPath("/v2/bot/user/{userId}/richmenu/{richMenuId}", {
-      userId: userId,
-      richMenuId: richMenuId,
-    });
+    const requestPath = buildPath(
+      "/v2/bot/user/{userId}/richmenu/{richMenuId}",
+      {
+        userId: userId,
+        richMenuId: richMenuId,
+      },
+    );
 
-    const res = await this.httpClient.post(path);
+    const res = await this.httpClient.post(requestPath);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -1926,11 +1932,11 @@ export class MessagingApiClient {
   public async setDefaultRichMenuWithHttpInfo(
     richMenuId: string,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
-    const path = buildPath("/v2/bot/user/all/richmenu/{richMenuId}", {
+    const requestPath = buildPath("/v2/bot/user/all/richmenu/{richMenuId}", {
       richMenuId: richMenuId,
     });
 
-    const res = await this.httpClient.post(path);
+    const res = await this.httpClient.post(requestPath);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -2059,11 +2065,11 @@ export class MessagingApiClient {
   public async unlinkRichMenuIdFromUserWithHttpInfo(
     userId: string,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
-    const path = buildPath("/v2/bot/user/{userId}/richmenu", {
+    const requestPath = buildPath("/v2/bot/user/{userId}/richmenu", {
       userId: userId,
     });
 
-    const res = await this.httpClient.delete(path);
+    const res = await this.httpClient.delete(requestPath);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -2135,13 +2141,13 @@ export class MessagingApiClient {
     richMenuAliasId: string,
     updateRichMenuAliasRequest: UpdateRichMenuAliasRequest,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
-    const path = buildPath("/v2/bot/richmenu/alias/{richMenuAliasId}", {
+    const requestPath = buildPath("/v2/bot/richmenu/alias/{richMenuAliasId}", {
       richMenuAliasId: richMenuAliasId,
     });
 
     const params = updateRichMenuAliasRequest;
 
-    const res = await this.httpClient.post(path, params);
+    const res = await this.httpClient.post(requestPath, params);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };

--- a/lib/module-attach/api/lineModuleAttachClient.ts
+++ b/lib/module-attach/api/lineModuleAttachClient.ts
@@ -14,7 +14,7 @@
 import { AttachModuleResponse } from "../model/attachModuleResponse.js";
 
 import * as Types from "../../types.js";
-import { ensureJSON } from "../../utils.js";
+import { ensureJSON, buildPath } from "../../utils.js";
 import { Readable } from "node:stream";
 
 import HTTPFetchClient, {

--- a/lib/module/api/lineModuleClient.ts
+++ b/lib/module/api/lineModuleClient.ts
@@ -16,7 +16,7 @@ import { DetachModuleRequest } from "../model/detachModuleRequest.js";
 import { GetModulesResponse } from "../model/getModulesResponse.js";
 
 import * as Types from "../../types.js";
-import { ensureJSON } from "../../utils.js";
+import { ensureJSON, buildPath } from "../../utils.js";
 import { Readable } from "node:stream";
 
 import HTTPFetchClient, {
@@ -83,15 +83,13 @@ export class LineModuleClient {
     chatId: string,
     acquireChatControlRequest?: AcquireChatControlRequest,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
+    const path = buildPath("/v2/bot/chat/{chatId}/control/acquire", {
+      chatId: chatId,
+    });
+
     const params = acquireChatControlRequest;
 
-    const res = await this.httpClient.post(
-      "/v2/bot/chat/{chatId}/control/acquire".replace(
-        "{chatId}",
-        String(chatId),
-      ),
-      params,
-    );
+    const res = await this.httpClient.post(path, params);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -188,12 +186,11 @@ export class LineModuleClient {
   public async releaseChatControlWithHttpInfo(
     chatId: string,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
-    const res = await this.httpClient.post(
-      "/v2/bot/chat/{chatId}/control/release".replace(
-        "{chatId}",
-        String(chatId),
-      ),
-    );
+    const path = buildPath("/v2/bot/chat/{chatId}/control/release", {
+      chatId: chatId,
+    });
+
+    const res = await this.httpClient.post(path);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };

--- a/lib/module/api/lineModuleClient.ts
+++ b/lib/module/api/lineModuleClient.ts
@@ -83,13 +83,13 @@ export class LineModuleClient {
     chatId: string,
     acquireChatControlRequest?: AcquireChatControlRequest,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
-    const path = buildPath("/v2/bot/chat/{chatId}/control/acquire", {
+    const requestPath = buildPath("/v2/bot/chat/{chatId}/control/acquire", {
       chatId: chatId,
     });
 
     const params = acquireChatControlRequest;
 
-    const res = await this.httpClient.post(path, params);
+    const res = await this.httpClient.post(requestPath, params);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };
@@ -186,11 +186,11 @@ export class LineModuleClient {
   public async releaseChatControlWithHttpInfo(
     chatId: string,
   ): Promise<Types.ApiResponseType<Types.MessageAPIResponseBase>> {
-    const path = buildPath("/v2/bot/chat/{chatId}/control/release", {
+    const requestPath = buildPath("/v2/bot/chat/{chatId}/control/release", {
       chatId: chatId,
     });
 
-    const res = await this.httpClient.post(path);
+    const res = await this.httpClient.post(requestPath);
     const text = await res.text();
     const parsedBody = text ? JSON.parse(text) : null;
     return { httpResponse: res, body: parsedBody };

--- a/lib/shop/api/shopClient.ts
+++ b/lib/shop/api/shopClient.ts
@@ -14,7 +14,7 @@
 import { MissionStickerRequest } from "../model/missionStickerRequest.js";
 
 import * as Types from "../../types.js";
-import { ensureJSON } from "../../utils.js";
+import { ensureJSON, buildPath } from "../../utils.js";
 import { Readable } from "node:stream";
 
 import HTTPFetchClient, {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,12 +1,29 @@
 import { Buffer } from "node:buffer";
 import { JSONParseError } from "./exceptions.js";
 
+// Mirrors retrofit's PATH_TRAVERSAL: matches when any path segment is purely
+// "." / ".." (or their percent-encoded forms), after the parameters have been
+// substituted. See square/retrofit RequestBuilder.java.
+const PATH_TRAVERSAL = /^(?:.*\/)?(?:\.|%2e|%2E){1,2}(?:\/.*)?$/;
+
 export function ensureJSON<T>(raw: T): T {
   if (typeof raw === "object") {
     return raw;
   } else {
     throw new JSONParseError("Failed to parse response body as JSON", { raw });
   }
+}
+
+export function createURLSearchParams(
+  params: Record<string, unknown>,
+): URLSearchParams {
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value != null) {
+      searchParams.append(key, String(value));
+    }
+  }
+  return searchParams;
 }
 
 function toArrayBuffer(input: Uint8Array | Buffer): ArrayBuffer {
@@ -21,16 +38,30 @@ function toArrayBuffer(input: Uint8Array | Buffer): ArrayBuffer {
   return arrayBuffer;
 }
 
-export function createURLSearchParams(
-  params: Record<string, unknown>,
-): URLSearchParams {
-  const searchParams = new URLSearchParams();
-  for (const [key, value] of Object.entries(params)) {
-    if (value != null) {
-      searchParams.append(key, String(value));
-    }
+function encodePathParam(value: unknown, name: string): string {
+  if (value === null || value === undefined) {
+    throw new TypeError(`${name} is required`);
   }
-  return searchParams;
+  return encodeURIComponent(String(value));
+}
+
+export function buildPath(
+  pathTemplate: string,
+  params: Record<string, unknown>,
+): string {
+  let path = pathTemplate;
+
+  for (const [name, value] of Object.entries(params)) {
+    path = path.split(`{${name}}`).join(encodePathParam(value, name));
+  }
+
+  if (PATH_TRAVERSAL.test(path)) {
+    throw new TypeError(
+      `Path parameters shouldn't perform path traversal ('.' or '..'): ${path}`,
+    );
+  }
+
+  return path;
 }
 
 export function createMultipartFormData(

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,4 +1,3 @@
-import { Buffer } from "node:buffer";
 import { JSONParseError } from "./exceptions.js";
 
 // Mirrors retrofit's PATH_TRAVERSAL: matches when any path segment is purely
@@ -26,18 +25,6 @@ export function createURLSearchParams(
   return searchParams;
 }
 
-function toArrayBuffer(input: Uint8Array | Buffer): ArrayBuffer {
-  if (input.buffer instanceof ArrayBuffer) {
-    return input.buffer.slice(
-      input.byteOffset,
-      input.byteOffset + input.byteLength,
-    );
-  }
-  const arrayBuffer = new ArrayBuffer(input.byteLength);
-  new Uint8Array(arrayBuffer).set(input);
-  return arrayBuffer;
-}
-
 function encodePathParam(value: unknown, name: string): string {
   if (value === null || value === undefined) {
     throw new TypeError(`${name} is required`);
@@ -62,25 +49,4 @@ export function buildPath(
   }
 
   return path;
-}
-
-export function createMultipartFormData(
-  this: FormData | void,
-  formBody: Record<string, any>,
-): FormData {
-  const formData = this instanceof FormData ? this : new FormData();
-  for (const [key, value] of Object.entries(formBody)) {
-    if (value == null) continue;
-
-    if (value instanceof Blob) {
-      formData.append(key, value);
-    } else if (Buffer.isBuffer(value) || value instanceof Uint8Array) {
-      const arrayBuffer = toArrayBuffer(value);
-      formData.append(key, new Blob([arrayBuffer]));
-    } else {
-      formData.append(key, String(value));
-    }
-  }
-
-  return formData;
 }

--- a/test/libs-manageAudience.spec.ts
+++ b/test/libs-manageAudience.spec.ts
@@ -60,4 +60,73 @@ describe("manageAudience", () => {
     equal(requestCount, 1);
     deepEqual(res, {});
   });
+
+  it("deleteAudienceGroupWithHttpInfo builds path from numeric audienceGroupId", async () => {
+    let requestCount = 0;
+    server.use(
+      http.delete(
+        "https://api.line.me/v2/bot/audienceGroup/0",
+        ({ request }) => {
+          requestCount++;
+
+          equal(
+            request.headers.get("Authorization"),
+            "Bearer test_channel_access_token",
+          );
+          return HttpResponse.json({});
+        },
+      ),
+    );
+
+    const res = await client.deleteAudienceGroupWithHttpInfo(0);
+    equal(requestCount, 1);
+    deepEqual(res.body, {});
+  });
+
+  it("getSharedAudienceDataWithHttpInfo builds path from numeric audienceGroupId", async () => {
+    let requestCount = 0;
+    server.use(
+      http.get(
+        "https://api.line.me/v2/bot/audienceGroup/shared/12345",
+        ({ request }) => {
+          requestCount++;
+
+          equal(
+            request.headers.get("Authorization"),
+            "Bearer test_channel_access_token",
+          );
+          return HttpResponse.json({});
+        },
+      ),
+    );
+
+    const res = await client.getSharedAudienceDataWithHttpInfo(12345);
+    equal(requestCount, 1);
+    deepEqual(res.body, {});
+  });
+
+  it("updateAudienceGroupDescriptionWithHttpInfo builds path from numeric audienceGroupId", async () => {
+    let requestCount = 0;
+    server.use(
+      http.put(
+        "https://api.line.me/v2/bot/audienceGroup/999/updateDescription",
+        async ({ request }) => {
+          requestCount++;
+
+          equal(
+            request.headers.get("Authorization"),
+            "Bearer test_channel_access_token",
+          );
+          deepEqual(await request.json(), { description: "renamed-audience" });
+          return HttpResponse.json({});
+        },
+      ),
+    );
+
+    const res = await client.updateAudienceGroupDescriptionWithHttpInfo(999, {
+      description: "renamed-audience",
+    });
+    equal(requestCount, 1);
+    deepEqual(res.body, {});
+  });
 });

--- a/test/libs-messagingApi.spec.ts
+++ b/test/libs-messagingApi.spec.ts
@@ -2,6 +2,7 @@ import { messagingApi } from "../lib/index.js";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import { deepEqual, equal } from "node:assert";
+import { rejects } from "node:assert/strict";
 
 import { describe, it, beforeAll, afterAll, afterEach } from "vitest";
 
@@ -227,6 +228,108 @@ describe("messagingApi", () => {
       ],
       next: "yANU9IA..",
     });
+  });
+
+  it("encodes path parameter slash for profile endpoint", async () => {
+    let requestCount = 0;
+    server.use(
+      http.get(
+        "https://api.line.me/v2/bot/profile/..%2Falice",
+        ({ request, params, cookies }) => {
+          requestCount++;
+
+          equal(
+            request.headers.get("Authorization"),
+            "Bearer test_channel_access_token",
+          );
+          return HttpResponse.json({});
+        },
+      ),
+    );
+
+    const res = await client.getProfileWithHttpInfo("../alice");
+    equal(requestCount, 1);
+    deepEqual(res.body, {});
+  });
+
+  it("treats encoded dot sequence as data for profile endpoint", async () => {
+    let requestCount = 0;
+    server.use(
+      http.get(
+        "https://api.line.me/v2/bot/profile/%252e%252e%2Fmessage%2Fquota",
+        ({ request, params, cookies }) => {
+          requestCount++;
+
+          equal(
+            request.headers.get("Authorization"),
+            "Bearer test_channel_access_token",
+          );
+          return HttpResponse.json({});
+        },
+      ),
+    );
+
+    const res = await client.getProfileWithHttpInfo("%2e%2e/message/quota");
+    equal(requestCount, 1);
+    deepEqual(res.body, {});
+  });
+
+  it("encodes path parameters for multi-path endpoint", async () => {
+    let requestCount = 0;
+    server.use(
+      http.get(
+        "https://api.line.me/v2/bot/group/..%2Fgroup/member/user%2F42",
+        ({ request, params, cookies }) => {
+          requestCount++;
+
+          equal(
+            request.headers.get("Authorization"),
+            "Bearer test_channel_access_token",
+          );
+          return HttpResponse.json({});
+        },
+      ),
+    );
+
+    const res = await client.getGroupMemberProfileWithHttpInfo(
+      "../group",
+      "user/42",
+    );
+    equal(requestCount, 1);
+    deepEqual(res.body, {});
+  });
+
+  it("rejects dot segments for profile endpoint path parameter", async () => {
+    const localClient = new messagingApi.MessagingApiClient({
+      channelAccessToken,
+      baseURL: "http://127.0.0.1:1",
+    });
+
+    for (const userId of [".", ".."]) {
+      await rejects(localClient.getProfileWithHttpInfo(userId), {
+        name: "TypeError",
+        message: `Path parameters shouldn't perform path traversal ('.' or '..'): /v2/bot/profile/${userId}`,
+      });
+    }
+  });
+
+  it("rejects dot segments for multi-path endpoint path parameter", async () => {
+    const localClient = new messagingApi.MessagingApiClient({
+      channelAccessToken,
+      baseURL: "http://127.0.0.1:1",
+    });
+
+    await rejects(localClient.getGroupMemberProfileWithHttpInfo(".", "user"), {
+      name: "TypeError",
+      message: `Path parameters shouldn't perform path traversal ('.' or '..'): /v2/bot/group/./member/user`,
+    });
+    await rejects(
+      localClient.getGroupMemberProfileWithHttpInfo("group", ".."),
+      {
+        name: "TypeError",
+        message: `Path parameters shouldn't perform path traversal ('.' or '..'): /v2/bot/group/group/member/..`,
+      },
+    );
   });
 
   it("config is not overrided", async () => {

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -1,4 +1,4 @@
-import { ensureJSON, createURLSearchParams } from "../lib/utils.js";
+import { buildPath, ensureJSON, createURLSearchParams } from "../lib/utils.js";
 import { JSONParseError } from "../lib/exceptions.js";
 import { equal, ok } from "node:assert";
 
@@ -82,6 +82,98 @@ describe("utils", () => {
       equal(result.get("emptyStr"), "");
       equal(result.get("nullVal"), null);
       equal(result.get("undefinedVal"), null);
+    });
+  });
+
+  describe("buildPath", () => {
+    it("accepts common path parameter values and encodes reserved characters", () => {
+      equal(
+        buildPath("/v2/bot/profile/{userId}", {
+          userId: "U0123456789abcdef0123456789abcdef",
+        }),
+        "/v2/bot/profile/U0123456789abcdef0123456789abcdef",
+      );
+
+      equal(
+        buildPath("/v2/bot/profile/{userId}", {
+          userId: "abc..def",
+        }),
+        "/v2/bot/profile/abc..def",
+      );
+
+      equal(
+        buildPath("/v2/bot/profile/{userId}", {
+          userId: "../message/quota",
+        }),
+        "/v2/bot/profile/..%2Fmessage%2Fquota",
+      );
+
+      equal(
+        buildPath("/v2/bot/profile/{userId}", {
+          userId: "%2e%2e/message/quota",
+        }),
+        "/v2/bot/profile/%252e%252e%2Fmessage%2Fquota",
+      );
+
+      equal(
+        buildPath("/v2/bot/profile/{userId}", {
+          userId: "foo?bar",
+        }),
+        "/v2/bot/profile/foo%3Fbar",
+      );
+
+      equal(
+        buildPath("/v2/bot/profile/{userId}", {
+          userId: "foo#bar",
+        }),
+        "/v2/bot/profile/foo%23bar",
+      );
+
+      equal(
+        buildPath("/v2/bot/profile/{userId}", {
+          userId: "foo\\bar",
+        }),
+        "/v2/bot/profile/foo%5Cbar",
+      );
+
+      equal(
+        buildPath("/v2/bot/profile/{userId}", {
+          userId: "foo:bar;baz",
+        }),
+        "/v2/bot/profile/foo%3Abar%3Bbaz",
+      );
+    });
+
+    it("rejects dot-only path parameter values", () => {
+      try {
+        buildPath("/v2/bot/profile/{userId}", { userId: "." });
+        ok(false);
+      } catch (err) {
+        equal((err as TypeError).name, "TypeError");
+      }
+
+      try {
+        buildPath("/v2/bot/profile/{userId}", { userId: ".." });
+        ok(false);
+      } catch (err) {
+        equal((err as TypeError).name, "TypeError");
+      }
+    });
+
+    it("rejects dot segments in generated path", () => {
+      for (const rawPath of [
+        "/v2/bot/profile/.",
+        "/v2/bot/profile/..",
+        "/v2/bot/profile/%2e",
+        "/v2/bot/profile/%2e%2e",
+      ]) {
+        try {
+          buildPath(rawPath, {});
+          ok(false);
+        } catch (err) {
+          equal((err as TypeError).name, "TypeError");
+        }
+      }
     });
   });
 });


### PR DESCRIPTION
This is part of the fix for https://github.com/line/line-bot-mcp-server/issues/462.

Path parameters must not be able to change the resolved endpoint. Without this protection, invalid request can be routed to another endpoint. For example
`/v2/bot/profile/{userId}` + `userId=../message/quota` is resolved as `/v2/bot/message/quota`.

This prevents path traversal inputs from escaping the intended API path, like retrofit. (line-bot-sdk-java already prevents this.)