### PR TITLE
Make renovate manage dependency in examples

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,30 +44,8 @@ jobs:
       - name: Generate code
         run: |
           python3 generate-code.py
-      - name: Test Project
-        run: export NODE_OPTIONS=--max-old-space-size=6144; npm test
-      - name: Test building apidocs
-        run: export NODE_OPTIONS=--openssl-legacy-provider; npm run apidocs
-      - name: Test building docs
-        run: export NODE_OPTIONS=--openssl-legacy-provider; npm run docs:build
-      - name: Test building examples (CJS)
-        run: |
-          cd examples/echo-bot-ts-cjs
-          npm run build-sdk
-          npm install
-          npm run build
-          cd -
-      - name: Test building examples (ESM)
-        run: |
-          cd examples/echo-bot-ts-esm
-          npm run build-sdk
-          npm install
-          npm run build
-          cd -
-      - name: publint
-        run: npm run check:publint
-      - name: validate package
-        run: npm run check:attw
+      - name: Run all checks
+        run: npm run checkAll
 
   pinact:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,8 @@ Especially for bug fixes, please follow this flow for testing and development:
 
 ### Run your code in your local
 
-You can use the example projects to test your changes locally before submitting a pull request.
+You can use the example projects under `examples/` to test your changes locally before submitting a pull request.
+See each example's README for instructions.
 
 ### Run CI tasks in your local
 
@@ -57,6 +58,7 @@ The following npm scripts are available for development:
 * `npm run test`: Run test suites using Vitest.
 * `npm run format`: Format source code with [Prettier](https://github.com/prettier/prettier).
 * `npm run build`: Build TypeScript code into JavaScript. The built files will be placed in `dist/`.
+* `npm run checkAll`: Run the full set of checks executed in CI.
 
 We test, lint and build on CI, but it is always nice to check them before uploading a pull request.
 For details on the commands executed in the CI, please refer to `.github/workflows/test.yml`.

--- a/examples/echo-bot-esm/README.md
+++ b/examples/echo-bot-esm/README.md
@@ -7,7 +7,6 @@ An example LINE bot just to echo messages written in ES modules.
 ### Install deps
 
 ``` shell
-$ npm build-sdk
 $ npm install
 ```
 
@@ -30,3 +29,15 @@ $ node .
 ```
 https://your.base.url/callback
 ```
+
+## Using a local build of `@line/bot-sdk`
+
+When developing the SDK in this repository, run `npm run build-sdk` after `npm install` to test the example
+against your unreleased local SDK changes instead of the published package from npm:
+
+``` shell
+$ npm install
+$ npm run build-sdk
+```
+
+Without `build-sdk`, the published package from npm is used.

--- a/examples/echo-bot-esm/package-lock.json
+++ b/examples/echo-bot-esm/package-lock.json
@@ -8,41 +8,30 @@
       "name": "echo-bot-esm",
       "version": "0.0.0",
       "dependencies": {
-        "@line/bot-sdk": "../../",
+        "@line/bot-sdk": "^11.0.1",
         "express": "^4.17.3"
       }
     },
-    "../..": {
-      "name": "@line/bot-sdk",
-      "version": "1.0.0-test",
+    "node_modules/@line/bot-sdk": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@line/bot-sdk/-/bot-sdk-11.0.1.tgz",
+      "integrity": "sha512-De9gBX2JfZs78nDSyzfetHJw0R6hncPVVy3tzPMwYZzgwK06C/tcijGy7Vq28K8uYKGVTSthbtMIoYKNhXISzw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^24.0.0"
-      },
-      "devDependencies": {
-        "@arethetypeswrong/cli": "0.18.2",
-        "@types/express": "5.0.6",
-        "@types/finalhandler": "1.2.4",
-        "@vitest/coverage-v8": "^4.1.0",
-        "express": "5.2.1",
-        "finalhandler": "2.1.1",
-        "msw": "2.14.6",
-        "oxc-minify": "^0.132.0",
-        "prettier": "3.8.3",
-        "publint": "0.3.21",
-        "typedoc": "^0.28.14",
-        "typedoc-plugin-markdown": "^4.3.0",
-        "typescript": "^6.0.0",
-        "vitepress": "^2.0.0-alpha.17",
-        "vitest": "^4.1.0"
       },
       "engines": {
         "node": ">=22"
       }
     },
-    "node_modules/@line/bot-sdk": {
-      "resolved": "../..",
-      "link": true
+    "node_modules/@types/node": {
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -237,9 +226,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -416,9 +405,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -727,14 +716,14 @@
       "license": "ISC"
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -828,6 +817,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/examples/echo-bot-esm/package.json
+++ b/examples/echo-bot-esm/package.json
@@ -4,11 +4,11 @@
   "description": "An example LINE bot just to echo messages written in ES modules",
   "main": "index.js",
   "scripts": {
-    "build-sdk": "cd ../../ && npm install && npm run build",
+    "build-sdk": "npm --prefix ../.. run build && npm install --no-save --package-lock=false @line/bot-sdk@file:../..",
     "start": "node ."
   },
   "dependencies": {
-    "@line/bot-sdk": "../../",
+    "@line/bot-sdk": "^11.0.1",
     "express": "^4.17.3"
   },
   "type": "module"

--- a/examples/echo-bot-ts-cjs/README.md
+++ b/examples/echo-bot-ts-cjs/README.md
@@ -27,7 +27,6 @@ cd line-bot-sdk-nodejs/examples/echo-bot-ts-cjs
 - Install all dependencies.
 
 ```bash
-npm run build-sdk
 npm install
 ```
 
@@ -57,3 +56,14 @@ npm run build
 npm start
 ```
 
+## Using a local build of `@line/bot-sdk`
+
+When developing the SDK in this repository, run `npm run build-sdk` after `npm install` to test the example
+against your unreleased local SDK changes instead of the published package from npm:
+
+```bash
+npm install
+npm run build-sdk
+```
+
+Without `build-sdk`, the published package from npm is used.

--- a/examples/echo-bot-ts-cjs/package-lock.json
+++ b/examples/echo-bot-ts-cjs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "echo-bot-ts-cjs",
       "version": "0.0.0",
       "dependencies": {
-        "@line/bot-sdk": "../../",
+        "@line/bot-sdk": "^11.0.1",
         "express": "^4.18.2"
       },
       "devDependencies": {
@@ -16,34 +16,6 @@
         "@types/node": "^20.6.3",
         "rimraf": "^5.0.1",
         "typescript": "^6.0.0"
-      }
-    },
-    "../..": {
-      "name": "@line/bot-sdk",
-      "version": "1.0.0-test",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "^24.0.0"
-      },
-      "devDependencies": {
-        "@arethetypeswrong/cli": "0.18.2",
-        "@types/express": "5.0.6",
-        "@types/finalhandler": "1.2.4",
-        "@vitest/coverage-v8": "^4.1.0",
-        "express": "5.2.1",
-        "finalhandler": "2.1.1",
-        "msw": "2.14.6",
-        "oxc-minify": "^0.132.0",
-        "prettier": "3.8.3",
-        "publint": "0.3.21",
-        "typedoc": "^0.28.14",
-        "typedoc-plugin-markdown": "^4.3.0",
-        "typescript": "^6.0.0",
-        "vitepress": "^2.0.0-alpha.17",
-        "vitest": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -65,8 +37,31 @@
       }
     },
     "node_modules/@line/bot-sdk": {
-      "resolved": "../..",
-      "link": true
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@line/bot-sdk/-/bot-sdk-11.0.1.tgz",
+      "integrity": "sha512-De9gBX2JfZs78nDSyzfetHJw0R6hncPVVy3tzPMwYZzgwK06C/tcijGy7Vq28K8uYKGVTSthbtMIoYKNhXISzw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^24.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@line/bot-sdk/node_modules/@types/node": {
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@line/bot-sdk/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -141,9 +136,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
-      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -274,9 +269,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -482,9 +477,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -700,9 +695,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -1150,14 +1145,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },

--- a/examples/echo-bot-ts-cjs/package.json
+++ b/examples/echo-bot-ts-cjs/package.json
@@ -6,11 +6,11 @@
   "scripts": {
     "clean": "rimraf ./dist",
     "build": "npm run clean && tsc",
-    "build-sdk": "cd ../../ && npm install && npm run build",
+    "build-sdk": "npm --prefix ../.. run build && npm install --no-save --package-lock=false @line/bot-sdk@file:../..",
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@line/bot-sdk": "../../",
+    "@line/bot-sdk": "^11.0.1",
     "express": "^4.18.2"
   },
   "devDependencies": {

--- a/examples/echo-bot-ts-esm/README.md
+++ b/examples/echo-bot-ts-esm/README.md
@@ -27,7 +27,6 @@ cd line-bot-sdk-nodejs/examples/echo-bot-ts-esm
 - Install all dependencies.
 
 ```bash
-npm run build-sdk
 npm install
 ```
 
@@ -57,3 +56,14 @@ npm run build
 npm start
 ```
 
+## Using a local build of `@line/bot-sdk`
+
+When developing the SDK in this repository, run `npm run build-sdk` after `npm install` to test the example
+against your unreleased local SDK changes instead of the published package from npm:
+
+```bash
+npm install
+npm run build-sdk
+```
+
+Without `build-sdk`, the published package from npm is used.

--- a/examples/echo-bot-ts-esm/package-lock.json
+++ b/examples/echo-bot-ts-esm/package-lock.json
@@ -8,7 +8,7 @@
       "name": "echo-bot-ts-esm",
       "version": "0.0.0",
       "dependencies": {
-        "@line/bot-sdk": "../../",
+        "@line/bot-sdk": "^11.0.1",
         "express": "^4.18.2"
       },
       "devDependencies": {
@@ -16,34 +16,6 @@
         "@types/node": "^20.6.3",
         "rimraf": "^5.0.1",
         "typescript": "^6.0.0"
-      }
-    },
-    "../..": {
-      "name": "@line/bot-sdk",
-      "version": "1.0.0-test",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "^24.0.0"
-      },
-      "devDependencies": {
-        "@arethetypeswrong/cli": "0.18.2",
-        "@types/express": "5.0.6",
-        "@types/finalhandler": "1.2.4",
-        "@vitest/coverage-v8": "^4.1.0",
-        "express": "5.2.1",
-        "finalhandler": "2.1.1",
-        "msw": "2.14.6",
-        "oxc-minify": "^0.132.0",
-        "prettier": "3.8.3",
-        "publint": "0.3.21",
-        "typedoc": "^0.28.14",
-        "typedoc-plugin-markdown": "^4.3.0",
-        "typescript": "^6.0.0",
-        "vitepress": "^2.0.0-alpha.17",
-        "vitest": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -65,8 +37,31 @@
       }
     },
     "node_modules/@line/bot-sdk": {
-      "resolved": "../..",
-      "link": true
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@line/bot-sdk/-/bot-sdk-11.0.1.tgz",
+      "integrity": "sha512-De9gBX2JfZs78nDSyzfetHJw0R6hncPVVy3tzPMwYZzgwK06C/tcijGy7Vq28K8uYKGVTSthbtMIoYKNhXISzw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^24.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@line/bot-sdk/node_modules/@types/node": {
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@line/bot-sdk/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -141,9 +136,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
-      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -274,9 +269,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -482,9 +477,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -700,9 +695,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -1150,14 +1145,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },

--- a/examples/echo-bot-ts-esm/package.json
+++ b/examples/echo-bot-ts-esm/package.json
@@ -7,11 +7,11 @@
   "scripts": {
     "clean": "rimraf ./dist",
     "build": "npm run clean && tsc",
-    "build-sdk": "cd ../../ && npm install && npm run build",
+    "build-sdk": "npm --prefix ../.. run build && npm install --no-save --package-lock=false @line/bot-sdk@file:../..",
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@line/bot-sdk": "../../",
+    "@line/bot-sdk": "^11.0.1",
     "express": "^4.18.2"
   },
   "devDependencies": {

--- a/examples/echo-bot/README.md
+++ b/examples/echo-bot/README.md
@@ -7,7 +7,6 @@ An example LINE bot just to echo messages written in CommonJS.
 ### Install deps
 
 ``` shell
-$ npm build-sdk
 $ npm install
 ```
 
@@ -30,3 +29,15 @@ $ node .
 ```
 https://your.base.url/callback
 ```
+
+## Using a local build of `@line/bot-sdk`
+
+When developing the SDK in this repository, run `npm run build-sdk` after `npm install` to test the example
+against your unreleased local SDK changes instead of the published package from npm:
+
+``` shell
+$ npm install
+$ npm run build-sdk
+```
+
+Without `build-sdk`, the published package from npm is used.

--- a/examples/echo-bot/package-lock.json
+++ b/examples/echo-bot/package-lock.json
@@ -8,41 +8,30 @@
       "name": "echo-bot",
       "version": "0.0.0",
       "dependencies": {
-        "@line/bot-sdk": "../../",
+        "@line/bot-sdk": "^11.0.1",
         "express": "^4.17.3"
       }
     },
-    "../..": {
-      "name": "@line/bot-sdk",
-      "version": "1.0.0-test",
+    "node_modules/@line/bot-sdk": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@line/bot-sdk/-/bot-sdk-11.0.1.tgz",
+      "integrity": "sha512-De9gBX2JfZs78nDSyzfetHJw0R6hncPVVy3tzPMwYZzgwK06C/tcijGy7Vq28K8uYKGVTSthbtMIoYKNhXISzw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^24.0.0"
-      },
-      "devDependencies": {
-        "@arethetypeswrong/cli": "0.18.2",
-        "@types/express": "5.0.6",
-        "@types/finalhandler": "1.2.4",
-        "@vitest/coverage-v8": "^4.1.0",
-        "express": "5.2.1",
-        "finalhandler": "2.1.1",
-        "msw": "2.14.6",
-        "oxc-minify": "^0.132.0",
-        "prettier": "3.8.3",
-        "publint": "0.3.21",
-        "typedoc": "^0.28.14",
-        "typedoc-plugin-markdown": "^4.3.0",
-        "typescript": "^6.0.0",
-        "vitepress": "^2.0.0-alpha.17",
-        "vitest": "^4.1.0"
       },
       "engines": {
         "node": ">=22"
       }
     },
-    "node_modules/@line/bot-sdk": {
-      "resolved": "../..",
-      "link": true
+    "node_modules/@types/node": {
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -237,9 +226,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -416,9 +405,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -727,14 +716,14 @@
       "license": "ISC"
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -828,6 +817,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/examples/echo-bot/package.json
+++ b/examples/echo-bot/package.json
@@ -4,11 +4,11 @@
   "description": "An example LINE bot just to echo messages written in CommonJS",
   "main": "index.js",
   "scripts": {
-    "build-sdk": "cd ../../ && npm install && npm run build",
+    "build-sdk": "npm --prefix ../.. run build && npm install --no-save --package-lock=false @line/bot-sdk@file:../..",
     "start": "node ."
   },
   "dependencies": {
-    "@line/bot-sdk": "../../",
+    "@line/bot-sdk": "^11.0.1",
     "express": "^4.17.3"
   },
   "overrides": {

--- a/examples/kitchensink/README.md
+++ b/examples/kitchensink/README.md
@@ -7,32 +7,23 @@ A kitchen-sink LINE bot example
 Install npm dependencies:
 
 ```bash
-npm run build-sdk # build SDK installed from local directory
 npm install
 ```
 
 Also, FFmpeg and ImageMagick should be installed to test image and video
 echoing.
 
-### About local dependencies
+### Using a local build of `@line/bot-sdk`
 
-Currently, [`@line/bot-sdk`](package.json) is installed from local directory.
+When developing the SDK in this repository, run `npm run build-sdk` after `npm install` to test the example
+against your unreleased local SDK changes instead of the published package from npm:
 
-```json
-{
-  "@line/bot-sdk": "../../"
-}
+```bash
+npm install
+npm run build-sdk
 ```
 
-To install `@line/bot-sdk` from npm, please update the line with the following:
-
-```json
-{
-  "@line/bot-sdk": "*"
-}
-```
-
-In the case, `npm run build-sdk` needn't be run before `npm install`.
+Without `build-sdk`, the published package from npm is used.
 
 ## Configuration
 

--- a/examples/kitchensink/package-lock.json
+++ b/examples/kitchensink/package-lock.json
@@ -8,41 +8,30 @@
       "name": "kitchensink",
       "version": "0.0.0",
       "dependencies": {
-        "@line/bot-sdk": "../../",
+        "@line/bot-sdk": "^11.0.1",
         "express": "^4.18.2"
       }
     },
-    "../..": {
-      "name": "@line/bot-sdk",
-      "version": "1.0.0-test",
+    "node_modules/@line/bot-sdk": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@line/bot-sdk/-/bot-sdk-11.0.1.tgz",
+      "integrity": "sha512-De9gBX2JfZs78nDSyzfetHJw0R6hncPVVy3tzPMwYZzgwK06C/tcijGy7Vq28K8uYKGVTSthbtMIoYKNhXISzw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^24.0.0"
-      },
-      "devDependencies": {
-        "@arethetypeswrong/cli": "0.18.2",
-        "@types/express": "5.0.6",
-        "@types/finalhandler": "1.2.4",
-        "@vitest/coverage-v8": "^4.1.0",
-        "express": "5.2.1",
-        "finalhandler": "2.1.1",
-        "msw": "2.14.6",
-        "oxc-minify": "^0.132.0",
-        "prettier": "3.8.3",
-        "publint": "0.3.21",
-        "typedoc": "^0.28.14",
-        "typedoc-plugin-markdown": "^4.3.0",
-        "typescript": "^6.0.0",
-        "vitepress": "^2.0.0-alpha.17",
-        "vitest": "^4.1.0"
       },
       "engines": {
         "node": ">=22"
       }
     },
-    "node_modules/@line/bot-sdk": {
-      "resolved": "../..",
-      "link": true
+    "node_modules/@types/node": {
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -237,9 +226,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -416,9 +405,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -727,14 +716,14 @@
       "license": "ISC"
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -828,6 +817,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/examples/kitchensink/package.json
+++ b/examples/kitchensink/package.json
@@ -4,11 +4,11 @@
   "description": "A kitchen-sink LINE bot example",
   "main": "index.js",
   "scripts": {
-    "build-sdk": "cd ../../ && npm install && npm run build",
+    "build-sdk": "npm --prefix ../.. run build && npm install --no-save --package-lock=false @line/bot-sdk@file:../..",
     "start": "node ."
   },
   "dependencies": {
-    "@line/bot-sdk": "../../",
+    "@line/bot-sdk": "^11.0.1",
     "express": "^4.18.2"
   },
   "overrides": {

--- a/examples/rich-menu/README.md
+++ b/examples/rich-menu/README.md
@@ -7,7 +7,6 @@
 ### Install deps
 
 ``` shell
-$ npm run build-sdk
 $ npm install
 ```
 
@@ -23,3 +22,15 @@ $ export CHANNEL_ACCESS_TOKEN=YOUR_CHANNEL_ACCESS_TOKEN
 ``` shell
 $ node .
 ```
+
+## Using a local build of `@line/bot-sdk`
+
+When developing the SDK in this repository, run `npm run build-sdk` after `npm install` to test the example
+against your unreleased local SDK changes instead of the published package from npm:
+
+``` shell
+$ npm install
+$ npm run build-sdk
+```
+
+Without `build-sdk`, the published package from npm is used.

--- a/examples/rich-menu/package-lock.json
+++ b/examples/rich-menu/package-lock.json
@@ -8,40 +8,35 @@
       "name": "rich-menu",
       "version": "0.0.0",
       "dependencies": {
-        "@line/bot-sdk": "../../"
+        "@line/bot-sdk": "^11.0.1"
       }
     },
-    "../..": {
-      "name": "@line/bot-sdk",
-      "version": "1.0.0-test",
+    "node_modules/@line/bot-sdk": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@line/bot-sdk/-/bot-sdk-11.0.1.tgz",
+      "integrity": "sha512-De9gBX2JfZs78nDSyzfetHJw0R6hncPVVy3tzPMwYZzgwK06C/tcijGy7Vq28K8uYKGVTSthbtMIoYKNhXISzw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^24.0.0"
-      },
-      "devDependencies": {
-        "@arethetypeswrong/cli": "0.18.2",
-        "@types/express": "5.0.6",
-        "@types/finalhandler": "1.2.4",
-        "@vitest/coverage-v8": "^4.1.0",
-        "express": "5.2.1",
-        "finalhandler": "2.1.1",
-        "msw": "2.14.6",
-        "oxc-minify": "^0.132.0",
-        "prettier": "3.8.3",
-        "publint": "0.3.21",
-        "typedoc": "^0.28.14",
-        "typedoc-plugin-markdown": "^4.3.0",
-        "typescript": "^6.0.0",
-        "vitepress": "^2.0.0-alpha.17",
-        "vitest": "^4.1.0"
       },
       "engines": {
         "node": ">=22"
       }
     },
-    "node_modules/@line/bot-sdk": {
-      "resolved": "../..",
-      "link": true
+    "node_modules/@types/node": {
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
     }
   }
 }

--- a/examples/rich-menu/package.json
+++ b/examples/rich-menu/package.json
@@ -4,10 +4,10 @@
   "description": "An example LINE bot just to rich menu",
   "main": "index.js",
   "scripts": {
-    "build-sdk": "cd ../../ && npm install && npm run build",
+    "build-sdk": "npm --prefix ../.. run build && npm install --no-save --package-lock=false @line/bot-sdk@file:../..",
     "start": "node ."
   },
   "dependencies": {
-    "@line/bot-sdk": "../../"
+    "@line/bot-sdk": "^11.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,12 +41,12 @@
     "clean": "rm -rf dist/*",
     "build": "npm run format:check && npm run clean && tsc -p ./tsconfig.esm.json && tsc -p ./tsconfig.cjs.json && echo \"{\\\"type\\\": \\\"commonjs\\\"}\" > dist/cjs/package.json",
     "check:publint": "publint",
-    "pack:check": "npm pack",
     "check:attw": "attw $(npm pack)",
     "docs": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs",
     "apidocs": "typedoc --tsconfig ./tsconfig.esm.json --excludePrivate --plugin typedoc-plugin-markdown --out docs/apidocs lib/index.ts",
+    "checkAll": "bash scripts/check-all.sh",
     "release": "npm run build && npm publish --provenance --access public"
   },
   "repository": {

--- a/renovate.json5
+++ b/renovate.json5
@@ -14,6 +14,11 @@
     "dependency upgrade"
   ],
   minimumReleaseAge : "7 days",
+  // Override the default ignorePaths to let Renovate manage dependencies under examples/.
+  ignorePaths: [
+    "**/node_modules/**",
+    "**/test/**"
+  ],
   // To prevent libraries in optionalDependencies from being removed from the lock file
   constraints: {
     npm: "11.16.0"
@@ -35,20 +40,6 @@
       matchPackageNames: [
         "/line-openapi/"
       ],
-    },
-    {
-      matchFileNames: [
-        "examples/*"
-      ],
-      postUpgradeTasks: {
-        commands: [
-          "npm install"
-        ],
-        fileFilters: [
-          "package.json",
-          "package-lock.json"
-        ],
-      },
     },
   ],
 }

--- a/scripts/check-all.sh
+++ b/scripts/check-all.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== Test project ==="
+NODE_OPTIONS=--max-old-space-size=6144 npm test
+
+echo "=== Build apidocs ==="
+NODE_OPTIONS=--openssl-legacy-provider npm run apidocs
+
+echo "=== Build docs ==="
+NODE_OPTIONS=--openssl-legacy-provider npm run docs:build
+
+for ex in echo-bot echo-bot-esm kitchensink rich-menu; do
+  echo "=== Check example: $ex ==="
+  (cd "examples/$ex" && npm ci && node --check index.js)
+done
+
+for ex in echo-bot-ts-cjs echo-bot-ts-esm; do
+  echo "=== Build example: $ex ==="
+  (cd "examples/$ex" && npm ci && npm run build-sdk && npm run build)
+done
+
+echo "=== publint ==="
+npm run check:publint
+
+echo "=== Validate package (attw) ==="
+npm run check:attw


### PR DESCRIPTION
It's as same as https://github.com/line/line-bot-sdk-ruby/pull/836.

For example projects, 
- Renovate should update examples too (by default, it's disabled)
- User doesn't have to use local sdk, for them not to modify the dependency later.
- Test job should check install, and check script as nodejs script.

