### PR TITLE
Remove final handler depenedency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,8 @@
       "devDependencies": {
         "@arethetypeswrong/cli": "0.18.2",
         "@types/express": "5.0.6",
-        "@types/finalhandler": "1.2.4",
         "@vitest/coverage-v8": "^4.1.0",
         "express": "5.2.1",
-        "finalhandler": "2.1.1",
         "msw": "2.14.6",
         "oxc-minify": "^0.133.0",
         "prettier": "3.8.3",
@@ -1290,16 +1288,6 @@
         "@types/qs": "*",
         "@types/range-parser": "*",
         "@types/send": "*"
-      }
-    },
-    "node_modules/@types/finalhandler": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@types/finalhandler/-/finalhandler-1.2.4.tgz",
-      "integrity": "sha512-ojpQ5ywnKZko/+tw8lR4xvUN5Uvfnar4ZtfpoLG1TdxlmiIqcQGUbXmc9iV5ud7J6rRtacNbwTkCE98NmsBPYw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/hast": {

--- a/package.json
+++ b/package.json
@@ -66,10 +66,8 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.2",
     "@types/express": "5.0.6",
-    "@types/finalhandler": "1.2.4",
     "@vitest/coverage-v8": "^4.1.0",
     "express": "5.2.1",
-    "finalhandler": "2.1.1",
     "msw": "2.14.6",
     "oxc-minify": "^0.133.0",
     "prettier": "3.8.3",

--- a/test/helpers/test-server.ts
+++ b/test/helpers/test-server.ts
@@ -8,7 +8,6 @@ import {
   JSONParseError,
   SignatureValidationFailed,
 } from "../../lib/exceptions.js";
-import finalhandler from "finalhandler";
 
 // Use a map to store multiple server instances
 let servers: Map<number, Server> = new Map();
@@ -69,11 +68,19 @@ function listen(port: number, middleware?: express.RequestHandler) {
         res.status(400).send(err.raw);
         return;
       }
-      // https://github.com/expressjs/express/blob/2df1ad26a58bf51228d7600df0d62ed17a90ff71/lib/application.js#L162
-      // express will record error in console when
-      // there is no other handler to handle error & it is in test environment
-      // use final handler the same as in express application.js
-      finalhandler(req, res)(err);
+      // Fallback for any other unexpected error. We handle it here instead of
+      // delegating to Express's default error handler (via next(err)), which
+      // would log the stack trace to the console during tests. This mirrors
+      // what finalhandler did, but without the extra dependency.
+      if (res.headersSent) {
+        return;
+      }
+      const { status, statusCode } = err as {
+        status?: number;
+        statusCode?: number;
+      };
+      const code = status ?? statusCode ?? 500;
+      res.status(code >= 400 && code < 600 ? code : 500).end();
     },
   );
 


### PR DESCRIPTION
https://github.com/pillarjs/finalhandler

The final handler is only used in tests.
Even without it, covering the same behavior in tests is straightforward, so let's stop using it.