### PR TITLE
Close npm audit reminder automatically 

### DIFF
--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -20,11 +20,40 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
+          package-manager-cache: false
 
       - name: Run npm audit and check diff
         id: audit
         run: ./scripts/npm-audit.sh
         continue-on-error: true
+
+      - name: Close reminder issue when audit passes
+        if: steps.audit.outcome == 'success'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const title = 'Reminder: run npm audit';
+
+            const { data: result } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${owner}/${repo} is:issue is:open in:title "${title}"`
+            });
+
+            for (const issue of result.items) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issue.number,
+                body: 'Auto-closed because npm audit is now passing.'
+              });
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'completed'
+              });
+            }
 
       - name: Create or update reminder issue
         if: steps.audit.outcome == 'failure'


### PR DESCRIPTION
As with https://github.com/line/line-bot-mcp-server/blob/b61b59e293c9c22ee71d0b9ebc6b62cc2fc991b6/.github/workflows/npm-audit.yml, if Renovate's lockfile maintenance reduces the number of affected libraries to zero, it's fine to close the reminder issue automatically.


