### PR TITLE
Fix npm audit vulnerability and exclude gitignored paths from npm-audit.sh

### DIFF
--- a/examples/echo-bot-ts-cjs/package-lock.json
+++ b/examples/echo-bot-ts-cjs/package-lock.json
@@ -188,16 +188,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/bytes": {

--- a/examples/echo-bot-ts-esm/package-lock.json
+++ b/examples/echo-bot-ts-esm/package-lock.json
@@ -188,16 +188,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/bytes": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2137,16 +2137,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/bytes": {

--- a/scripts/npm-audit.sh
+++ b/scripts/npm-audit.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# List lockfiles via git so that gitignored paths (e.g. local worktrees) are excluded.
+# --others picks up new packages that are not committed yet.
 IFS=$'\n'
-locks=($(find . \( -path '*/node_modules' -o -path './line-openapi' \) -prune -o -name package-lock.json -print))
+locks=($(git ls-files --cached --others --exclude-standard | grep -E '(^|/)package-lock\.json$'))
 unset IFS
 
 declare -a failed=()


### PR DESCRIPTION
resolve  #1743

## Changes

- `scripts/npm-audit.sh`
  - Discover lockfiles via `git ls-files` instead of `find`, so gitignored paths (e.g. local worktrees) are excluded from audit targets.
  - `node_modules` and the `line-openapi` submodule are excluded by git itself, so the explicit prune rules are no longer needed.
- `package-lock.json` (root, `echo-bot-ts-cjs`, `echo-bot-ts-esm`)
  - Update `brace-expansion` to 5.0.8 to fix https://github.com/advisories/GHSA-mh99-v99m-4gvg.

### Note
`npm audit fix` alone could not apply the update because 5.0.8 was published less than 7 days ago and blocked by `min-release-age=7` in .npmrc, so it was updated with a one-off `--min-release-age=0` override.

Manually checked that it's safe: https://github.com/juliangruber/brace-expansion/compare/v5.0.7...v5.0.8