### PR TITLE
Enable lockfile maintenance by renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -13,6 +13,12 @@
   labels: [
     "dependency upgrade"
   ],
+  lockFileMaintenance: {
+    enabled: true,
+    schedule: [
+      "after 1am and before 4am every day"
+    ],
+  },
   minimumReleaseAge : "7 days",
   // To prevent libraries in optionalDependencies from being removed from the lock file
   constraints: {


### PR DESCRIPTION
It's as same as https://github.com/line/line-bot-mcp-server/pull/470.

In many cases, `npm audit` issues will be resolved automatically.